### PR TITLE
[general][mbedtls] Fix mbedtls CVE and update source code

### DIFF
--- a/common/mbedtls/mbedtls-2.28.1/include/mbedtls/config.h
+++ b/common/mbedtls/mbedtls-2.28.1/include/mbedtls/config.h
@@ -15,17 +15,47 @@
 #define MBEDTLS_USE_ROM_API
 #endif
 
-/* RTL_CRYPTO_FRAGMENT should be less than 16000, and should be 16bytes-aligned */
-#define RTL_CRYPTO_FRAGMENT               15360
+#if defined(CONFIG_EXAMPLE_MBEDTLS_ECDHE) && (CONFIG_EXAMPLE_MBEDTLS_ECDHE == 1)
+#define MBEDTLS_ECDH_C
+#define MBEDTLS_ECP_C
+#define MBEDTLS_ENTROPY_C
+#define MBEDTLS_KEY_EXCHANGE_PSK_ENABLED
+#define MBEDTLS_ENTROPY_HARDWARE_ALT
+#define MBEDTLS_NO_PLATFORM_ENTROPY
+#define MBEDTLS_CTR_DRBG_C
+#endif
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#if defined(CONFIG_SSL_RSA) && CONFIG_SSL_RSA
+#if defined(CONFIG_PLATFORM_8710C)
+#define SUPPORT_HW_SSL_HMAC_SHA256
+#endif
+
+/* RTL_CRYPTO_FRAGMENT should be less than 16000, and should be 16bytes-aligned */
+#if defined (CONFIG_PLATFORM_8195A)
+#define RTL_CRYPTO_FRAGMENT                4096
+#else
+#define RTL_CRYPTO_FRAGMENT               15360
+#endif
+
+#if defined(CONFIG_SSL_ROM)
+#include <section_config.h>
+#include "platform_stdlib.h"
+#include "mbedtls/config_rom.h"
+#define SUPPORT_HW_SW_CRYPTO
+#elif defined(CONFIG_BAIDU_DUER) && CONFIG_BAIDU_DUER
+#define CONFIG_SSL_RSA          0
+#include "baidu_ca_mbedtls_config.h"
+#elif defined(CONFIG_SSL_RSA) && CONFIG_SSL_RSA
+#if defined(ENABLE_AMAZON_COMMON)
+#include "platform_stdlib.h"
+#include "mbedtls/config_rsa_amazon.h"
+#elif (defined(CONFIG_EXAMPLE_FFS) && CONFIG_EXAMPLE_FFS)
+#include "platform_stdlib.h"
+#include "mbedtls/config_rsa_amazon.h"
+#else
 #include "platform_stdlib.h"
 #include "mbedtls/config_rsa.h"
+#endif
 #else
 #include "platform_stdlib.h"
 #include "mbedtls/config_all.h"
-#endif
-#else
-#include MBEDTLS_CONFIG_FILE
 #endif

--- a/common/mbedtls/mbedtls-2.28.1/include/mbedtls/gcm.h
+++ b/common/mbedtls/mbedtls-2.28.1/include/mbedtls/gcm.h
@@ -76,6 +76,10 @@ typedef struct mbedtls_gcm_context
     int mode;                             /*!< The operation to perform:
                                                #MBEDTLS_GCM_ENCRYPT or
                                                #MBEDTLS_GCM_DECRYPT. */
+#ifdef RTL_HW_CRYPTO
+    unsigned int keybytes;
+    unsigned char key[32];
+#endif
 }
 mbedtls_gcm_context;
 

--- a/common/mbedtls/mbedtls-2.28.1/include/mbedtls/rsa.h
+++ b/common/mbedtls/mbedtls-2.28.1/include/mbedtls/rsa.h
@@ -725,6 +725,10 @@ int mbedtls_rsa_rsaes_oaep_encrypt( mbedtls_rsa_context *ctx,
  *                 It is the generic wrapper for performing a PKCS#1 decryption
  *                 operation using the \p mode from the context.
  *
+ * \warning        When \p ctx->padding is set to #MBEDTLS_RSA_PKCS_V15,
+ *                 mbedtls_rsa_rsaes_pkcs1_v15_decrypt() is called, which is an
+ *                 inherently dangerous function (CWE-242).
+ *
  * \note           The output buffer length \c output_max_len should be
  *                 as large as the size \p ctx->len of \p ctx->N (for example,
  *                 128 Bytes if RSA-1024 is used) to be able to hold an
@@ -773,6 +777,11 @@ int mbedtls_rsa_pkcs1_decrypt( mbedtls_rsa_context *ctx,
 /**
  * \brief          This function performs a PKCS#1 v1.5 decryption
  *                 operation (RSAES-PKCS1-v1_5-DECRYPT).
+ *
+ * \warning        This is an inherently dangerous function (CWE-242). Unless
+ *                 it is used in a side channel free and safe way (eg.
+ *                 implementing the TLS protocol as per 7.4.7.1 of RFC 5246),
+ *                 the calling code is vulnerable.
  *
  * \note           The output buffer length \c output_max_len should be
  *                 as large as the size \p ctx->len of \p ctx->N, for example,

--- a/common/mbedtls/mbedtls-2.28.1/include/psa/crypto_values.h
+++ b/common/mbedtls/mbedtls-2.28.1/include/psa/crypto_values.h
@@ -1658,6 +1658,13 @@
      0)
 
 /** RSA PKCS#1 v1.5 encryption.
+ *
+ * \warning     Calling psa_asymmetric_decrypt() with this algorithm as a
+ *              parameter is considered an inherently dangerous function
+ *              (CWE-242). Unless it is used in a side channel free and safe
+ *              way (eg. implementing the TLS protocol as per 7.4.7.1 of
+ *              RFC 5246), the calling code is vulnerable.
+ *
  */
 #define PSA_ALG_RSA_PKCS1V15_CRYPT              ((psa_algorithm_t)0x07000200)
 

--- a/common/mbedtls/mbedtls-2.28.1/library/aes.c
+++ b/common/mbedtls/mbedtls-2.28.1/library/aes.c
@@ -515,9 +515,6 @@ void mbedtls_aes_free( mbedtls_aes_context *ctx )
 int mbedtls_aes_setkey_enc( mbedtls_aes_context *ctx, const unsigned char *key,
                     unsigned int keybits )
 {
-    unsigned int i;
-    uint32_t *RK;
-
     AES_VALIDATE_RET( ctx != NULL );
     AES_VALIDATE_RET( key != NULL );
 
@@ -528,6 +525,18 @@ int mbedtls_aes_setkey_enc( mbedtls_aes_context *ctx, const unsigned char *key,
         case 256: ctx->nr = 14; break;
         default : return( MBEDTLS_ERR_AES_INVALID_KEY_LENGTH );
     }
+
+#ifdef RTL_HW_CRYPTO
+    if(rom_ssl_ram_map.use_hw_crypto_func)
+    {
+        memcpy(ctx->enc_key, key, (keybits / 8));
+        return 0;
+    }
+#endif /* RTL_HW_CRYPTO */
+
+#ifdef SUPPORT_HW_SW_CRYPTO
+    unsigned int i;
+    uint32_t *RK;
 
 #if !defined(MBEDTLS_AES_ROM_TABLES)
     if( aes_init_done == 0 )
@@ -621,6 +630,7 @@ int mbedtls_aes_setkey_enc( mbedtls_aes_context *ctx, const unsigned char *key,
     }
 
     return( 0 );
+#endif /* SUPPORT_HW_SW_CRYPTO */
 }
 #endif /* !MBEDTLS_AES_SETKEY_ENC_ALT */
 
@@ -631,6 +641,22 @@ int mbedtls_aes_setkey_enc( mbedtls_aes_context *ctx, const unsigned char *key,
 int mbedtls_aes_setkey_dec( mbedtls_aes_context *ctx, const unsigned char *key,
                     unsigned int keybits )
 {
+#ifdef RTL_HW_CRYPTO
+    if(rom_ssl_ram_map.use_hw_crypto_func)
+    {
+        switch(keybits)
+        {
+            case 128: ctx->nr = 10; break;
+            case 192: ctx->nr = 12; break;
+            case 256: ctx->nr = 14; break;
+            default : return(MBEDTLS_ERR_AES_INVALID_KEY_LENGTH);
+        }
+        memcpy(ctx->dec_key, key, (keybits / 8));
+        return 0;
+    }
+#endif /* RTL_HW_CRYPTO */
+
+#ifdef SUPPORT_HW_SW_CRYPTO
     int i, j, ret;
     mbedtls_aes_context cty;
     uint32_t *RK;
@@ -693,6 +719,7 @@ exit:
     mbedtls_aes_free( &cty );
 
     return( ret );
+#endif /* SUPPORT_HW_SW_CRYPTO */
 }
 #endif /* !MBEDTLS_AES_SETKEY_DEC_ALT */
 
@@ -905,6 +932,28 @@ int mbedtls_aes_crypt_ecb( mbedtls_aes_context *ctx,
     AES_VALIDATE_RET( mode == MBEDTLS_AES_ENCRYPT ||
                       mode == MBEDTLS_AES_DECRYPT );
 
+#ifdef RTL_HW_CRYPTO
+    if(rom_ssl_ram_map.use_hw_crypto_func)
+    {
+        unsigned char key_buf[32 + 32 + 32], *key_buf_aligned;
+        key_buf_aligned = (unsigned char *) (((unsigned int) key_buf + 32) / 32 * 32);
+        if(mode == MBEDTLS_AES_DECRYPT)
+        {
+            memcpy(key_buf_aligned, ctx->dec_key, ((ctx->nr - 6) * 4));
+            rom_ssl_ram_map.hw_crypto_aes_ecb_init(key_buf_aligned, ((ctx->nr - 6) * 4));
+            rom_ssl_ram_map.hw_crypto_aes_ecb_decrypt(input, 16, NULL, 0, output);
+        }
+        else
+        {
+            memcpy(key_buf_aligned, ctx->enc_key, ((ctx->nr - 6) * 4));
+            rom_ssl_ram_map.hw_crypto_aes_ecb_init(key_buf_aligned,((ctx->nr - 6) * 4));
+            rom_ssl_ram_map.hw_crypto_aes_ecb_encrypt(input, 16, NULL, 0, output);
+        }
+        return 0;
+    }
+#endif /* RTL_HW_CRYPTO */
+
+#ifdef SUPPORT_HW_SW_CRYPTO
 #if defined(MBEDTLS_AESNI_C) && defined(MBEDTLS_HAVE_X86_64)
     if( mbedtls_aesni_has_support( MBEDTLS_AESNI_AES ) )
         return( mbedtls_aesni_crypt_ecb( ctx, mode, input, output ) );
@@ -926,6 +975,7 @@ int mbedtls_aes_crypt_ecb( mbedtls_aes_context *ctx,
         return( mbedtls_internal_aes_encrypt( ctx, input, output ) );
     else
         return( mbedtls_internal_aes_decrypt( ctx, input, output ) );
+#endif /* SUPPORT_HW_SW_CRYPTO */
 }
 
 #if defined(MBEDTLS_CIPHER_MODE_CBC)
@@ -939,10 +989,6 @@ int mbedtls_aes_crypt_cbc( mbedtls_aes_context *ctx,
                     const unsigned char *input,
                     unsigned char *output )
 {
-    int i;
-    int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
-    unsigned char temp[16];
-
     AES_VALIDATE_RET( ctx != NULL );
     AES_VALIDATE_RET( mode == MBEDTLS_AES_ENCRYPT ||
                       mode == MBEDTLS_AES_DECRYPT );
@@ -952,6 +998,65 @@ int mbedtls_aes_crypt_cbc( mbedtls_aes_context *ctx,
 
     if( length % 16 )
         return( MBEDTLS_ERR_AES_INVALID_INPUT_LENGTH );
+
+#ifdef RTL_HW_CRYPTO
+    if(rom_ssl_ram_map.use_hw_crypto_func)
+    {
+        unsigned char key_buf[32 + 32 + 32], *key_buf_aligned;
+        unsigned char iv_buf[32 + 16 + 32], *iv_buf_aligned, iv_tmp[16];
+        size_t length_done = 0;
+
+        if(length % 16)
+            return(MBEDTLS_ERR_AES_INVALID_INPUT_LENGTH);
+
+        if(length > 0)
+        {
+            key_buf_aligned = (unsigned char *) (((unsigned int) key_buf + 32) / 32 * 32);
+            iv_buf_aligned = (unsigned char *) (((unsigned int) iv_buf + 32) / 32 * 32);
+
+            memcpy(iv_buf_aligned, iv, 16);
+
+            if(mode == MBEDTLS_AES_DECRYPT)
+            {
+                memcpy(key_buf_aligned, ctx->dec_key, ((ctx->nr - 6) * 4));
+                rom_ssl_ram_map.hw_crypto_aes_cbc_init(key_buf_aligned, ((ctx->nr - 6) * 4));
+
+                while((length - length_done) > RTL_CRYPTO_FRAGMENT)
+                {
+                    memcpy(iv_tmp, (input + length_done + RTL_CRYPTO_FRAGMENT - 16), 16);
+                    rom_ssl_ram_map.hw_crypto_aes_cbc_decrypt(input + length_done, RTL_CRYPTO_FRAGMENT, iv_buf_aligned, 16, output + length_done);
+                    memcpy(iv_buf_aligned, iv_tmp, 16);
+                    length_done += RTL_CRYPTO_FRAGMENT;
+                }
+
+                memcpy(iv_tmp, (input + length - 16), 16);
+                rom_ssl_ram_map.hw_crypto_aes_cbc_decrypt(input + length_done, length - length_done, iv_buf_aligned, 16, output + length_done);
+                memcpy(iv, iv_tmp, 16);
+            }
+            else
+            {
+                memcpy(key_buf_aligned, ctx->enc_key, ((ctx->nr - 6) * 4));
+                rom_ssl_ram_map.hw_crypto_aes_cbc_init(key_buf_aligned,((ctx->nr - 6) * 4));
+
+                while((length - length_done) > RTL_CRYPTO_FRAGMENT)
+                {
+                    rom_ssl_ram_map.hw_crypto_aes_cbc_encrypt(input + length_done, RTL_CRYPTO_FRAGMENT, iv_buf_aligned, 16, output + length_done);
+                    memcpy(iv_buf_aligned, (output + length_done + RTL_CRYPTO_FRAGMENT - 16), 16);
+                    length_done += RTL_CRYPTO_FRAGMENT;
+                }
+
+                rom_ssl_ram_map.hw_crypto_aes_cbc_encrypt(input + length_done, length - length_done, iv_buf_aligned, 16, output + length_done);
+                memcpy(iv, (output + length - 16), 16);
+            }
+        }
+        return 0;
+    }
+#endif /* RTL_HW_CRYPTO */
+
+#ifdef SUPPORT_HW_SW_CRYPTO
+    int i;
+    int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
+    unsigned char temp[16];
 
 #if defined(MBEDTLS_PADLOCK_C) && defined(MBEDTLS_HAVE_X86)
     if( aes_padlock_ace )
@@ -1005,6 +1110,7 @@ int mbedtls_aes_crypt_cbc( mbedtls_aes_context *ctx,
 
 exit:
     return( ret );
+#endif /* SUPPORT_HW_SW_CRYPTO */
 }
 #endif /* MBEDTLS_CIPHER_MODE_CBC */
 

--- a/common/mbedtls/mbedtls-2.28.1/library/bignum_internal.h
+++ b/common/mbedtls/mbedtls-2.28.1/library/bignum_internal.h
@@ -1,0 +1,71 @@
+/**
+ *  Low level bignum functions
+ *
+ *  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+ */
+
+#ifndef MBEDTLS_BIGNUM_INTERNAL_H
+#define MBEDTLS_BIGNUM_INTERNAL_H
+
+#include "mbedtls/bignum.h"
+
+/**
+ * \brief Calculate the square of the Montgomery constant. (Needed
+ *        for conversion and operations in Montgomery form.)
+ *
+ * \param[out] X  A pointer to the result of the calculation of
+ *                the square of the Montgomery constant:
+ *                2^{2*n*biL} mod N.
+ * \param[in]  N  Little-endian presentation of the modulus, which must be odd.
+ *
+ * \return        0 if successful.
+ * \return        #MBEDTLS_ERR_MPI_ALLOC_FAILED if there is not enough space
+ *                to store the value of Montgomery constant squared.
+ * \return        #MBEDTLS_ERR_MPI_DIVISION_BY_ZERO if \p N modulus is zero.
+ * \return        #MBEDTLS_ERR_MPI_NEGATIVE_VALUE if \p N modulus is negative.
+ */
+int mbedtls_mpi_get_mont_r2_unsafe(mbedtls_mpi *X,
+                                   const mbedtls_mpi *N);
+
+/**
+ * \brief Calculate initialisation value for fast Montgomery modular
+ *        multiplication
+ *
+ * \param[in] N  Little-endian presentation of the modulus. This must have
+ *               at least one limb.
+ *
+ * \return       The initialisation value for fast Montgomery modular multiplication
+ */
+mbedtls_mpi_uint mbedtls_mpi_montmul_init(const mbedtls_mpi_uint *N);
+
+/** Montgomery multiplication: A = A * B * R^-1 mod N  (HAC 14.36)
+ *
+ * \param[in,out]   A   One of the numbers to multiply.
+ *                      It must have at least as many limbs as N
+ *                      (A->n >= N->n), and any limbs beyond n are ignored.
+ *                      On successful completion, A contains the result of
+ *                      the multiplication A * B * R^-1 mod N where
+ *                      R = (2^ciL)^n.
+ * \param[in]       B   One of the numbers to multiply.
+ *                      It must be nonzero and must not have more limbs than N
+ *                      (B->n <= N->n).
+ * \param[in]       N   The modulo. N must be odd.
+ * \param           mm  The value calculated by
+ *                      `mbedtls_mpi_montg_init(&mm, N)`.
+ *                      This is -N^-1 mod 2^ciL.
+ * \param[in,out]   T   A bignum for temporary storage.
+ *                      It must be at least twice the limb size of N plus 2
+ *                      (T->n >= 2 * (N->n + 1)).
+ *                      Its initial content is unused and
+ *                      its final content is indeterminate.
+ *                      Note that unlike the usual convention in the library
+ *                      for `const mbedtls_mpi*`, the content of T can change.
+ */
+void mbedtls_mpi_montmul(mbedtls_mpi *A,
+                         const mbedtls_mpi *B,
+                         const mbedtls_mpi *N,
+                         mbedtls_mpi_uint mm,
+                         const mbedtls_mpi *T);
+
+#endif /* MBEDTLS_BIGNUM_INTERNAL_H */

--- a/common/mbedtls/mbedtls-2.28.1/library/ctr_drbg.c
+++ b/common/mbedtls/mbedtls-2.28.1/library/ctr_drbg.c
@@ -33,8 +33,9 @@
 
 #include <string.h>
 
-#if (CONFIG_EXAMPLE_MATTER) && (CONFIG_ENABLE_MATTER_PRNG)
+#if (CONFIG_MATTER) && (CONFIG_ENABLE_MATTER_PRNG)
 #include <crypto_api.h>
+#include <device_lock.h>
 #endif
 
 #if defined(MBEDTLS_FS_IO)
@@ -596,19 +597,22 @@ exit:
 int mbedtls_ctr_drbg_random( void *p_rng, unsigned char *output,
                              size_t output_len )
 {
-#if (CONFIG_EXAMPLE_MATTER) && (CONFIG_ENABLE_MATTER_PRNG)
-    int ret = crypto_init();
+#if (CONFIG_MATTER) && (CONFIG_ENABLE_MATTER_PRNG)
+    int ret = 0;
+
+    device_mutex_lock(RT_DEV_LOCK_CRYPTO);
+    ret = crypto_init();
     if (ret != SUCCESS)
     {
         printf("crypto_init() failed\r\n");
+        device_mutex_unlock(RT_DEV_LOCK_CRYPTO);
         return ret;
     }
 
     ret = crypto_random_generate(output, output_len);
+    device_mutex_unlock(RT_DEV_LOCK_CRYPTO);
     if (ret != 0)
-        ret = 0xac // CHIP_ERROR_INTERNAL
-
-    return ret;
+        ret = 0xac; // CHIP_ERROR_INTERNAL
 #else
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     mbedtls_ctr_drbg_context *ctx = (mbedtls_ctr_drbg_context *) p_rng;
@@ -624,7 +628,7 @@ int mbedtls_ctr_drbg_random( void *p_rng, unsigned char *output,
     if( mbedtls_mutex_unlock( &ctx->mutex ) != 0 )
         return( MBEDTLS_ERR_THREADING_MUTEX_ERROR );
 #endif
-#endif
+#endif /* CONFIG_MATTER */
 
     return( ret );
 }

--- a/common/mbedtls/mbedtls-2.28.1/library/net_sockets.c
+++ b/common/mbedtls/mbedtls-2.28.1/library/net_sockets.c
@@ -25,7 +25,7 @@
 #define _POSIX_C_SOURCE 200112L
 #endif
 #ifndef _XOPEN_SOURCE
-#define _XOPEN_SOURCE 600 /* sockaddr_storage */
+#define _XOPEN_SOURCE 600 //sockaddr_storage
 #endif
 */
 

--- a/common/mbedtls/mbedtls-2.28.1/library/rsa.c
+++ b/common/mbedtls/mbedtls-2.28.1/library/rsa.c
@@ -46,6 +46,7 @@
 #include "mbedtls/error.h"
 #include "constant_time_internal.h"
 #include "mbedtls/constant_time.h"
+#include "bignum_internal.h"
 
 #include <string.h>
 
@@ -828,6 +829,46 @@ cleanup:
 }
 
 /*
+ * Unblind
+ * T = T * Vf mod N
+ */
+static int rsa_unblind(mbedtls_mpi *T, mbedtls_mpi *Vf, const mbedtls_mpi *N)
+{
+    int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
+    const size_t nlimbs = N->n;
+    const size_t tlimbs = 2 * (nlimbs + 1);
+
+    mbedtls_mpi_uint mm = mbedtls_mpi_montmul_init(N->p);
+
+    mbedtls_mpi RR, M_T;
+
+    mbedtls_mpi_init(&RR);
+    mbedtls_mpi_init(&M_T);
+
+    MBEDTLS_MPI_CHK(mbedtls_mpi_get_mont_r2_unsafe(&RR, N));
+    MBEDTLS_MPI_CHK(mbedtls_mpi_grow(&M_T, tlimbs));
+
+    MBEDTLS_MPI_CHK(mbedtls_mpi_grow(T, nlimbs));
+    MBEDTLS_MPI_CHK(mbedtls_mpi_grow(Vf, nlimbs));
+
+    /* T = T * Vf mod N
+     * Reminder: montmul(A, B, N) = A * B * R^-1 mod N
+     * Usually both operands are multiplied by R mod N beforehand, yielding a
+     * result that's also * R mod N (aka "in the Montgomery domain"). Here we
+     * only multiply one operand by R mod N, so the result is directly what we
+     * want - no need to call `mpi_montred()` on it. */
+    mbedtls_mpi_montmul(T, &RR, N, mm, &M_T);
+    mbedtls_mpi_montmul(T, Vf, N, mm, &M_T);
+
+cleanup:
+
+    mbedtls_mpi_free(&RR);
+    mbedtls_mpi_free(&M_T);
+
+    return ret;
+}
+
+/*
  * Exponent blinding supposed to prevent side-channel attacks using multiple
  * traces of measurements to recover the RSA key. The more collisions are there,
  * the more bits of the key can be recovered. See [3].
@@ -890,7 +931,7 @@ int mbedtls_rsa_private( mbedtls_rsa_context *ctx,
 
     /* Temporaries holding the initial input and the double
      * checked result; should be the same in the end. */
-    mbedtls_mpi I, C;
+    mbedtls_mpi input_blinded, check_result_blinded;
 
     RSA_VALIDATE_RET( ctx != NULL );
     RSA_VALIDATE_RET( input  != NULL );
@@ -928,8 +969,8 @@ int mbedtls_rsa_private( mbedtls_rsa_context *ctx,
     mbedtls_mpi_init( &TP ); mbedtls_mpi_init( &TQ );
 #endif
 
-    mbedtls_mpi_init( &I );
-    mbedtls_mpi_init( &C );
+    mbedtls_mpi_init(&input_blinded);
+    mbedtls_mpi_init(&check_result_blinded);
 
     /* End of MPI initialization */
 
@@ -939,8 +980,6 @@ int mbedtls_rsa_private( mbedtls_rsa_context *ctx,
         ret = MBEDTLS_ERR_MPI_BAD_INPUT_DATA;
         goto cleanup;
     }
-
-    MBEDTLS_MPI_CHK( mbedtls_mpi_copy( &I, &T ) );
 
     if( f_rng != NULL )
     {
@@ -994,6 +1033,9 @@ int mbedtls_rsa_private( mbedtls_rsa_context *ctx,
 #endif /* MBEDTLS_RSA_NO_CRT */
     }
 
+    /* Make a copy of the input (after blinding if there was any) */
+    MBEDTLS_MPI_CHK(mbedtls_mpi_copy(&input_blinded, &T));
+
 #if defined(MBEDTLS_RSA_NO_CRT)
     MBEDTLS_MPI_CHK( mbedtls_mpi_exp_mod( &T, &T, D, &ctx->N, &ctx->RN ) );
 #else
@@ -1021,23 +1063,21 @@ int mbedtls_rsa_private( mbedtls_rsa_context *ctx,
     MBEDTLS_MPI_CHK( mbedtls_mpi_add_mpi( &T, &TQ, &TP ) );
 #endif /* MBEDTLS_RSA_NO_CRT */
 
+    /* Verify the result to prevent glitching attacks. */
+    MBEDTLS_MPI_CHK(mbedtls_mpi_exp_mod(&check_result_blinded, &T, &ctx->E,
+                                        &ctx->N, &ctx->RN));
+    if (mbedtls_mpi_cmp_mpi(&check_result_blinded, &input_blinded) != 0) {
+        ret = MBEDTLS_ERR_RSA_VERIFY_FAILED;
+        goto cleanup;
+    }
+
     if( f_rng != NULL )
     {
         /*
          * Unblind
          * T = T * Vf mod N
          */
-        MBEDTLS_MPI_CHK( mbedtls_mpi_mul_mpi( &T, &T, &ctx->Vf ) );
-        MBEDTLS_MPI_CHK( mbedtls_mpi_mod_mpi( &T, &T, &ctx->N ) );
-    }
-
-    /* Verify the result to prevent glitching attacks. */
-    MBEDTLS_MPI_CHK( mbedtls_mpi_exp_mod( &C, &T, &ctx->E,
-                                          &ctx->N, &ctx->RN ) );
-    if( mbedtls_mpi_cmp_mpi( &C, &I ) != 0 )
-    {
-        ret = MBEDTLS_ERR_RSA_VERIFY_FAILED;
-        goto cleanup;
+        MBEDTLS_MPI_CHK(rsa_unblind(&T, &ctx->Vf, &ctx->N));
     }
 
     olen = ctx->len;
@@ -1069,8 +1109,8 @@ cleanup:
     mbedtls_mpi_free( &TP ); mbedtls_mpi_free( &TQ );
 #endif
 
-    mbedtls_mpi_free( &C );
-    mbedtls_mpi_free( &I );
+    mbedtls_mpi_free(&check_result_blinded);
+    mbedtls_mpi_free(&input_blinded);
 
     if( ret != 0 && ret >= -0x007f )
         return( MBEDTLS_ERROR_ADD( MBEDTLS_ERR_RSA_PRIVATE_FAILED, ret ) );

--- a/common/mbedtls/mbedtls-2.28.1/library/ssl_msg.c
+++ b/common/mbedtls/mbedtls-2.28.1/library/ssl_msg.c
@@ -1169,6 +1169,15 @@ int mbedtls_ssl_decrypt_buf( mbedtls_ssl_context const *ssl,
 #if defined(MBEDTLS_ARC4_C) || defined(MBEDTLS_CIPHER_NULL_CIPHER)
     if( mode == MBEDTLS_MODE_STREAM )
     {
+        if (rec->data_len < transform->maclen)
+        {
+            MBEDTLS_SSL_DEBUG_MSG(1,
+                                  ("Record too short for MAC:"
+                                   " %" MBEDTLS_PRINTF_SIZET " < %" MBEDTLS_PRINTF_SIZET,
+                                   rec->data_len, transform->maclen));
+            return MBEDTLS_ERR_SSL_INVALID_MAC;
+        }
+
         padlen = 0;
         if( ( ret = mbedtls_cipher_crypt( &transform->cipher_ctx_dec,
                                    transform->iv_dec,
@@ -1632,7 +1641,7 @@ int mbedtls_ssl_decrypt_buf( mbedtls_ssl_context const *ssl,
         unsigned char mac_expect[MBEDTLS_SSL_MAC_ADD] = { 0 };
         unsigned char mac_peer[MBEDTLS_SSL_MAC_ADD] = { 0 };
 
-        /* If the initial value of padlen was such that
+        /* For CBC+MAC, If the initial value of padlen was such that
          * data_len < maclen + padlen + 1, then padlen
          * got reset to 1, and the initial check
          * data_len >= minlen + maclen + 1
@@ -1644,6 +1653,9 @@ int mbedtls_ssl_decrypt_buf( mbedtls_ssl_context const *ssl,
          * subtracted either padlen + 1 (if the padding was correct)
          * or 0 (if the padding was incorrect) since then,
          * hence data_len >= maclen in any case.
+         *
+         * For stream ciphers, we checked above that
+         * data_len >= maclen.
          */
         rec->data_len -= transform->maclen;
         ssl_extract_add_data_from_record( add_data, &add_data_len, rec,

--- a/common/mbedtls/mbedtls-2.28.1/library/ssl_tls.c
+++ b/common/mbedtls/mbedtls-2.28.1/library/ssl_tls.c
@@ -1332,20 +1332,8 @@ static int ssl_populate_transform( mbedtls_ssl_transform *transform,
                                           mac_enc, mac_key_len );
             if( ret != 0 )
                 goto end;
-#if defined(SUPPORT_HW_SSL_HMAC_SHA256)
-            int is_sha256 = 0;
-            if(transform->md_ctx_dec.md_info == mbedtls_md_info_from_type(MBEDTLS_MD_SHA256)) {
-                is_sha256 = 1;
-                ((mbedtls_sha256_context *) transform->md_ctx_dec.md_ctx)->ssl_hmac = 1;
-                device_mutex_lock(RT_DEV_LOCK_CRYPTO);
-            }
-#endif
             ret = mbedtls_md_hmac_starts( &transform->md_ctx_dec,
                                           mac_dec, mac_key_len );
-#if defined(SUPPORT_HW_SSL_HMAC_SHA256)
-            if(is_sha256)
-                device_mutex_unlock(RT_DEV_LOCK_CRYPTO);
-#endif
             if( ret != 0 )
                 goto end;
         }
@@ -4017,9 +4005,9 @@ int mbedtls_ssl_setup( mbedtls_ssl_context *ssl,
     ssl->in_buf_len = in_buf_len;
 #endif
 #if defined(CONFIG_BUILD_SECURE) && (CONFIG_BUILD_SECURE == 1)
-    ssl->in_buf = mbedtls_calloc( 1, in_buf_len );
+    ssl->in_buf = ns_calloc( 1, len );
 #else
-    if( ssl->in_buf == NULL )
+    ssl->in_buf = mbedtls_calloc( 1, in_buf_len );
 #endif
     if( ssl->in_buf == NULL )
     {

--- a/common/mbedtls/mbedtls-2.28.1/library/x509_create.c
+++ b/common/mbedtls/mbedtls-2.28.1/library/x509_create.c
@@ -210,6 +210,10 @@ int mbedtls_x509_set_extension( mbedtls_asn1_named_data **head, const char *oid,
 {
     mbedtls_asn1_named_data *cur;
 
+    if (val_len > (SIZE_MAX  - 1)) {
+        return MBEDTLS_ERR_X509_BAD_INPUT_DATA;
+    }
+
     if( ( cur = mbedtls_asn1_store_named_data( head, oid, oid_len,
                                        NULL, val_len + 1 ) ) == NULL )
     {

--- a/tools/docker/amebad/Dockerfile
+++ b/tools/docker/amebad/Dockerfile
@@ -3,7 +3,7 @@ FROM ameba-rtos-matter:common
 
 # Redefine following build arguments to respective repo and tag/branch
 ARG AMEBA_MATTER_REPO=https://github.com/xshuqun/ameba-rtos-matter.git
-ARG TAG_NAME=ameba/update_241116
+ARG TAG_NAME=ameba/mbedtls-cve-main
 
 # Define fixed build arguments
 ARG AMBD_REPO=https://github.com/Ameba-AIoT/ameba-rtos-d.git

--- a/tools/docker/amebaz2/Dockerfile
+++ b/tools/docker/amebaz2/Dockerfile
@@ -3,7 +3,7 @@ FROM ameba-rtos-matter:common
 
 # Redefine following build arguments to respective repo and tag/branch
 ARG AMEBA_MATTER_REPO=https://github.com/xshuqun/ameba-rtos-matter.git
-ARG TAG_NAME=ameba/update_241116
+ARG TAG_NAME=ameba/mbedtls-cve-main
 
 # Define fixed build arguments
 ARG AMBZ2_REPO=https://github.com/Ameba-AIoT/ameba-rtos-z2.git


### PR DESCRIPTION
Into Main Branch:

* fix CVE-2023-43615 (fix buffer overread with stream cipher)
* fix CVE-2024-23170 (Marvin Attack)
* fix CVE-2024-23775 (Buffer overflow in mbedtls_x509_set_extension())
* synchronize mbedtls code from 7.1 GIT.

Notes:
* Applied from mbedtls github: https://github.com/Mbed-TLS/mbedtls/commit/326ba3c0bb6e54473cd80fb9bf22c27780d46018
* Applied from mbedtls github (https://github.com/Mbed-TLS/mbedtls/tree/v2.28.7) -. commit 4217503, 4fe396f, aa6760d, 601bffc, eaeff5b, 8cdb606, 1a9a697
* Applied from mbedtls github: https://github.com/Mbed-TLS/mbedtls/commit/e90cbc3d1260901efc879178a15f2d90a5e17612