### PR TITLE
[amebaz2][sdk] optimize memory usage

### DIFF
--- a/common/lwip/lwip_v2.1.2/src/include/lwip/opt.h
+++ b/common/lwip/lwip_v2.1.2/src/include/lwip/opt.h
@@ -255,7 +255,7 @@
  * already use it.
  */
 #if !defined MEM_LIBC_MALLOC || defined __DOXYGEN__
-#define MEM_LIBC_MALLOC                 0
+#define MEM_LIBC_MALLOC                 1
 #endif
 
 /**
@@ -268,7 +268,7 @@
  * not only for internal pools defined in memp_std.h)!
  */
 #if !defined MEMP_MEM_MALLOC || defined __DOXYGEN__
-#define MEMP_MEM_MALLOC                 0
+#define MEMP_MEM_MALLOC                 1
 #endif
 
 /**

--- a/project/amebaz2/rtl8710c_ram_matter.ld
+++ b/project/amebaz2/rtl8710c_ram_matter.ld
@@ -190,12 +190,6 @@ SECTIONS
 
 		*ram_start*.o(.text*)
 		*hal_power_mode*.o(.text*)
-		*hal_sys_ctrl*.o(.text*)
-		*rtl8710c_pinmux_patch*.o(.text*)
-		*hal_syson*.o(.text*)
-		*hal_pinmux*.o(.text*)
-		*hal_efuse*.o(.text*)
-		*sys_irq*.o(.text*)
 
 		*(.lpddr.text*)
 		*(.sram.text*)
@@ -217,12 +211,6 @@ SECTIONS
 
 		*ram_start*.o(.rodata*)
 		*hal_power_mode*.o(.rodata*)
-		*hal_sys_ctrl*.o(.rodata*)
-		*rtl8710c_pinmux_patch*.o(.rodata*)
-		*hal_syson*.o(.rodata*)
-		*hal_pinmux*.o(.rodata*)
-		*hal_efuse*.o(.rodata*)
-		*sys_irq*.o(.rodata*)
 
 		. = ALIGN(4);
 		__ram_code_rodata_end__ = .;

--- a/tools/docker/amebad/Dockerfile
+++ b/tools/docker/amebad/Dockerfile
@@ -3,7 +3,7 @@ FROM ameba-rtos-matter:common
 
 # Redefine following build arguments to respective repo and tag/branch
 ARG AMEBA_MATTER_REPO=https://github.com/xshuqun/ameba-rtos-matter.git
-ARG TAG_NAME=ameba/sync_sdk_250313
+ARG TAG_NAME=ameba/optimize_ram_usage
 
 # Define fixed build arguments
 ARG AMBD_REPO=https://github.com/Ameba-AIoT/ameba-rtos-d.git

--- a/tools/docker/amebaz2/Dockerfile
+++ b/tools/docker/amebaz2/Dockerfile
@@ -3,7 +3,7 @@ FROM ameba-rtos-matter:common
 
 # Redefine following build arguments to respective repo and tag/branch
 ARG AMEBA_MATTER_REPO=https://github.com/xshuqun/ameba-rtos-matter.git
-ARG TAG_NAME=ameba/sync_sdk_250313
+ARG TAG_NAME=ameba/optimize_ram_usage
 
 # Define fixed build arguments
 ARG AMBZ2_REPO=https://github.com/Ameba-AIoT/ameba-rtos-z2.git


### PR DESCRIPTION
* enable MEM_LIBC_MALLOC and MEMP_MEM_MALLOC to save code size.
* remove several object files from ram text and rodata, default will place it in xip.