### PR TITLE
[general][scripts] update script to catch errors

### DIFF
--- a/.github/workflows/build-ameba.yml
+++ b/.github/workflows/build-ameba.yml
@@ -1,10 +1,18 @@
 name: Build Ameba RTOS Matter Docker Image
 
 on:
+  push:
+    branches:
+      - main
+      - release/*
   pull_request:
     branches:
       - main
       - release/*
+
+concurrency:
+    group: ${{ github.ref }}-${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.number) || (github.event_name == 'workflow_dispatch' && github.run_number) || github.sha }}
+    cancel-in-progress: true
 
 jobs:
   build:
@@ -14,13 +22,13 @@ jobs:
     - name: Free Disk Space (Ubuntu)
       uses: jlumbroso/free-disk-space@main
       with:
-          tool-cache: false
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: false
-          docker-images: true
-          swap-storage: true
+        tool-cache: false
+        android: true
+        dotnet: true
+        haskell: true
+        large-packages: false
+        docker-images: true
+        swap-storage: true
 
     - name: Checkout code
       uses: actions/checkout@v3
@@ -52,4 +60,3 @@ jobs:
 
     - name: Clean up Docker
       run: docker system prune -af
-

--- a/tools/docker/amebad/Dockerfile
+++ b/tools/docker/amebad/Dockerfile
@@ -3,7 +3,7 @@ FROM ameba-rtos-matter:common
 
 # Redefine following build arguments to respective repo and tag/branch
 ARG AMEBA_MATTER_REPO=https://github.com/xshuqun/ameba-rtos-matter.git
-ARG TAG_NAME=ameba/script_update_250526
+ARG TAG_NAME=ameba/update_sdk_v1.4_250529
 
 # Define fixed build arguments
 ARG AMBD_REPO=https://github.com/Ameba-AIoT/ameba-rtos-d.git

--- a/tools/docker/amebad/run_docker_build_scripts.sh
+++ b/tools/docker/amebad/run_docker_build_scripts.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 run_docker_build_scripts() {
   # Define the common path for the tools directory
   local tools_dir="component/common/application/matter/tools/docker"

--- a/tools/docker/amebaz2/Dockerfile
+++ b/tools/docker/amebaz2/Dockerfile
@@ -3,7 +3,7 @@ FROM ameba-rtos-matter:common
 
 # Redefine following build arguments to respective repo and tag/branch
 ARG AMEBA_MATTER_REPO=https://github.com/xshuqun/ameba-rtos-matter.git
-ARG TAG_NAME=ameba/script_update_250526
+ARG TAG_NAME=ameba/update_sdk_v1.4_250529
 
 # Define fixed build arguments
 ARG AMBZ2_REPO=https://github.com/Ameba-AIoT/ameba-rtos-z2.git

--- a/tools/docker/amebaz2/run_docker_build_scripts.sh
+++ b/tools/docker/amebaz2/run_docker_build_scripts.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 run_docker_build_scripts() {
   # Define the common path for the tools directory
   local tools_dir="component/common/application/matter/tools/docker"


### PR DESCRIPTION
This commit addresses:

1. Adding of `set -e` command in a shell script is used to make the script exit immediately if any command returns a non-zero exit status. It helps catch errors early by stopping the script as soon as something goes wrong, instead of continuing the CI build.

2.  Stop any ongoing workflow when new workflow is triggered.