### PR TITLE
[build] Add Ameba observer to other non-porting layer examples

### DIFF
--- a/project/amebad/make/chip_main/air_purifier_app/Makefile
+++ b/project/amebad/make/chip_main/air_purifier_app/Makefile
@@ -90,6 +90,7 @@ IFLAGS += -I$(CHIPDIR)/zzz_generated
 IFLAGS += -I$(CHIPDIR)/zzz_generated/app-common
 IFLAGS += -I$(CODEGEN_DIR)
 IFLAGS += -I$(CODEGEN_DIR)/zap-generated
+IFLAGS += -I$(CHIPDIR)/examples/all-clusters-app/ameba/main/include #to get AmebaObserver.h
 IFLAGS += -I$(CHIPDIR)/examples/air-purifier-app/air-purifier-common
 IFLAGS += -I$(CHIPDIR)/examples/air-purifier-app/air-purifier-common/include
 IFLAGS += -I$(CHIPDIR)/examples/air-purifier-app/ameba/main/include

--- a/project/amebad/make/chip_main/light_switch_app/Makefile
+++ b/project/amebad/make/chip_main/light_switch_app/Makefile
@@ -90,6 +90,7 @@ IFLAGS += -I$(CHIPDIR)/zzz_generated
 IFLAGS += -I$(CHIPDIR)/zzz_generated/app-common
 IFLAGS += -I$(CODEGEN_DIR)
 IFLAGS += -I$(CODEGEN_DIR)/zap-generated
+IFLAGS += -I$(CHIPDIR)/examples/all-clusters-app/ameba/main/include #to get AmebaObserver.h
 IFLAGS += -I$(CHIPDIR)/examples/light-switch-app/light-switch-common
 IFLAGS += -I$(CHIPDIR)/examples/light-switch-app/ameba/main/include
 IFLAGS += -I$(CHIPDIR)/examples/light-switch-app/ameba/build/chip/gen/include

--- a/project/amebad/make/chip_main/lighting_app/Makefile
+++ b/project/amebad/make/chip_main/lighting_app/Makefile
@@ -87,6 +87,7 @@ IFLAGS += -I$(CHIPDIR)/zzz_generated
 IFLAGS += -I$(CHIPDIR)/zzz_generated/app-common
 IFLAGS += -I$(CODEGEN_DIR)
 IFLAGS += -I$(CODEGEN_DIR)/zap-generated
+IFLAGS += -I$(CHIPDIR)/examples/all-clusters-app/ameba/main/include #to get AmebaObserver.h
 IFLAGS += -I$(CHIPDIR)/examples/lighting-app/lighting-common
 IFLAGS += -I$(CHIPDIR)/examples/lighting-app/ameba/main/include
 IFLAGS += -I$(CHIPDIR)/examples/lighting-app/ameba/build/chip/gen/include

--- a/project/amebad/make/chip_main/ota_requestor_app/Makefile
+++ b/project/amebad/make/chip_main/ota_requestor_app/Makefile
@@ -87,6 +87,7 @@ IFLAGS += -I$(CHIPDIR)/zzz_generated
 IFLAGS += -I$(CHIPDIR)/zzz_generated/app-common
 IFLAGS += -I$(CODEGEN_DIR)
 IFLAGS += -I$(CODEGEN_DIR)/zap-generated
+IFLAGS += -I$(CHIPDIR)/examples/all-clusters-app/ameba/main/include #to get AmebaObserver.h
 IFLAGS += -I$(CHIPDIR)/examples/ota-requestor-app/ota-requestor-common
 IFLAGS += -I$(CHIPDIR)/examples/ota-requestor-app/ota-requestor-common/include
 IFLAGS += -I$(CHIPDIR)/examples/ota-requestor-app/ameba/main/include

--- a/project/amebaz2/make/air_purifier/lib_chip_air_purifier_main.mk
+++ b/project/amebaz2/make/air_purifier/lib_chip_air_purifier_main.mk
@@ -72,6 +72,7 @@ INCLUDES += -I$(CHIPDIR)/third_party/nlassert/repo/include
 INCLUDES += -I$(CHIPDIR)/third_party/nlio/repo/include
 INCLUDES += -I$(CHIPDIR)/third_party/nlunit-test/repo/src
 INCLUDES += -I$(CHIPDIR)/zzz_generated/app-common
+INCLUDES += -I$(CHIPDIR)/examples/all-clusters-app/ameba/main/include #to get AmebaObserver.h
 INCLUDES += -I$(CHIPDIR)/examples/air-purifier-app/air-purifier-common
 INCLUDES += -I$(CHIPDIR)/examples/air-purifier-app/air-purifier-common/include
 INCLUDES += -I$(CHIPDIR)/examples/air-purifier-app/ameba/main/include

--- a/project/amebaz2/make/chef/lib_chip_chef_main.mk
+++ b/project/amebaz2/make/chef/lib_chip_chef_main.mk
@@ -74,6 +74,7 @@ INCLUDES += -I$(CHIPDIR)/third_party/nlunit-test/repo/src
 INCLUDES += -I$(CHIPDIR)/zzz_generated/app-common
 INCLUDES += -I$(CHIPDIR)/examples/chef/out/lighting-app
 INCLUDES += -I$(CHIPDIR)/examples/chef/out/lighting-app/zap-generated
+INCLUDES += -I$(CHIPDIR)/examples/all-clusters-app/ameba/main/include #to get AmebaObserver.h
 INCLUDES += -I$(CHIPDIR)/examples/lighting-app/lighting-common
 INCLUDES += -I$(CHIPDIR)/examples/lighting-app/ameba/main/include
 INCLUDES += -I$(CHIPDIR)/examples/lighting-app/ameba/build/chip/gen/include

--- a/project/amebaz2/make/light/lib_chip_light_main.mk
+++ b/project/amebaz2/make/light/lib_chip_light_main.mk
@@ -72,6 +72,7 @@ INCLUDES += -I$(CHIPDIR)/third_party/nlassert/repo/include
 INCLUDES += -I$(CHIPDIR)/third_party/nlio/repo/include
 INCLUDES += -I$(CHIPDIR)/third_party/nlunit-test/repo/src
 INCLUDES += -I$(CHIPDIR)/zzz_generated/app-common
+INCLUDES += -I$(CHIPDIR)/examples/all-clusters-app/ameba/main/include #to get AmebaObserver.h
 INCLUDES += -I$(CHIPDIR)/examples/lighting-app/lighting-common
 INCLUDES += -I$(CHIPDIR)/examples/lighting-app/ameba/main/include
 INCLUDES += -I$(CHIPDIR)/examples/lighting-app/ameba/build/chip/gen/include

--- a/project/amebaz2/make/light_switch/lib_chip_light_switch_main.mk
+++ b/project/amebaz2/make/light_switch/lib_chip_light_switch_main.mk
@@ -73,6 +73,7 @@ INCLUDES += -I$(CHIPDIR)/third_party/nlassert/repo/include
 INCLUDES += -I$(CHIPDIR)/third_party/nlio/repo/include
 INCLUDES += -I$(CHIPDIR)/third_party/nlunit-test/repo/src
 INCLUDES += -I$(CHIPDIR)/zzz_generated/app-common
+INCLUDES += -I$(CHIPDIR)/examples/all-clusters-app/ameba/main/include #to get AmebaObserver.h
 INCLUDES += -I$(CHIPDIR)/examples/light-switch-app/light-switch-common
 INCLUDES += -I$(CHIPDIR)/examples/light-switch-app/light-switch-common/include
 INCLUDES += -I$(CHIPDIR)/examples/light-switch-app/ameba/main/include

--- a/project/amebaz2/make/otar/lib_chip_otar_main.mk
+++ b/project/amebaz2/make/otar/lib_chip_otar_main.mk
@@ -73,6 +73,7 @@ INCLUDES += -I$(CHIPDIR)/third_party/nlassert/repo/include
 INCLUDES += -I$(CHIPDIR)/third_party/nlio/repo/include
 INCLUDES += -I$(CHIPDIR)/third_party/nlunit-test/repo/src
 INCLUDES += -I$(CHIPDIR)/zzz_generated/app-common
+INCLUDES += -I$(CHIPDIR)/examples/all-clusters-app/ameba/main/include #to get AmebaObserver.h
 INCLUDES += -I$(CHIPDIR)/examples/ota-requestor-app/ameba/build/chip/gen/include
 INCLUDES += -I$(CHIPDIR)/examples/ota-requestor-app/ameba/main/include
 INCLUDES += -I$(CODEGENDIR)


### PR DESCRIPTION
* Add include flag : -I$(CHIPDIR)/examples/all-clusters-app/ameba/main/include, the folder which contains AmebaObserver.h