### PR TITLE
[general][sdk] fix build issue, timer and diagnostic logs

### DIFF
--- a/common/atcmd/atcmd_matter.c
+++ b/common/atcmd/atcmd_matter.c
@@ -129,18 +129,26 @@ void fATuserlog(void *arg)
         printf("      Set more than 1024 to trigger bdx transfer\n\r");
         return;
     }
+
     size_t dataSize = (size_t)atoi((const char *)arg);
     u8 *data = (u8 *)malloc(dataSize * sizeof(u8));
-    if (data == NULL)
-    {
+    if (data == NULL) {
         return;
     }
-    const char *logMessage = "Hello World";
-    strncpy((char *)data, logMessage, 11);
-    data[sizeof(data) - 1] = '\0';
+
+    const char *logMessage = "UserLogTesting";
+    size_t logMessageLength = strlen(logMessage);
+
+    size_t i;
+    for (i = 0; i < dataSize; i++) {
+        data[i] = logMessage[i % logMessageLength];
+    }
+
+    data[dataSize - 1] = '\0';
+
     matter_insert_user_log(data, dataSize);
-    if (data)
-    {
+
+    if (data) {
         free(data);
     }
     return;
@@ -153,16 +161,26 @@ void fATnetworklog(void *arg)
         printf("      Set more than 1024 to trigger bdx transfer\n\r");
         return;
     }
+
     size_t dataSize = (size_t)atoi((const char *)arg);
     u8 *data = (u8 *)malloc(dataSize * sizeof(u8));
     if (data == NULL)
     {
         return;
     }
-    const char *logMessage = "No Error Found";
-    strncpy((char *)data, logMessage, 14);
-    data[sizeof(data) - 1] = '\0';
+
+    const char *logMessage = "NetworkLogTesting";
+    size_t logMessageLength = strlen(logMessage);
+
+    size_t i;
+    for (i = 0; i < dataSize; i++) {
+        data[i] = logMessage[i % logMessageLength];
+    }
+
+    data[dataSize - 1] = '\0';
+
     matter_insert_network_log(data, dataSize);
+
     if (data)
     {
         free(data);

--- a/common/include/platform_opts_matter.h
+++ b/common/include/platform_opts_matter.h
@@ -159,8 +159,6 @@
 #define CONFIG_AMEBA_LOG_FILENAME_MAXSZ         32
 #endif /* CONFIG_ENABLE_AMEBA_SHORT_LOGGING */
 
-#define RETAIN_NLOGS_WHEN_FULL                  40 // most recent N logs will be kept, the rest cleared
-
 #undef SECTOR_SIZE_FLASH
 #undef FAULT_FLASH_SECTOR_SIZE
 #define SECTOR_SIZE_FLASH                       4096
@@ -175,12 +173,6 @@
 #define LFS_DEVICE_SIZE                         (0x20000)
 #define LFS_FLASH_BASE_ADDR                     (MATTER_KVS_BEGIN_ADDR2 - LFS_DEVICE_SIZE)
 #define LFS_NUM_BLOCKS                          (LFS_DEVICE_SIZE / SECTOR_SIZE_FLASH)
-
-// redefine fault message redirection flash address
-#undef FAULT_LOG1
-#undef FAULT_LOG2
-#define FAULT_LOG1                              (LFS_FLASH_BASE_ADDR - 0x1000)
-#define FAULT_LOG2                              (LFS_FLASH_BASE_ADDR - 0x2000)
 #endif /* CONFIG_ENABLE_AMEBA_LFS */
 
 #endif /* __PLATFORM_OPTS_MATTER_H__ */

--- a/common/mbedtls/matter_mbedtls_config.h
+++ b/common/mbedtls/matter_mbedtls_config.h
@@ -36,10 +36,11 @@
 #define _CRT_SECURE_NO_DEPRECATE 1
 #endif
 
+#define SUPPORT_HW_SW_CRYPTO
+
 #if defined(CONFIG_PLATFORM_8710C)
 #include <rom_ssl_ram_map.h>
 #define RTL_HW_CRYPTO
-#define SUPPORT_HW_SW_CRYPTO
 //#define SUPPORT_HW_SSL_HMAC_SHA256
 #endif
 

--- a/common/mbedtls/mbedtls-2.28.1/library/ssl_msg.c
+++ b/common/mbedtls/mbedtls-2.28.1/library/ssl_msg.c
@@ -1408,7 +1408,7 @@ int mbedtls_ssl_decrypt_buf( mbedtls_ssl_context const *ssl,
             ret = mbedtls_md_hmac_reset( &transform->md_ctx_dec );
 #if defined(SUPPORT_HW_SSL_HMAC_SHA256)
             if(is_sha256) {
-                is_sha256 = 0
+                is_sha256 = 0;
                 device_mutex_unlock(RT_DEV_LOCK_CRYPTO);
             }
 #endif
@@ -1433,7 +1433,7 @@ int mbedtls_ssl_decrypt_buf( mbedtls_ssl_context const *ssl,
         hmac_failed_etm_enabled:
 #if defined(SUPPORT_HW_SSL_HMAC_SHA256)
             if(is_sha256) {
-                is_sha256 = 0
+                is_sha256 = 0;
                 device_mutex_unlock(RT_DEV_LOCK_CRYPTO);
             }
 #endif

--- a/common/port/matter_timers.c
+++ b/common/port/matter_timers.c
@@ -24,10 +24,8 @@ extern "C" {
 #define US_OVERFLOW_MAX            (0xFFFFFFFF)
 
 #if defined(CONFIG_PLATFORM_8710C)
-#define MATTER_SW_RTC_TIMER_ID     TIMER5
 extern int FreeRTOS_errno;
 #elif defined(CONFIG_PLATFORM_8721D)
-#define MATTER_SW_RTC_TIMER_ID     TIMER2
 int FreeRTOS_errno = 0;
 #endif
 
@@ -35,10 +33,8 @@ int FreeRTOS_errno = 0;
 
 extern void vTaskDelay(const TickType_t xTicksToDelay);
 
-static gtimer_t matter_rtc_timer;
-static volatile uint32_t rtc_counter = 0;
-static volatile uint64_t last_current_us = 0;
-static uint64_t last_global_us = 0;
+static uint64_t current_us = 0;
+static uint32_t tick_count = 0;
 static bool matter_sntp_rtc_sync = FALSE;
 
 BOOL UTILS_ValidateTimespec(const struct timespec *const pxTimespec)
@@ -216,50 +212,18 @@ void matter_rtc_write(time_t time)
 
 uint64_t ameba_get_clock_time(void)
 {
-    uint64_t global_us = 0, current_us = 0;
-#if defined(CONFIG_PLATFORM_8710C)
-    // Read current timer value in microseconds
-    current_us = gtimer_read_us(&matter_rtc_timer);
-    // Check if the timer has wrapped around
-    if (current_us < last_current_us)
-    {
-        // Timer wrapped around, increment global_us and adjust last_global_us
-        global_us = last_global_us + 1;
-    }
-    else
-    {
-        // Calculate global_us based on the rtc_counter and current_us
-        global_us = ((uint64_t)rtc_counter * US_OVERFLOW_MAX) + current_us;
-        last_current_us = current_us;
+    uint64_t global_us = 0, current_ticks;
+
+    current_ticks = (uint64_t)xTaskGetTickCount() * 1000000 / configTICK_RATE_HZ;
+
+    if (current_ticks < current_us) {
+        tick_count++;
     }
 
-    last_global_us = global_us;
-#elif defined(CONFIG_PLATFORM_8721D)
-    uint32_t current_tick = 0;
-    current_tick = gtimer_read_tick(&matter_rtc_timer);
-    current_us = (uint64_t) current_tick * 1000000 / 32768;
-    global_us = ((uint64_t)rtc_counter * US_OVERFLOW_MAX) + (current_us);
-#else
-    global_us = (((uint64_t)xTaskGetTickCount()) * configTICK_RATE_HZ);
-#endif
+    current_us = current_ticks;
+    global_us = ((uint64_t)tick_count * US_OVERFLOW_MAX) + current_us;
+
     return global_us;
-}
-
-static void matter_timer_rtc_callback(void)
-{
-    rtc_counter++;
-#if defined(CONFIG_PLATFORM_8710C)
-    last_current_us = 0;
-#endif
-}
-
-void matter_timer_init(void)
-{
-    gtimer_init(&matter_rtc_timer, MATTER_SW_RTC_TIMER_ID);
-#if defined(CONFIG_PLATFORM_8710C)
-    hal_timer_set_cntmode(&matter_rtc_timer.timer_adp, 0); //use count up
-#endif
-    gtimer_start_periodical(&matter_rtc_timer, US_OVERFLOW_MAX, (void *)matter_timer_rtc_callback, (uint32_t) &matter_rtc_timer);
 }
 
 #if defined(CONFIG_ENABLE_AMEBA_SNTP) && (CONFIG_ENABLE_AMEBA_SNTP == 1)

--- a/common/port/matter_wifis.c
+++ b/common/port/matter_wifis.c
@@ -281,6 +281,7 @@ void matter_wifi_autoreconnect_hdl(rtw_security_t security_type,
 
 void matter_set_autoreconnect(uint8_t mode)
 {
+#if defined(CONFIG_AUTO_RECONNECT) && CONFIG_AUTO_RECONNECT
     size_t ssidLen = 0;
     unsigned char buf[32];
     const char kWiFiSSIDKeyName[] = "wifi-ssid";
@@ -305,6 +306,7 @@ void matter_set_autoreconnect(uint8_t mode)
         wext_set_autoreconnect(WLAN0_NAME, mode, AUTO_RECONNECT_COUNT, AUTO_RECONNECT_INTERVAL);
 #endif
     }
+#endif /* CONFIG_AUTO_RECONNECT */
     return;
 }
 

--- a/core/matter_core.cpp
+++ b/core/matter_core.cpp
@@ -300,7 +300,6 @@ CHIP_ERROR matter_core_start(void)
     if (res == 0)
     {
         ChipLogProgress(DeviceLayer, "Matter FlashFS Initialized");
-        matter_read_last_fault_log();
     }
 
     // register log redirection
@@ -309,7 +308,6 @@ CHIP_ERROR matter_core_start(void)
 #endif
 
     wifi_set_autoreconnect(0); //Disable default autoreconnect
-    matter_timer_init();
 
     return matter_core_init();
 }

--- a/drivers/matter_drivers/diagnostic_logs/ameba_logging_faultlog.cpp
+++ b/drivers/matter_drivers/diagnostic_logs/ameba_logging_faultlog.cpp
@@ -10,6 +10,7 @@
 #include <matter_fs.h>
 
 #include <diagnostic_logs/ameba_diagnosticlogs_provider_delegate_impl.h>
+#include <diagnostic_logs/ameba_logging_insert_logs.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -38,10 +39,7 @@ void matter_fault_log(char *msg, int len)
         restricted_len = len;
     }
 
-    device_mutex_lock(RT_DEV_LOCK_FLASH);
-    flash_erase_sector(&fault_flash, FAULT_LOG1);
-    flash_stream_write(&fault_flash, FAULT_LOG1, restricted_len, (uint8_t*)msg);
-    device_mutex_unlock(RT_DEV_LOCK_FLASH);
+    matter_insert_crash_log((uint8_t *)msg, (uint32_t)restricted_len);
 }
 
 void matter_bt_log(char *msg, int len)
@@ -64,105 +62,7 @@ void matter_bt_log(char *msg, int len)
         restricted_len = len;
     }
 
-    device_mutex_lock(RT_DEV_LOCK_FLASH);
-    flash_erase_sector(&fault_flash, FAULT_LOG2);
-    flash_stream_write(&fault_flash, FAULT_LOG2, restricted_len, (uint8_t*)msg);
-    device_mutex_unlock(RT_DEV_LOCK_FLASH);
-}
-
-void matter_read_last_fault_log(void)
-{
-    flash_t fault_flash;
-    lfs_file_t* fp = chip::app::Clusters::DiagnosticLogs::AmebaDiagnosticLogsProvider::GetFpCrashLog();
-    int res;
-    uint unused_writecount = 0;
-    uint readsize = 0;
-
-    //always make a new crash.log file
-    int err = matter_fs_fopen(CRASH_LOG_FILENAME, fp, LFS_O_RDWR | LFS_O_CREAT);
-    if (err != 0)
-    {
-        ChipLogError(DeviceLayer, "Open err: %d", err);
-        return;
-    }
-
-    uint8_t *log = (uint8_t *)malloc(FAULT_FLASH_SECTOR_SIZE);
-    if (!log)
-    {
-        ChipLogError(DeviceLayer, "Memory allocation failed");
-        matter_fs_fclose(fp);
-        return;
-    }
-
-    memset(log, 0xFF, FAULT_FLASH_SECTOR_SIZE);
-    device_mutex_lock(RT_DEV_LOCK_FLASH);
-    flash_stream_read(&fault_flash, FAULT_LOG1, FAULT_FLASH_SECTOR_SIZE, log);
-    device_mutex_unlock(RT_DEV_LOCK_FLASH);
-
-    if (log[0] != 0xFF)
-    {
-        ChipLogProgress(DeviceLayer, "Copy Fault log.....");
-
-        // find the first 0xFF. replacement for strlen which only terminates at \0
-        while (readsize < FAULT_FLASH_SECTOR_SIZE)
-        {
-            if (log[readsize] == 0xFF) break;
-            readsize++;
-        }
-
-        res = matter_fs_fwrite(fp, log, readsize, &unused_writecount); // write to FS
-        if (res >= 0)
-        {
-            ChipLogProgress(DeviceLayer, "Wrote %d bytes to crashlog", unused_writecount);
-        }
-        else
-        {
-            ChipLogError(DeviceLayer, "Write error! %d", res);
-            free(log);
-            matter_fs_fclose(fp);
-            return;
-        }
-    }
-
-    device_mutex_lock(RT_DEV_LOCK_FLASH);
-    flash_stream_read(&fault_flash, FAULT_LOG2, FAULT_FLASH_SECTOR_SIZE, log);
-    device_mutex_unlock(RT_DEV_LOCK_FLASH);
-
-    readsize = 0;
-    if (log[0] != 0xFF)
-    {
-        ChipLogProgress(DeviceLayer, "Copy Backtrace log......");
-
-        while (readsize < FAULT_FLASH_SECTOR_SIZE)
-        {
-            if (log[readsize] == 0xFF) break;
-            readsize++;
-        }
-
-        res = matter_fs_fwrite(fp, log, readsize, &unused_writecount);
-        if (res >= 0) 
-        {
-            ChipLogProgress(DeviceLayer, "wrote %d bytes to crashlog", unused_writecount);
-        }
-        else
-        {
-            ChipLogError(DeviceLayer, "write error! %d", res);
-            free(log);
-            matter_fs_fclose(fp);
-            return;
-        }
-    }
-
-    free(log);
-    matter_fs_fclose(fp);
-
-    // erase fault log area for new log
-    device_mutex_lock(RT_DEV_LOCK_FLASH);
-    flash_erase_sector(&fault_flash, FAULT_LOG1);
-    flash_erase_sector(&fault_flash, FAULT_LOG2);
-    device_mutex_unlock(RT_DEV_LOCK_FLASH);
-
-    return;
+    matter_insert_crash_log((uint8_t *)msg, (uint32_t)restricted_len);
 }
 
 #ifdef __cplusplus

--- a/drivers/matter_drivers/diagnostic_logs/ameba_logging_faultlog.h
+++ b/drivers/matter_drivers/diagnostic_logs/ameba_logging_faultlog.h
@@ -21,11 +21,6 @@ void matter_fault_log(char *msg, int len);
  */
 void matter_bt_log(char *msg, int len);
 
-/**
- * @brief  Reads the last crash logs from LFS
- */
-void matter_read_last_fault_log(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/drivers/matter_drivers/diagnostic_logs/ameba_logging_insert_logs.cpp
+++ b/drivers/matter_drivers/diagnostic_logs/ameba_logging_insert_logs.cpp
@@ -8,52 +8,89 @@
 #if defined(CONFIG_ENABLE_AMEBA_DLOG) && (CONFIG_ENABLE_AMEBA_DLOG == 1)
 #include <lfs.h>
 #include <matter_fs.h>
-
 #include <diagnostic_logs/ameba_diagnosticlogs_provider_delegate_impl.h>
-
+#include <diagnostic_logs/ameba_logging_insert_logs.h>
+extern bool ClearLogStrategy(void* fp);
 #ifdef __cplusplus
 extern "C" {
 #endif
 
+static int insert_log_data(char* filename, lfs_file_t* fp, uint8_t* data, uint32_t data_len)
+{
+    int res;
+    uint unused_writecount = 0;
+    bool fsReady = chip::app::Clusters::DiagnosticLogs::AmebaDiagnosticLogsProvider::IsFSReady();
+
+    if (!fsReady) {
+        res = matter_fs_fopen(filename, fp, LFS_O_RDWR | LFS_O_CREAT | LFS_O_TRUNC);
+        if (res < 0)
+        {
+            ChipLogError(DeviceLayer, "Open res: %d", res);
+            return res;
+        }
+    }
+
+    ChipLogProgress(DeviceLayer, "Copy log.....");
+
+    res = matter_fs_fwrite(fp, data, data_len, &unused_writecount);
+    if (res < 0) {
+        if (res == LFS_ERR_NOSPC) {
+            ChipLogProgress(DeviceLayer, "Insufficient space, try clearing out old data");
+            if (ClearLogStrategy((void *)fp) == false) {
+                ChipLogError(DeviceLayer, "Failed to execute log clear strategy");
+                return res;
+            }
+            else {
+                res = matter_fs_fwrite(fp, data, data_len, &unused_writecount);
+                if (res == LFS_ERR_NOSPC) {
+                    ChipLogProgress(DeviceLayer, "Still insufficient space, ignore, dropping data...");
+                    return LFS_ERR_OK;
+                }
+            }
+        }
+        else {
+            ChipLogError(DeviceLayer, "Error writing log to file: %d", res);
+            return res;
+        }
+    }
+    else {
+        ChipLogProgress(DeviceLayer, "fs wrote %d bytes", unused_writecount);
+    }
+
+    // Close file if not already ready
+    if (!fsReady) {
+        matter_fs_fclose(fp);
+    }
+
+    return LFS_ERR_OK;
+}
+
 _WEAK void matter_insert_user_log(uint8_t* data, uint32_t data_len)
 {
     lfs_file_t* fp = chip::app::Clusters::DiagnosticLogs::AmebaDiagnosticLogsProvider::GetFpUserLog();
-    int res;
-    uint unused_writecount = 0;
-
-    ChipLogProgress(DeviceLayer, "Copy User log.....");
-
-    res = matter_fs_fwrite(fp, data, data_len, &unused_writecount); // write to FS
-    if (res >= 0)
-    {
-        ChipLogProgress(DeviceLayer, "Wrote %d bytes to userlog", unused_writecount);
+    int res = insert_log_data(USER_LOG_FILENAME, fp, data, data_len);
+    if (res != LFS_ERR_OK) {
+        ChipLogError(DeviceLayer, "Failed to insert user log: %d", res);
     }
-    else
-    {
-        ChipLogError(DeviceLayer, "Write error! %d", res);
-        return;
-    }
-
-    return;
 }
 
+// Network log function
 _WEAK void matter_insert_network_log(uint8_t* data, uint32_t data_len)
 {
     lfs_file_t* fp = chip::app::Clusters::DiagnosticLogs::AmebaDiagnosticLogsProvider::GetFpNetdiagLog();
-    int res;
-    uint unused_writecount = 0;
-
-    ChipLogProgress(DeviceLayer, "Copy Network log.....");
-
-    res = matter_fs_fwrite(fp, data, data_len, &unused_writecount); // write to FS
-    if (res >= 0)
-    {
-        ChipLogProgress(DeviceLayer, "Wrote %d bytes to Networklog", unused_writecount);
+    int res = insert_log_data(NET_LOG_FILENAME, fp, data, data_len);
+    if (res != LFS_ERR_OK) {
+        ChipLogError(DeviceLayer, "Failed to insert network log: %d", res);
     }
-    else
-    {
-        ChipLogError(DeviceLayer, "Write error! %d", res);
-        return;
+}
+
+// Crash log function
+_WEAK void matter_insert_crash_log(uint8_t* data, uint32_t data_len)
+{
+    lfs_file_t* fp = chip::app::Clusters::DiagnosticLogs::AmebaDiagnosticLogsProvider::GetFpCrashLog();
+    int res = insert_log_data(CRASH_LOG_FILENAME, fp, data, data_len);
+    if (res != LFS_ERR_OK) {
+        ChipLogError(DeviceLayer, "Failed to insert crash log: %d", res);
     }
 }
 

--- a/drivers/matter_drivers/diagnostic_logs/ameba_logging_insert_logs.h
+++ b/drivers/matter_drivers/diagnostic_logs/ameba_logging_insert_logs.h
@@ -7,7 +7,7 @@ extern "C" {
 
 /**
  * @brief Inserts user log data into the logging system.
- * 
+ *
  * @param data Pointer to the data to be logged.
  * @param data_len Length of the data in bytes.
  */
@@ -15,11 +15,20 @@ _WEAK void matter_insert_user_log(uint8_t* data, uint32_t data_len);
 
 /**
  * @brief Inserts network log data into the logging system.
- * 
+ *
  * @param data Pointer to the network log data to be logged.
  * @param data_len Length of the data in bytes.
  */
 _WEAK void matter_insert_network_log(uint8_t* data, uint32_t data_len);
+
+
+/**
+ * @brief Inserts crash log data into the logging system.
+ *
+ * @param data Pointer to the crash log data to be logged.
+ * @param data_len Length of the data in bytes.
+ */
+_WEAK void matter_insert_crash_log(uint8_t* data, uint32_t data_len);
 
 #ifdef __cplusplus
 }

--- a/drivers/matter_drivers/diagnostic_logs/ameba_logging_redirect_handler.h
+++ b/drivers/matter_drivers/diagnostic_logs/ameba_logging_redirect_handler.h
@@ -23,6 +23,8 @@ typedef struct __attribute__((__packed__)) AmebaLog {
 #endif
 } amebalog_t;
 
+bool ClearLogStrategy(void* fp);
+
 class AmebaLogRedirectHandler
 {
 public:

--- a/examples/chiptest/example_matter.c
+++ b/examples/chiptest/example_matter.c
@@ -35,13 +35,8 @@ static void example_matter_task_thread(void *pvParameters)
     if (res == 0)
     {
         printf("\nMatter FlashFS Initialized\n");
-        matter_read_last_fault_log();
     }
-#endif
 
-    matter_timer_init();
-
-#if defined(CONFIG_ENABLE_AMEBA_DLOG) && (CONFIG_ENABLE_AMEBA_DLOG == 1)
     // register log redirection: C wrapper version
     ameba_logging_redirect_wrapper_init();
 #endif

--- a/tools/docker/amebad/Dockerfile
+++ b/tools/docker/amebad/Dockerfile
@@ -3,7 +3,7 @@ FROM ameba-rtos-matter:common
 
 # Redefine following build arguments to respective repo and tag/branch
 ARG AMEBA_MATTER_REPO=https://github.com/xshuqun/ameba-rtos-matter.git
-ARG TAG_NAME=ameba/mbedtls-cve-main
+ARG TAG_NAME=ameba/update_250123
 
 # Define fixed build arguments
 ARG AMBD_REPO=https://github.com/Ameba-AIoT/ameba-rtos-d.git

--- a/tools/docker/amebaz2/Dockerfile
+++ b/tools/docker/amebaz2/Dockerfile
@@ -3,7 +3,7 @@ FROM ameba-rtos-matter:common
 
 # Redefine following build arguments to respective repo and tag/branch
 ARG AMEBA_MATTER_REPO=https://github.com/xshuqun/ameba-rtos-matter.git
-ARG TAG_NAME=ameba/mbedtls-cve-main
+ARG TAG_NAME=ameba/update_250123
 
 # Define fixed build arguments
 ARG AMBZ2_REPO=https://github.com/Ameba-AIoT/ameba-rtos-z2.git


### PR DESCRIPTION
* Fix missing semicolon in SUPPORT_HW_SSL_HMAC_SHA256 codes.
* Fix build error when disabling CONFIG_AUTO_RECONNECT.
* Use Freertos TickCount for Matter System Time instead of gtimer.
* Update diagnostic logs cluster implementations.