### PR TITLE
[ameba-rtos][sdk] Fixes for new ameba-rtos base SDK (v1.3)

### DIFF
--- a/common/port/matter_wifis.c
+++ b/common/port/matter_wifis.c
@@ -69,9 +69,6 @@ int matter_initiate_wifi_and_connect(rtw_network_info_t *connect_param)
         case RTW_CONNECT_SUCCESS:
             error_flag = RTW_NO_ERROR;
             break;
-        case RTW_CONNECT_UNKNOWN_FAIL:
-            error_flag = RTW_UNKNOWN;
-            break;
         case RTW_CONNECT_SCAN_FAIL:
             error_flag = RTW_NONE_NETWORK;
             break;
@@ -98,7 +95,6 @@ static void print_matter_scan_result(rtw_scan_result_t *record)
     RTW_API_INFO(MAC_FMT, MAC_ARG(record->BSSID.octet));
     RTW_API_INFO(" %d\t ", record->signal_strength);
     RTW_API_INFO(" %d\t  ", record->channel);
-    RTW_API_INFO(" %d\t  ", record->wps_type);
     RTW_API_INFO("%s\t\t ", (record->security == RTW_SECURITY_OPEN) ? "Open" :
                  (record->security == RTW_SECURITY_WEP_PSK) ? "WEP" :
                  (record->security == RTW_SECURITY_WPA_TKIP_PSK) ? "WPA TKIP" :

--- a/project/amebadplus/Makefile.include.matter
+++ b/project/amebadplus/Makefile.include.matter
@@ -18,10 +18,10 @@ endif
 #                              Include Directories                            #
 #*****************************************************************************#
 
+IFLAGS               += -I$(MATTER_DIR)/common/mbedtls
 ifeq ($(MBEDTLS_MATTER_ENABLE),y)
 IFLAGS               += -I$(MBEDTLSDIR)/include
 IFLAGS               += -I$(MBEDTLSDIR)/include/mbedtls
-IFLAGS               += -I$(MATTER_DIR)/common/mbedtls
 IFLAGS               += -I$(BASEDIR)/component/ssl/mbedtls_ram_map/rom
 endif
 
@@ -58,7 +58,6 @@ IFLAGS               += -I$(MATTER_DIR)/common/lwip/lwip_v2.1.2/port/realtek/inc
 GLOBAL_CFLAGS += -DCONFIG_MATTER=1
 
 # CPP standards and language
-CPPFLAGS += -std=c++11
 CPPFLAGS += -std=gnu++17
 CPPFLAGS += -fno-rtti
 

--- a/project/amebalite/Makefile.include.matter
+++ b/project/amebalite/Makefile.include.matter
@@ -18,10 +18,10 @@ endif
 #                              Include Directories
 #*****************************************************************************#
 
+IFLAGS               += -I$(MATTER_DIR)/common/mbedtls
 ifeq ($(MBEDTLS_MATTER_ENABLE),y)
 IFLAGS               += -I$(MBEDTLSDIR)/include
 IFLAGS               += -I$(MBEDTLSDIR)/include/mbedtls
-IFLAGS               += -I$(MATTER_DIR)/common/mbedtls
 IFLAGS               += -I$(BASEDIR)/component/ssl/mbedtls_ram_map/rom
 endif
 
@@ -58,7 +58,6 @@ IFLAGS               += -I$(MATTER_DIR)/common/lwip/lwip_v2.1.2/port/realtek/inc
 GLOBAL_CFLAGS += -DCONFIG_MATTER=1
 
 # CPP standards and language
-CPPFLAGS += -std=c++11
 CPPFLAGS += -std=gnu++17
 CPPFLAGS += -fno-rtti
 

--- a/project/amebasmart/Makefile.include.matter
+++ b/project/amebasmart/Makefile.include.matter
@@ -18,10 +18,10 @@ endif
 #                              Include Directories
 #*****************************************************************************#
 
+IFLAGS               += -I$(MATTER_DIR)/common/mbedtls
 ifeq ($(MBEDTLS_MATTER_ENABLE),y)
 IFLAGS               += -I$(MBEDTLSDIR)/include
 IFLAGS               += -I$(MBEDTLSDIR)/include/mbedtls
-IFLAGS               += -I$(MATTER_DIR)/common/mbedtls
 IFLAGS               += -I$(BASEDIR)/component/ssl/mbedtls_ram_map/rom
 endif
 
@@ -57,7 +57,6 @@ IFLAGS               += -I$(MATTER_DIR)/common/lwip/lwip_v2.1.2/port/realtek/inc
 GLOBAL_CFLAGS += -DCONFIG_MATTER=1
 
 # CPP standards and language
-CPPFLAGS += -std=c++11
 CPPFLAGS += -std=gnu++17
 CPPFLAGS += -fno-rtti
 

--- a/tools/docker/ameba-rtos/Dockerfile
+++ b/tools/docker/ameba-rtos/Dockerfile
@@ -3,11 +3,11 @@ FROM ameba-rtos-matter:common
 
 # Redefine following build arguments to respective repo and tag/branch
 ARG AMEBA_MATTER_REPO=https://github.com/mikaelajiwidodo/ameba-rtos-matter.git
-ARG TAG_NAME=ameba-rtos/v1.3/add_sta_ap_wifi_mode
+ARG TAG_NAME=ameba-rtos/v1.3/fix_for_new_base
 
 # Define fixed build arguments
-ARG AMBRTOS_REPO=https://github.com/mikaelajiwidodo/ameba-rtos.git
-ARG AMBRTOS_TAG_NAME=release/v1.0+matter_init
+ARG AMBRTOS_REPO=https://github.com/Ameba-AIoT/ameba-rtos.git
+ARG AMBRTOS_TAG_NAME=release/v1.0+matter
 ARG AMEBA_MATTER_DIR=component/application/matter
 ARG AMEBA_DIR=/opt/ameba
 

--- a/tools/docker/ameba-rtos/amebadplus/amebadplus_build.sh
+++ b/tools/docker/ameba-rtos/amebadplus/amebadplus_build.sh
@@ -32,7 +32,7 @@ source ${chipdir}/scripts/activate.sh
 cd ${amebadir}
 
 chmod u+x matter_setup.sh
-.//matter_setup.sh ameba-rtos || handle_error "Failed to run matter_setup.sh for ameba-rtos"
+.//matter_setup.sh ameba-rtos v1.3 || handle_error "Failed to run matter_setup.sh for ameba-rtos"
 
 cp ${amebadir}/component/application/matter/tools/docker/ameba-rtos/amebadplus/inc/km0/platform_autoconf.h ${amebadir}/amebadplus_gcc_project/project_km0/inc/
 cp ${amebadir}/component/application/matter/tools/docker/ameba-rtos/amebadplus/inc/km4/platform_autoconf.h ${amebadir}/amebadplus_gcc_project/project_km4/inc/

--- a/tools/docker/ameba-rtos/amebalite/amebalite_build.sh
+++ b/tools/docker/ameba-rtos/amebalite/amebalite_build.sh
@@ -32,7 +32,7 @@ source ${chipdir}/scripts/activate.sh
 cd ${amebadir}
 
 chmod u+x matter_setup.sh
-.//matter_setup.sh ameba-rtos || handle_error "Failed to run matter_setup.sh for ameba-rtos"
+.//matter_setup.sh ameba-rtos v1.3 || handle_error "Failed to run matter_setup.sh for ameba-rtos"
 
 cp ${amebadir}/component/application/matter/tools/docker/ameba-rtos/amebalite/inc/kr4/platform_autoconf.h ${amebadir}/amebalite_gcc_project/project_kr4/inc/
 cp ${amebadir}/component/application/matter/tools/docker/ameba-rtos/amebalite/inc/km4/platform_autoconf.h ${amebadir}/amebalite_gcc_project/project_km4/inc/

--- a/tools/docker/ameba-rtos/amebasmart/amebasmart_build.sh
+++ b/tools/docker/ameba-rtos/amebasmart/amebasmart_build.sh
@@ -32,7 +32,7 @@ source ${chipdir}/scripts/activate.sh
 cd ${amebadir}
 
 chmod u+x matter_setup.sh
-.//matter_setup.sh ameba-rtos || handle_error "Failed to run matter_setup.sh for ameba-rtos"
+.//matter_setup.sh ameba-rtos v1.3 || handle_error "Failed to run matter_setup.sh for ameba-rtos"
 
 cp ${amebadir}/component/application/matter/tools/docker/ameba-rtos/amebasmart/inc/lp/platform_autoconf.h ${amebadir}/amebasmart_gcc_project/project_lp/inc/
 cp ${amebadir}/component/application/matter/tools/docker/ameba-rtos/amebasmart/inc/hp/platform_autoconf.h ${amebadir}/amebasmart_gcc_project/project_hp/inc/


### PR DESCRIPTION
* To include $(MATTER_DIR)/common/mbedtls folder even when MBEDTLS_MATTER_ENABLE is not enabled
- Removed -std=c++11 from CPPFLAGS
- Removed RTW_CONNECT_UNKNOWN_FAIL case from matter_initiate_wifi_and_connect API
- Removed RTW_API_INFO(wps_type) from print_matter_scan_result API