### PR TITLE
[ameba-rtos][wifi] add RTW_MODE_STA_AP to matter_wifis.h

### DIFF
--- a/common/port/matter_wifis.h
+++ b/common/port/matter_wifis.h
@@ -31,6 +31,11 @@ extern uint32_t rtw_join_status;
 extern rtw_mode_t wifi_mode;
 
 /******************************************************
+ *               WiFi Mode
+ ******************************************************/
+#define RTW_MODE_STA_AP RTW_MODE_STA
+
+/******************************************************
  *               WiFi Security
  ******************************************************/
 #define RTW_SECURITY_WPA_WPA2_MIXED    RTW_SECURITY_WPA_WPA2_MIXED_PSK

--- a/tools/docker/ameba-rtos/Dockerfile
+++ b/tools/docker/ameba-rtos/Dockerfile
@@ -3,11 +3,11 @@ FROM ameba-rtos-matter:common
 
 # Redefine following build arguments to respective repo and tag/branch
 ARG AMEBA_MATTER_REPO=https://github.com/mikaelajiwidodo/ameba-rtos-matter.git
-ARG TAG_NAME=ameba-rtos/release/v1.3
+ARG TAG_NAME=ameba-rtos/v1.3/add_sta_ap_wifi_mode
 
 # Define fixed build arguments
 ARG AMBRTOS_REPO=https://github.com/mikaelajiwidodo/ameba-rtos.git
-ARG AMBRTOS_TAG_NAME=ameba-rtos-v1.0/matter/release/v1.3
+ARG AMBRTOS_TAG_NAME=release/v1.0+matter_init
 ARG AMEBA_MATTER_DIR=component/application/matter
 ARG AMEBA_DIR=/opt/ameba
 


### PR DESCRIPTION
* define RTW_MODE_STA_AP to RTW_MODE_STA
* RTW_MODE_STA_AP is not available in ameba-rtos SDK
* The macro is needed at [AmebaUtils.cpp](https://github.com/project-chip/connectedhomeip/blob/f647fda9ee8167c383e00ed9a911c4c7645e56b8/src/platform/Ameba/AmebaUtils.cpp#L49)