### PR TITLE
[ameba-rtos][wifi] remove wifi_indication to fix WiFi states (v1.4)

### DIFF
--- a/common/port/matter_wifis.c
+++ b/common/port/matter_wifis.c
@@ -60,9 +60,6 @@ int matter_initiate_wifi_and_connect(rtw_network_info_t *connect_param)
     if (error_flag == RTW_SUCCESS) {
         sta_security_type = connect_param->security_type;
         memcpy(&ap_bssid, connect_param->bssid.octet, ETH_ALEN);
-        wifi_indication(WIFI_EVENT_STA_ASSOC, NULL, 0, 0);
-        // wifi_join_status_indicate(RTW_JOINSTATUS_SUCCESS);
-        wifi_indication(WIFI_EVENT_JOIN_STATUS, NULL, 0, RTW_JOINSTATUS_SUCCESS);
     } else if (rtw_join_status == RTW_JOINSTATUS_FAIL) {
         wifi_indication(WIFI_EVENT_STA_DISASSOC, NULL, 0, 0);
         switch (error_flag) {


### PR DESCRIPTION
* Removed wifi_indication because WiFi library already indicate the WIFI_EVENT_STA_ASSOC
* If it is indicated again, it will cause the WiFi states to set wrongly at [connectedhomeip/src/platform/Ameba/ConnectivityManagerImpl.cpp](https://github.com/project-chip/connectedhomeip/blob/master/src/platform/Ameba/ConnectivityManagerImpl.cpp)