### PR TITLE
[general][sdk] enable persistent subscription on default (#57)

### DIFF
--- a/.github/ISSUE_TEMPLATE/pull_request_template.md
+++ b/.github/ISSUE_TEMPLATE/pull_request_template.md
@@ -1,0 +1,7 @@
+## This PR addresses:
+
+<!-- Clearly describe what the commit fixes, implements, or improves -->
+
+## Verification:
+
+<!-- Describe how the changes were tested -->

--- a/.github/workflows/check_pr_message.yml
+++ b/.github/workflows/check_pr_message.yml
@@ -1,0 +1,19 @@
+name: Check PR Template Format
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+jobs:
+  check-pr-message:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR body for required sections
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.pull_request.body || "";
+
+            if (!body.includes("This PR addresses:") || !body.includes("Verification:")) {
+              core.setFailed(`❌ PR description must include both "This commit addresses:" and "Verification:" sections.`);
+            }

--- a/project/amebad/make/chip/air_purifier_app/Makefile
+++ b/project/amebad/make/chip/air_purifier_app/Makefile
@@ -72,6 +72,7 @@ GENERATE_NINJA:
 	if [ $(CHIP_ENABLE_AMEBA_TC) -eq 0 ]; then echo chip_terms_and_conditions_required = "false" >> $(OUTPUT_DIR)/args.gn; else echo chip_terms_and_conditions_required = "true" >> $(OUTPUT_DIR)/args.gn; fi && \
 	echo chip_support_enable_storage_api_audit = "false" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_use_transitional_commissionable_data_provider = "true" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_persist_subscriptions = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_logging = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_error_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_progress_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \

--- a/project/amebad/make/chip/aircon_app/Makefile
+++ b/project/amebad/make/chip/aircon_app/Makefile
@@ -72,6 +72,7 @@ GENERATE_NINJA:
 	if [ $(CHIP_ENABLE_AMEBA_TC) -eq 0 ]; then echo chip_terms_and_conditions_required = "false" >> $(OUTPUT_DIR)/args.gn; else echo chip_terms_and_conditions_required = "true" >> $(OUTPUT_DIR)/args.gn; fi && \
 	echo chip_support_enable_storage_api_audit = "false" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_use_transitional_commissionable_data_provider = "true" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_persist_subscriptions = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_logging = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_error_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_progress_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \

--- a/project/amebad/make/chip/all_clusters_app/Makefile
+++ b/project/amebad/make/chip/all_clusters_app/Makefile
@@ -73,6 +73,7 @@ GENERATE_NINJA:
 	echo chip_build_libshell = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_support_enable_storage_api_audit = "false" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_use_transitional_commissionable_data_provider = "true" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_persist_subscriptions = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_logging = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_error_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_progress_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \

--- a/project/amebad/make/chip/bridge_app/Makefile
+++ b/project/amebad/make/chip/bridge_app/Makefile
@@ -71,6 +71,7 @@ GENERATE_NINJA:
 	if [ $(CHIP_ENABLE_AMEBA_TC) -eq 0 ]; then echo chip_terms_and_conditions_required = "false" >> $(OUTPUT_DIR)/args.gn; else echo chip_terms_and_conditions_required = "true" >> $(OUTPUT_DIR)/args.gn; fi && \
 	echo chip_support_enable_storage_api_audit = "false" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_use_transitional_commissionable_data_provider = "true" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_persist_subscriptions = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_logging = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_error_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_progress_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \

--- a/project/amebad/make/chip/bridge_app_dm/Makefile
+++ b/project/amebad/make/chip/bridge_app_dm/Makefile
@@ -71,6 +71,7 @@ GENERATE_NINJA:
 	if [ $(CHIP_ENABLE_AMEBA_TC) -eq 0 ]; then echo chip_terms_and_conditions_required = "false" >> $(OUTPUT_DIR)/args.gn; else echo chip_terms_and_conditions_required = "true" >> $(OUTPUT_DIR)/args.gn; fi && \
 	echo chip_support_enable_storage_api_audit = "false" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_use_transitional_commissionable_data_provider = "true" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_persist_subscriptions = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_logging = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_error_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_progress_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \

--- a/project/amebad/make/chip/dishwasher_app/Makefile
+++ b/project/amebad/make/chip/dishwasher_app/Makefile
@@ -72,6 +72,7 @@ GENERATE_NINJA:
 	if [ $(CHIP_ENABLE_AMEBA_TC) -eq 0 ]; then echo chip_terms_and_conditions_required = "false" >> $(OUTPUT_DIR)/args.gn; else echo chip_terms_and_conditions_required = "true" >> $(OUTPUT_DIR)/args.gn; fi && \
 	echo chip_support_enable_storage_api_audit = "false" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_use_transitional_commissionable_data_provider = "true" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_persist_subscriptions = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_logging = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_error_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_progress_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \

--- a/project/amebad/make/chip/fan_app/Makefile
+++ b/project/amebad/make/chip/fan_app/Makefile
@@ -72,6 +72,7 @@ GENERATE_NINJA:
 	if [ $(CHIP_ENABLE_AMEBA_TC) -eq 0 ]; then echo chip_terms_and_conditions_required = "false" >> $(OUTPUT_DIR)/args.gn; else echo chip_terms_and_conditions_required = "true" >> $(OUTPUT_DIR)/args.gn; fi && \
 	echo chip_support_enable_storage_api_audit = "false" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_use_transitional_commissionable_data_provider = "true" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_persist_subscriptions = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_logging = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_error_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_progress_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \

--- a/project/amebad/make/chip/generic_switch_app/Makefile
+++ b/project/amebad/make/chip/generic_switch_app/Makefile
@@ -72,6 +72,7 @@ GENERATE_NINJA:
 	if [ $(CHIP_ENABLE_AMEBA_TC) -eq 0 ]; then echo chip_terms_and_conditions_required = "false" >> $(OUTPUT_DIR)/args.gn; else echo chip_terms_and_conditions_required = "true" >> $(OUTPUT_DIR)/args.gn; fi && \
 	echo chip_support_enable_storage_api_audit = "false" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_use_transitional_commissionable_data_provider = "true" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_persist_subscriptions = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_logging = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_error_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_progress_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \

--- a/project/amebad/make/chip/laundrywasher_app/Makefile
+++ b/project/amebad/make/chip/laundrywasher_app/Makefile
@@ -72,6 +72,7 @@ GENERATE_NINJA:
 	if [ $(CHIP_ENABLE_AMEBA_TC) -eq 0 ]; then echo chip_terms_and_conditions_required = "false" >> $(OUTPUT_DIR)/args.gn; else echo chip_terms_and_conditions_required = "true" >> $(OUTPUT_DIR)/args.gn; fi && \
 	echo chip_support_enable_storage_api_audit = "false" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_use_transitional_commissionable_data_provider = "true" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_persist_subscriptions = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_logging = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_error_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_progress_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \

--- a/project/amebad/make/chip/light_switch_app/Makefile
+++ b/project/amebad/make/chip/light_switch_app/Makefile
@@ -73,6 +73,7 @@ GENERATE_NINJA:
 	echo chip_build_libshell = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_support_enable_storage_api_audit = "false" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_use_transitional_commissionable_data_provider = "true" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_persist_subscriptions = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_logging = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_error_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_progress_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \

--- a/project/amebad/make/chip/lighting_app/Makefile
+++ b/project/amebad/make/chip/lighting_app/Makefile
@@ -72,6 +72,7 @@ GENERATE_NINJA:
 	if [ $(CHIP_ENABLE_AMEBA_TC) -eq 0 ]; then echo chip_terms_and_conditions_required = "false" >> $(OUTPUT_DIR)/args.gn; else echo chip_terms_and_conditions_required = "true" >> $(OUTPUT_DIR)/args.gn; fi && \
 	echo chip_support_enable_storage_api_audit = "false" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_use_transitional_commissionable_data_provider = "true" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_persist_subscriptions = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_logging = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_error_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_progress_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \

--- a/project/amebad/make/chip/microwaveoven_app/Makefile
+++ b/project/amebad/make/chip/microwaveoven_app/Makefile
@@ -72,6 +72,7 @@ GENERATE_NINJA:
 	if [ $(CHIP_ENABLE_AMEBA_TC) -eq 0 ]; then echo chip_terms_and_conditions_required = "false" >> $(OUTPUT_DIR)/args.gn; else echo chip_terms_and_conditions_required = "true" >> $(OUTPUT_DIR)/args.gn; fi && \
 	echo chip_support_enable_storage_api_audit = "false" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_use_transitional_commissionable_data_provider = "true" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_persist_subscriptions = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_logging = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_error_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_progress_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \

--- a/project/amebad/make/chip/ota_requestor_app/Makefile
+++ b/project/amebad/make/chip/ota_requestor_app/Makefile
@@ -72,6 +72,7 @@ GENERATE_NINJA:
 	if [ $(CHIP_ENABLE_AMEBA_TC) -eq 0 ]; then echo chip_terms_and_conditions_required = "false" >> $(OUTPUT_DIR)/args.gn; else echo chip_terms_and_conditions_required = "true" >> $(OUTPUT_DIR)/args.gn; fi && \
 	echo chip_support_enable_storage_api_audit = "false" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_use_transitional_commissionable_data_provider = "true" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_persist_subscriptions = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_logging = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_error_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_progress_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \

--- a/project/amebad/make/chip/refrigerator_app/Makefile
+++ b/project/amebad/make/chip/refrigerator_app/Makefile
@@ -72,6 +72,7 @@ GENERATE_NINJA:
 	if [ $(CHIP_ENABLE_AMEBA_TC) -eq 0 ]; then echo chip_terms_and_conditions_required = "false" >> $(OUTPUT_DIR)/args.gn; else echo chip_terms_and_conditions_required = "true" >> $(OUTPUT_DIR)/args.gn; fi && \
 	echo chip_support_enable_storage_api_audit = "false" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_use_transitional_commissionable_data_provider = "true" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_persist_subscriptions = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_logging = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_error_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_progress_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \

--- a/project/amebad/make/chip/temperature_sensor_app/Makefile
+++ b/project/amebad/make/chip/temperature_sensor_app/Makefile
@@ -72,6 +72,7 @@ GENERATE_NINJA:
 	if [ $(CHIP_ENABLE_AMEBA_TC) -eq 0 ]; then echo chip_terms_and_conditions_required = "false" >> $(OUTPUT_DIR)/args.gn; else echo chip_terms_and_conditions_required = "true" >> $(OUTPUT_DIR)/args.gn; fi && \
 	echo chip_support_enable_storage_api_audit = "false" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_use_transitional_commissionable_data_provider = "true" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_persist_subscriptions = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_logging = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_error_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_progress_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \

--- a/project/amebad/make/chip/thermostat_app/Makefile
+++ b/project/amebad/make/chip/thermostat_app/Makefile
@@ -72,6 +72,7 @@ GENERATE_NINJA:
 	if [ $(CHIP_ENABLE_AMEBA_TC) -eq 0 ]; then echo chip_terms_and_conditions_required = "false" >> $(OUTPUT_DIR)/args.gn; else echo chip_terms_and_conditions_required = "true" >> $(OUTPUT_DIR)/args.gn; fi && \
 	echo chip_support_enable_storage_api_audit = "false" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_use_transitional_commissionable_data_provider = "true" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_persist_subscriptions = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_logging = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_error_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_progress_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \

--- a/project/amebaz2/make/air_purifier/lib_chip_air_purifier_core.mk
+++ b/project/amebaz2/make/air_purifier/lib_chip_air_purifier_core.mk
@@ -122,6 +122,7 @@ GENERATE_NINJA:
 	if [ $(CHIP_ENABLE_AMEBA_TC) -eq 0 ]; then echo chip_terms_and_conditions_required = "false" >> $(OUTPUT_DIR)/args.gn; else echo chip_terms_and_conditions_required = "true" >> $(OUTPUT_DIR)/args.gn; fi && \
 	echo chip_support_enable_storage_api_audit = "false" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_use_transitional_commissionable_data_provider = "true" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_persist_subscriptions = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_logging = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_error_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_progress_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \

--- a/project/amebaz2/make/aircon/lib_chip_aircon_core.mk
+++ b/project/amebaz2/make/aircon/lib_chip_aircon_core.mk
@@ -123,6 +123,7 @@ GENERATE_NINJA:
 	if [ $(CHIP_ENABLE_AMEBA_TC) -eq 0 ]; then echo chip_terms_and_conditions_required = "false" >> $(OUTPUT_DIR)/args.gn; else echo chip_terms_and_conditions_required = "true" >> $(OUTPUT_DIR)/args.gn; fi && \
 	echo chip_support_enable_storage_api_audit = "false" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_use_transitional_commissionable_data_provider = "true" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_persist_subscriptions = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_logging = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_error_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_progress_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \

--- a/project/amebaz2/make/all_clusters/lib_chip.mk
+++ b/project/amebaz2/make/all_clusters/lib_chip.mk
@@ -122,6 +122,7 @@ GENERATE_NINJA:
 	echo chip_build_libshell = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_support_enable_storage_api_audit = "false" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_use_transitional_commissionable_data_provider = "true" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_persist_subscriptions = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_logging = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_error_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_progress_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \

--- a/project/amebaz2/make/bridge_dm/lib_chip_bridge_core.mk
+++ b/project/amebaz2/make/bridge_dm/lib_chip_bridge_core.mk
@@ -123,6 +123,7 @@ GENERATE_NINJA:
 	if [ $(CHIP_ENABLE_AMEBA_TC) -eq 0 ]; then echo chip_terms_and_conditions_required = "false" >> $(OUTPUT_DIR)/args.gn; else echo chip_terms_and_conditions_required = "true" >> $(OUTPUT_DIR)/args.gn; fi && \
 	echo chip_support_enable_storage_api_audit = "false" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_use_transitional_commissionable_data_provider = "true" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_persist_subscriptions = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_logging = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_error_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_progress_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \

--- a/project/amebaz2/make/chef/lib_chip_chef_core.mk
+++ b/project/amebaz2/make/chef/lib_chip_chef_core.mk
@@ -122,6 +122,7 @@ GENERATE_NINJA:
 	if [ $(CHIP_ENABLE_AMEBA_TC) -eq 0 ]; then echo chip_terms_and_conditions_required = "false" >> $(OUTPUT_DIR)/args.gn; else echo chip_terms_and_conditions_required = "true" >> $(OUTPUT_DIR)/args.gn; fi && \
 	echo chip_support_enable_storage_api_audit = "false" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_use_transitional_commissionable_data_provider = "true" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_persist_subscriptions = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_logging = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_error_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_progress_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \

--- a/project/amebaz2/make/dishwasher/lib_chip_dishwasher_core.mk
+++ b/project/amebaz2/make/dishwasher/lib_chip_dishwasher_core.mk
@@ -124,6 +124,7 @@ GENERATE_NINJA:
 	if [ $(CHIP_ENABLE_AMEBA_TC) -eq 0 ]; then echo chip_terms_and_conditions_required = "false" >> $(OUTPUT_DIR)/args.gn; else echo chip_terms_and_conditions_required = "true" >> $(OUTPUT_DIR)/args.gn; fi && \
 	echo chip_support_enable_storage_api_audit = "false" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_use_transitional_commissionable_data_provider = "true" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_persist_subscriptions = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_logging = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_error_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_progress_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \

--- a/project/amebaz2/make/fan/lib_chip_fan_core.mk
+++ b/project/amebaz2/make/fan/lib_chip_fan_core.mk
@@ -123,6 +123,7 @@ GENERATE_NINJA:
 	if [ $(CHIP_ENABLE_AMEBA_TC) -eq 0 ]; then echo chip_terms_and_conditions_required = "false" >> $(OUTPUT_DIR)/args.gn; else echo chip_terms_and_conditions_required = "true" >> $(OUTPUT_DIR)/args.gn; fi && \
 	echo chip_support_enable_storage_api_audit = "false" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_use_transitional_commissionable_data_provider = "true" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_persist_subscriptions = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_logging = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_error_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_progress_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \

--- a/project/amebaz2/make/generic_switch/lib_chip_generic_switch_core.mk
+++ b/project/amebaz2/make/generic_switch/lib_chip_generic_switch_core.mk
@@ -124,6 +124,7 @@ GENERATE_NINJA:
 	if [ $(CHIP_ENABLE_AMEBA_TC) -eq 0 ]; then echo chip_terms_and_conditions_required = "false" >> $(OUTPUT_DIR)/args.gn; else echo chip_terms_and_conditions_required = "true" >> $(OUTPUT_DIR)/args.gn; fi && \
 	echo chip_support_enable_storage_api_audit = "false" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_use_transitional_commissionable_data_provider = "false" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_persist_subscriptions = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_logging = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_error_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_progress_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \

--- a/project/amebaz2/make/laundrywasher/lib_chip_laundrywasher_core.mk
+++ b/project/amebaz2/make/laundrywasher/lib_chip_laundrywasher_core.mk
@@ -123,6 +123,7 @@ GENERATE_NINJA:
 	if [ $(CHIP_ENABLE_AMEBA_TC) -eq 0 ]; then echo chip_terms_and_conditions_required = "false" >> $(OUTPUT_DIR)/args.gn; else echo chip_terms_and_conditions_required = "true" >> $(OUTPUT_DIR)/args.gn; fi && \
 	echo chip_support_enable_storage_api_audit = "false" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_use_transitional_commissionable_data_provider = "true" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_persist_subscriptions = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_logging = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_error_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_progress_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \

--- a/project/amebaz2/make/light/lib_chip_light_core.mk
+++ b/project/amebaz2/make/light/lib_chip_light_core.mk
@@ -122,6 +122,7 @@ GENERATE_NINJA:
 	if [ $(CHIP_ENABLE_AMEBA_TC) -eq 0 ]; then echo chip_terms_and_conditions_required = "false" >> $(OUTPUT_DIR)/args.gn; else echo chip_terms_and_conditions_required = "true" >> $(OUTPUT_DIR)/args.gn; fi && \
 	echo chip_support_enable_storage_api_audit = "false" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_use_transitional_commissionable_data_provider = "true" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_persist_subscriptions = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_logging = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_error_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_progress_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \

--- a/project/amebaz2/make/light_dm/lib_chip_light_core.mk
+++ b/project/amebaz2/make/light_dm/lib_chip_light_core.mk
@@ -122,6 +122,7 @@ GENERATE_NINJA:
 	if [ $(CHIP_ENABLE_AMEBA_TC) -eq 0 ]; then echo chip_terms_and_conditions_required = "false" >> $(OUTPUT_DIR)/args.gn; else echo chip_terms_and_conditions_required = "true" >> $(OUTPUT_DIR)/args.gn; fi && \
 	echo chip_support_enable_storage_api_audit = "false" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_use_transitional_commissionable_data_provider = "true" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_persist_subscriptions = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_logging = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_error_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_progress_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \

--- a/project/amebaz2/make/light_port/lib_chip_light_core.mk
+++ b/project/amebaz2/make/light_port/lib_chip_light_core.mk
@@ -122,6 +122,7 @@ GENERATE_NINJA:
 	if [ $(CHIP_ENABLE_AMEBA_TC) -eq 0 ]; then echo chip_terms_and_conditions_required = "false" >> $(OUTPUT_DIR)/args.gn; else echo chip_terms_and_conditions_required = "true" >> $(OUTPUT_DIR)/args.gn; fi && \
 	echo chip_support_enable_storage_api_audit = "false" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_use_transitional_commissionable_data_provider = "true" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_persist_subscriptions = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_logging = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_error_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_progress_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \

--- a/project/amebaz2/make/light_switch/lib_chip_light_switch_core.mk
+++ b/project/amebaz2/make/light_switch/lib_chip_light_switch_core.mk
@@ -126,6 +126,7 @@ GENERATE_NINJA:
 	echo chip_build_libshell = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_support_enable_storage_api_audit = "false" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_use_transitional_commissionable_data_provider = "true" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_persist_subscriptions = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_logging = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_error_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_progress_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \

--- a/project/amebaz2/make/microwaveoven/lib_chip_microwaveoven_core.mk
+++ b/project/amebaz2/make/microwaveoven/lib_chip_microwaveoven_core.mk
@@ -123,6 +123,7 @@ GENERATE_NINJA:
 	if [ $(CHIP_ENABLE_AMEBA_TC) -eq 0 ]; then echo chip_terms_and_conditions_required = "false" >> $(OUTPUT_DIR)/args.gn; else echo chip_terms_and_conditions_required = "true" >> $(OUTPUT_DIR)/args.gn; fi && \
 	echo chip_support_enable_storage_api_audit = "false" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_use_transitional_commissionable_data_provider = "true" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_persist_subscriptions = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_logging = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_error_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_progress_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \

--- a/project/amebaz2/make/otar/lib_chip_otar_core.mk
+++ b/project/amebaz2/make/otar/lib_chip_otar_core.mk
@@ -122,6 +122,7 @@ GENERATE_NINJA:
 	if [ $(CHIP_ENABLE_AMEBA_TC) -eq 0 ]; then echo chip_terms_and_conditions_required = "false" >> $(OUTPUT_DIR)/args.gn; else echo chip_terms_and_conditions_required = "true" >> $(OUTPUT_DIR)/args.gn; fi && \
 	echo chip_support_enable_storage_api_audit = "false" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_use_transitional_commissionable_data_provider = "true" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_persist_subscriptions = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_logging = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_error_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_progress_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \

--- a/project/amebaz2/make/refrigerator/lib_chip_refrigerator_core.mk
+++ b/project/amebaz2/make/refrigerator/lib_chip_refrigerator_core.mk
@@ -123,6 +123,7 @@ GENERATE_NINJA:
 	if [ $(CHIP_ENABLE_AMEBA_TC) -eq 0 ]; then echo chip_terms_and_conditions_required = "false" >> $(OUTPUT_DIR)/args.gn; else echo chip_terms_and_conditions_required = "true" >> $(OUTPUT_DIR)/args.gn; fi && \
 	echo chip_support_enable_storage_api_audit = "false" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_use_transitional_commissionable_data_provider = "true" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_persist_subscriptions = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_logging = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_error_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_progress_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \

--- a/project/amebaz2/make/temperature_sensor/lib_chip_temp_sensor_core.mk
+++ b/project/amebaz2/make/temperature_sensor/lib_chip_temp_sensor_core.mk
@@ -123,6 +123,7 @@ GENERATE_NINJA:
 	if [ $(CHIP_ENABLE_AMEBA_TC) -eq 0 ]; then echo chip_terms_and_conditions_required = "false" >> $(OUTPUT_DIR)/args.gn; else echo chip_terms_and_conditions_required = "true" >> $(OUTPUT_DIR)/args.gn; fi && \
 	echo chip_support_enable_storage_api_audit = "false" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_use_transitional_commissionable_data_provider = "true" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_persist_subscriptions = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_logging = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_error_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_progress_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \

--- a/project/amebaz2/make/thermostat/lib_chip_thermostat_core.mk
+++ b/project/amebaz2/make/thermostat/lib_chip_thermostat_core.mk
@@ -122,6 +122,7 @@ GENERATE_NINJA:
 	if [ $(CHIP_ENABLE_AMEBA_TC) -eq 0 ]; then echo chip_terms_and_conditions_required = "false" >> $(OUTPUT_DIR)/args.gn; else echo chip_terms_and_conditions_required = "true" >> $(OUTPUT_DIR)/args.gn; fi && \
 	echo chip_support_enable_storage_api_audit = "false" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_use_transitional_commissionable_data_provider = "true" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_persist_subscriptions = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_logging = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_error_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_progress_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \

--- a/project/amebaz2plus/make/air_purifier/lib_chip_air_purifier_core.mk
+++ b/project/amebaz2plus/make/air_purifier/lib_chip_air_purifier_core.mk
@@ -122,6 +122,7 @@ GENERATE_NINJA:
 	if [ $(CHIP_ENABLE_AMEBA_TC) -eq 0 ]; then echo chip_terms_and_conditions_required = "false" >> $(OUTPUT_DIR)/args.gn; else echo chip_terms_and_conditions_required = "true" >> $(OUTPUT_DIR)/args.gn; fi && \
 	echo chip_support_enable_storage_api_audit = "false" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_use_transitional_commissionable_data_provider = "true" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_persist_subscriptions = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_logging = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_error_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_progress_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \

--- a/project/amebaz2plus/make/aircon/lib_chip_aircon_core.mk
+++ b/project/amebaz2plus/make/aircon/lib_chip_aircon_core.mk
@@ -123,6 +123,7 @@ GENERATE_NINJA:
 	if [ $(CHIP_ENABLE_AMEBA_TC) -eq 0 ]; then echo chip_terms_and_conditions_required = "false" >> $(OUTPUT_DIR)/args.gn; else echo chip_terms_and_conditions_required = "true" >> $(OUTPUT_DIR)/args.gn; fi && \
 	echo chip_support_enable_storage_api_audit = "false" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_use_transitional_commissionable_data_provider = "true" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_persist_subscriptions = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_logging = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_error_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_progress_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \

--- a/project/amebaz2plus/make/all_clusters/lib_chip.mk
+++ b/project/amebaz2plus/make/all_clusters/lib_chip.mk
@@ -122,6 +122,7 @@ GENERATE_NINJA:
 	echo chip_build_libshell = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_support_enable_storage_api_audit = "false" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_use_transitional_commissionable_data_provider = "true" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_persist_subscriptions = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_logging = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_error_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_progress_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \

--- a/project/amebaz2plus/make/bridge_dm/lib_chip_bridge_core.mk
+++ b/project/amebaz2plus/make/bridge_dm/lib_chip_bridge_core.mk
@@ -123,6 +123,7 @@ GENERATE_NINJA:
 	if [ $(CHIP_ENABLE_AMEBA_TC) -eq 0 ]; then echo chip_terms_and_conditions_required = "false" >> $(OUTPUT_DIR)/args.gn; else echo chip_terms_and_conditions_required = "true" >> $(OUTPUT_DIR)/args.gn; fi && \
 	echo chip_support_enable_storage_api_audit = "false" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_use_transitional_commissionable_data_provider = "true" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_persist_subscriptions = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_logging = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_error_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_progress_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \

--- a/project/amebaz2plus/make/chef/lib_chip_chef_core.mk
+++ b/project/amebaz2plus/make/chef/lib_chip_chef_core.mk
@@ -122,6 +122,7 @@ GENERATE_NINJA:
 	if [ $(CHIP_ENABLE_AMEBA_TC) -eq 0 ]; then echo chip_terms_and_conditions_required = "false" >> $(OUTPUT_DIR)/args.gn; else echo chip_terms_and_conditions_required = "true" >> $(OUTPUT_DIR)/args.gn; fi && \
 	echo chip_support_enable_storage_api_audit = "false" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_use_transitional_commissionable_data_provider = "true" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_persist_subscriptions = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_logging = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_error_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_progress_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \

--- a/project/amebaz2plus/make/dishwasher/lib_chip_dishwasher_core.mk
+++ b/project/amebaz2plus/make/dishwasher/lib_chip_dishwasher_core.mk
@@ -124,6 +124,7 @@ GENERATE_NINJA:
 	if [ $(CHIP_ENABLE_AMEBA_TC) -eq 0 ]; then echo chip_terms_and_conditions_required = "false" >> $(OUTPUT_DIR)/args.gn; else echo chip_terms_and_conditions_required = "true" >> $(OUTPUT_DIR)/args.gn; fi && \
 	echo chip_support_enable_storage_api_audit = "false" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_use_transitional_commissionable_data_provider = "true" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_persist_subscriptions = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_logging = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_error_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_progress_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \

--- a/project/amebaz2plus/make/fan/lib_chip_fan_core.mk
+++ b/project/amebaz2plus/make/fan/lib_chip_fan_core.mk
@@ -123,6 +123,7 @@ GENERATE_NINJA:
 	if [ $(CHIP_ENABLE_AMEBA_TC) -eq 0 ]; then echo chip_terms_and_conditions_required = "false" >> $(OUTPUT_DIR)/args.gn; else echo chip_terms_and_conditions_required = "true" >> $(OUTPUT_DIR)/args.gn; fi && \
 	echo chip_support_enable_storage_api_audit = "false" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_use_transitional_commissionable_data_provider = "true" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_persist_subscriptions = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_logging = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_error_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_progress_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \

--- a/project/amebaz2plus/make/generic_switch/lib_chip_generic_switch_core.mk
+++ b/project/amebaz2plus/make/generic_switch/lib_chip_generic_switch_core.mk
@@ -124,6 +124,7 @@ GENERATE_NINJA:
 	if [ $(CHIP_ENABLE_AMEBA_TC) -eq 0 ]; then echo chip_terms_and_conditions_required = "false" >> $(OUTPUT_DIR)/args.gn; else echo chip_terms_and_conditions_required = "true" >> $(OUTPUT_DIR)/args.gn; fi && \
 	echo chip_support_enable_storage_api_audit = "false" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_use_transitional_commissionable_data_provider = "false" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_persist_subscriptions = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_logging = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_error_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_progress_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \

--- a/project/amebaz2plus/make/laundrywasher/lib_chip_laundrywasher_core.mk
+++ b/project/amebaz2plus/make/laundrywasher/lib_chip_laundrywasher_core.mk
@@ -123,6 +123,7 @@ GENERATE_NINJA:
 	if [ $(CHIP_ENABLE_AMEBA_TC) -eq 0 ]; then echo chip_terms_and_conditions_required = "false" >> $(OUTPUT_DIR)/args.gn; else echo chip_terms_and_conditions_required = "true" >> $(OUTPUT_DIR)/args.gn; fi && \
 	echo chip_support_enable_storage_api_audit = "false" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_use_transitional_commissionable_data_provider = "true" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_persist_subscriptions = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_logging = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_error_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_progress_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \

--- a/project/amebaz2plus/make/light/lib_chip_light_core.mk
+++ b/project/amebaz2plus/make/light/lib_chip_light_core.mk
@@ -122,6 +122,7 @@ GENERATE_NINJA:
 	if [ $(CHIP_ENABLE_AMEBA_TC) -eq 0 ]; then echo chip_terms_and_conditions_required = "false" >> $(OUTPUT_DIR)/args.gn; else echo chip_terms_and_conditions_required = "true" >> $(OUTPUT_DIR)/args.gn; fi && \
 	echo chip_support_enable_storage_api_audit = "false" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_use_transitional_commissionable_data_provider = "true" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_persist_subscriptions = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_logging = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_error_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_progress_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \

--- a/project/amebaz2plus/make/light_dm/lib_chip_light_core.mk
+++ b/project/amebaz2plus/make/light_dm/lib_chip_light_core.mk
@@ -122,6 +122,7 @@ GENERATE_NINJA:
 	if [ $(CHIP_ENABLE_AMEBA_TC) -eq 0 ]; then echo chip_terms_and_conditions_required = "false" >> $(OUTPUT_DIR)/args.gn; else echo chip_terms_and_conditions_required = "true" >> $(OUTPUT_DIR)/args.gn; fi && \
 	echo chip_support_enable_storage_api_audit = "false" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_use_transitional_commissionable_data_provider = "true" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_persist_subscriptions = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_logging = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_error_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_progress_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \

--- a/project/amebaz2plus/make/light_port/lib_chip_light_core.mk
+++ b/project/amebaz2plus/make/light_port/lib_chip_light_core.mk
@@ -122,6 +122,7 @@ GENERATE_NINJA:
 	if [ $(CHIP_ENABLE_AMEBA_TC) -eq 0 ]; then echo chip_terms_and_conditions_required = "false" >> $(OUTPUT_DIR)/args.gn; else echo chip_terms_and_conditions_required = "true" >> $(OUTPUT_DIR)/args.gn; fi && \
 	echo chip_support_enable_storage_api_audit = "false" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_use_transitional_commissionable_data_provider = "true" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_persist_subscriptions = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_logging = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_error_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_progress_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \

--- a/project/amebaz2plus/make/light_switch/lib_chip_light_switch_core.mk
+++ b/project/amebaz2plus/make/light_switch/lib_chip_light_switch_core.mk
@@ -126,6 +126,7 @@ GENERATE_NINJA:
 	echo chip_build_libshell = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_support_enable_storage_api_audit = "false" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_use_transitional_commissionable_data_provider = "true" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_persist_subscriptions = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_logging = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_error_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_progress_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \

--- a/project/amebaz2plus/make/microwaveoven/lib_chip_microwaveoven_core.mk
+++ b/project/amebaz2plus/make/microwaveoven/lib_chip_microwaveoven_core.mk
@@ -123,6 +123,7 @@ GENERATE_NINJA:
 	if [ $(CHIP_ENABLE_AMEBA_TC) -eq 0 ]; then echo chip_terms_and_conditions_required = "false" >> $(OUTPUT_DIR)/args.gn; else echo chip_terms_and_conditions_required = "true" >> $(OUTPUT_DIR)/args.gn; fi && \
 	echo chip_support_enable_storage_api_audit = "false" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_use_transitional_commissionable_data_provider = "true" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_persist_subscriptions = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_logging = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_error_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_progress_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \

--- a/project/amebaz2plus/make/otar/lib_chip_otar_core.mk
+++ b/project/amebaz2plus/make/otar/lib_chip_otar_core.mk
@@ -122,6 +122,7 @@ GENERATE_NINJA:
 	if [ $(CHIP_ENABLE_AMEBA_TC) -eq 0 ]; then echo chip_terms_and_conditions_required = "false" >> $(OUTPUT_DIR)/args.gn; else echo chip_terms_and_conditions_required = "true" >> $(OUTPUT_DIR)/args.gn; fi && \
 	echo chip_support_enable_storage_api_audit = "false" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_use_transitional_commissionable_data_provider = "true" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_persist_subscriptions = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_logging = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_error_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_progress_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \

--- a/project/amebaz2plus/make/refrigerator/lib_chip_refrigerator_core.mk
+++ b/project/amebaz2plus/make/refrigerator/lib_chip_refrigerator_core.mk
@@ -123,6 +123,7 @@ GENERATE_NINJA:
 	if [ $(CHIP_ENABLE_AMEBA_TC) -eq 0 ]; then echo chip_terms_and_conditions_required = "false" >> $(OUTPUT_DIR)/args.gn; else echo chip_terms_and_conditions_required = "true" >> $(OUTPUT_DIR)/args.gn; fi && \
 	echo chip_support_enable_storage_api_audit = "false" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_use_transitional_commissionable_data_provider = "true" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_persist_subscriptions = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_logging = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_error_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_progress_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \

--- a/project/amebaz2plus/make/temperature_sensor/lib_chip_temp_sensor_core.mk
+++ b/project/amebaz2plus/make/temperature_sensor/lib_chip_temp_sensor_core.mk
@@ -123,6 +123,7 @@ GENERATE_NINJA:
 	if [ $(CHIP_ENABLE_AMEBA_TC) -eq 0 ]; then echo chip_terms_and_conditions_required = "false" >> $(OUTPUT_DIR)/args.gn; else echo chip_terms_and_conditions_required = "true" >> $(OUTPUT_DIR)/args.gn; fi && \
 	echo chip_support_enable_storage_api_audit = "false" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_use_transitional_commissionable_data_provider = "true" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_persist_subscriptions = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_logging = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_error_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_progress_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \

--- a/project/amebaz2plus/make/thermostat/lib_chip_thermostat_core.mk
+++ b/project/amebaz2plus/make/thermostat/lib_chip_thermostat_core.mk
@@ -122,6 +122,7 @@ GENERATE_NINJA:
 	if [ $(CHIP_ENABLE_AMEBA_TC) -eq 0 ]; then echo chip_terms_and_conditions_required = "false" >> $(OUTPUT_DIR)/args.gn; else echo chip_terms_and_conditions_required = "true" >> $(OUTPUT_DIR)/args.gn; fi && \
 	echo chip_support_enable_storage_api_audit = "false" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_use_transitional_commissionable_data_provider = "true" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_persist_subscriptions = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_logging = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_error_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_progress_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \

--- a/tools/codegen_helpers/parse_clusters.py
+++ b/tools/codegen_helpers/parse_clusters.py
@@ -7,6 +7,10 @@ import glob
 import sys
 import os
 
+excluded_files = [
+    "TemporaryTestCoupling.cpp",
+]
+
 def parse_zapfile_clusters(cluster_file, chip_path):
     """Prints all of the source directories to build for a given ZAP file.
     Arguments:
@@ -26,8 +30,11 @@ def parse_zapfile_clusters(cluster_file, chip_path):
     chip_cluster_path = os.getcwd()
     for cluster in cluster_list:
         for clusters_cpp in glob.glob(chip_cluster_path + '/' + cluster + "/*.cpp"):
-                f.write(chip_cluster_path + '/' + cluster + '/' + os.path.basename(clusters_cpp) + '\n')
-        # f.write(chip_cluster_path + '/' + cluster + '/' + cluster + '.cpp' + '\n')
+            cpp_filename = os.path.basename(clusters_cpp)
+            if cpp_filename in excluded_files:
+                continue  # Skip excluded files
+            cpp_path = chip_cluster_path + '/' + cluster + '/' + cpp_filename
+            f.write(cpp_path + '\n')
 
     # Restore current working directory and close file
     os.chdir(cwd)

--- a/tools/docker/amebad/Dockerfile
+++ b/tools/docker/amebad/Dockerfile
@@ -3,7 +3,7 @@ FROM ameba-rtos-matter:common
 
 # Redefine following build arguments to respective repo and tag/branch
 ARG AMEBA_MATTER_REPO=https://github.com/xshuqun/ameba-rtos-matter.git
-ARG TAG_NAME=ameba/update_sdk_250529
+ARG TAG_NAME=ameba/update_sdk_250609
 
 # Define fixed build arguments
 ARG AMBD_REPO=https://github.com/Ameba-AIoT/ameba-rtos-d.git
@@ -24,4 +24,3 @@ WORKDIR ${AMEBA_DIR}/ameba-rtos-d
 
 # Set default command to bash for interaction
 CMD ["/bin/bash"]
-

--- a/tools/docker/amebaz2/Dockerfile
+++ b/tools/docker/amebaz2/Dockerfile
@@ -3,7 +3,7 @@ FROM ameba-rtos-matter:common
 
 # Redefine following build arguments to respective repo and tag/branch
 ARG AMEBA_MATTER_REPO=https://github.com/xshuqun/ameba-rtos-matter.git
-ARG TAG_NAME=ameba/update_sdk_250529
+ARG TAG_NAME=ameba/update_sdk_250609
 
 # Define fixed build arguments
 ARG AMBZ2_REPO=https://github.com/Ameba-AIoT/ameba-rtos-z2.git
@@ -24,4 +24,3 @@ WORKDIR ${AMEBA_DIR}/ameba-rtos-z2
 
 # Set default command to bash for interaction
 CMD ["/bin/bash"]
-


### PR DESCRIPTION
This PR addresses:

(1) Enable persistent subscription.
The persistent subscription allows to pertain the CASE session so when device reboot, it uses the previous CASE session record for communication.

(2) Added Pull Request Template.

(3) Fixed build error of multiple definition of SetBreadCrumb due to building of TemporaryTestCoupling.cpp.

Verification:

Tested with Ecosystem: when device reboots, device sends command to Ecosystem, Ecosystem reflects changes right away.
Tested with CI.