### PR TITLE
[general][sdk] Handle same-filename build conflicts

### DIFF
--- a/project/amebad/make/chip_main/air_purifier_app/Makefile
+++ b/project/amebad/make/chip_main/air_purifier_app/Makefile
@@ -86,10 +86,9 @@ endif
 #*****************************************************************************#
 #                              OBJECT FILE LIST                               #
 #*****************************************************************************#
-CPPOBJS = $(notdir $(CPPSRC:.cpp=.o))
+CPPOBJS = $(CPPSRC:.cpp=.o)
 COBJS = $(notdir $(CSRC:.c=.o))
-OBJS = $(CPPOBJS)
-OBJS += $(COBJS)
+OBJS = $(CPPOBJS) $(COBJS)
 STATIC_LIB = lib_main.a
 
 #*****************************************************************************#
@@ -105,20 +104,26 @@ all: CORE_TARGETS
 #*****************************************************************************#
 #                              GENERATE OBJECT FILE                           #
 #*****************************************************************************#
-CORE_TARGETS: $(OBJS) $(STATIC_LIB)
+CORE_TARGETS: $(CPPOBJS) $(COBJS) $(STATIC_LIB)
+
+$(CPPOBJS): %.o: %.cpp
+	$(CC) -ffunction-sections $(CPPFLAGS) $(MODULE_IFLAGS) -c $< -o $@
+	foldername=$$(basename $$(dirname $<)); \
+	mkdir -p $${foldername}; \
+	cp $@ $${foldername}/$(notdir $@)
+
 $(STATIC_LIB):$(OBJS)
-	$(AR) rvs $@ $^
+	$(AR) rvs $@ *.o */*.o
 	$(MOVE) -f $@ $(ROOTDIR)/lib/application
 
 #*****************************************************************************#
 #                              CLEAN GENERATED FILES                          #
 #*****************************************************************************#
 clean:
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/air_purifier_app/*.o
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/air_purifier_app/*.i
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/air_purifier_app/*.s
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/air_purifier_app/*.d
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/air_purifier_app/*.ii
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/air_purifier_app/*.su
+	find $(MATTER_BUILDDIR)/make/chip_main/air_purifier_app/ -mindepth 1 -type d -exec rm -r {} +
+	rm -f $(patsubst %.cpp,%.d,$(CPPSRC:.cpp=.d))
+	rm -f $(patsubst %.cpp,%.su,$(CPPSRC:.cpp=.su))
+	rm -f $(patsubst %.cpp,%.o,$(CPPSRC:.cpp=.o))
+	rm -f *.d *.su *.o
 
 -include $(DEPS)

--- a/project/amebad/make/chip_main/aircon_app_port/Makefile
+++ b/project/amebad/make/chip_main/aircon_app_port/Makefile
@@ -83,10 +83,9 @@ CPPSRC += $(MATTER_EXAMPLEDIR)/aircon/matter_drivers.cpp
 #*****************************************************************************#
 #                              OBJECT FILE LIST                               #
 #*****************************************************************************#
-CPPOBJS = $(notdir $(CPPSRC:.cpp=.o))
+CPPOBJS = $(CPPSRC:.cpp=.o)
 COBJS = $(notdir $(CSRC:.c=.o))
-OBJS = $(CPPOBJS)
-OBJS += $(COBJS)
+OBJS = $(CPPOBJS) $(COBJS)
 STATIC_LIB = lib_main.a
 
 #*****************************************************************************#
@@ -102,21 +101,27 @@ all: CORE_TARGETS
 #*****************************************************************************#
 #                              GENERATE OBJECT FILE                           #
 #*****************************************************************************#
-CORE_TARGETS: $(OBJS) $(STATIC_LIB)
+CORE_TARGETS: $(CPPOBJS) $(COBJS) $(STATIC_LIB)
+
+$(CPPOBJS): %.o: %.cpp
+	$(CC) -ffunction-sections $(CPPFLAGS) $(MODULE_IFLAGS) -c $< -o $@
+	foldername=$$(basename $$(dirname $<)); \
+	mkdir -p $${foldername}; \
+	cp $@ $${foldername}/$(notdir $@)
+
 $(STATIC_LIB):$(OBJS)
-	$(AR) rvs $@ $^
+	$(AR) rvs $@ *.o */*.o
 	$(MOVE) -f $@ $(ROOTDIR)/lib/application
 
 #*****************************************************************************#
 #                              CLEAN GENERATED FILES                          #
 #*****************************************************************************#
 clean:
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/aircon_app_port/*.o
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/aircon_app_port/*.i
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/aircon_app_port/*.s
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/aircon_app_port/*.d
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/aircon_app_port/*.ii
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/aircon_app_port/*.su
+	find $(MATTER_BUILDDIR)/make/chip_main/aircon_app_port/ -mindepth 1 -type d -exec rm -r {} +
+	rm -f $(patsubst %.cpp,%.d,$(CPPSRC:.cpp=.d))
+	rm -f $(patsubst %.cpp,%.su,$(CPPSRC:.cpp=.su))
+	rm -f $(patsubst %.cpp,%.o,$(CPPSRC:.cpp=.o))
+	rm -f *.d *.su *.o
 	rm -f $(MATTER_EXAMPLEDIR)/aircon/aircon-app.matter
 
 -include $(DEPS)

--- a/project/amebad/make/chip_main/all_clusters_app/Makefile
+++ b/project/amebad/make/chip_main/all_clusters_app/Makefile
@@ -78,7 +78,7 @@ IFLAGS += -I$(BASEDIR)/component/common/application/matter/examples/chiptest
 #                              SOURCE FILE LIST                               #
 #*****************************************************************************#
 # all-clusters-app clusters source files
-CPPSRC += $(SDKROOTDIR)/component/common/application/matter/drivers/matter_consoles/matter_command.cpp
+CPPSRC += $(MATTER_DIR)/drivers/matter_consoles/matter_command.cpp
 CPPSRC += $(MATTER_DRIVER)/action/ameba_bridged_actions_stubs.cpp
 CPPSRC += $(MATTER_DRIVER)/air_quality/ameba_air_quality_instance.cpp
 CPPSRC += $(MATTER_DRIVER)/device_energy_management/ameba_concentration_measurement_instances.cpp
@@ -144,10 +144,9 @@ CPPSRC += $(CHIPDIR)/examples/platform/ameba/test_event_trigger/AmebaTestEventTr
 #*****************************************************************************#
 #                              OBJECT FILE LIST                               #
 #*****************************************************************************#
-CPPOBJS = $(notdir $(CPPSRC:.cpp=.o))
+CPPOBJS = $(CPPSRC:.cpp=.o)
 COBJS = $(notdir $(CSRC:.c=.o))
-OBJS = $(CPPOBJS)
-OBJS += $(COBJS)
+OBJS = $(CPPOBJS) $(COBJS)
 STATIC_LIB = lib_main.a
 
 #*****************************************************************************#
@@ -163,20 +162,26 @@ all: CORE_TARGETS
 #*****************************************************************************#
 #                              GENERATE OBJECT FILE                           #
 #*****************************************************************************#
-CORE_TARGETS: $(OBJS) $(STATIC_LIB)
+CORE_TARGETS: $(CPPOBJS) $(COBJS) $(STATIC_LIB)
+
+$(CPPOBJS): %.o: %.cpp
+	$(CC) -ffunction-sections $(CPPFLAGS) $(MODULE_IFLAGS) -c $< -o $@
+	foldername=$$(basename $$(dirname $<)); \
+	mkdir -p $${foldername}; \
+	cp $@ $${foldername}/$(notdir $@)
+
 $(STATIC_LIB):$(OBJS)
-	$(AR) rvs $@ $^
+	$(AR) rvs $@ *.o */*.o
 	$(MOVE) -f $@ $(ROOTDIR)/lib/application
 
 #*****************************************************************************#
 #                              CLEAN GENERATED FILES                          #
 #*****************************************************************************#
 clean:
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/all_clusters_app/*.o
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/all_clusters_app/*.i
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/all_clusters_app/*.s
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/all_clusters_app/*.d
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/all_clusters_app/*.ii
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/all_clusters_app/*.su
+	find $(MATTER_BUILDDIR)/make/chip_main/all_clusters_app/ -mindepth 1 -type d -exec rm -r {} +
+	rm -f $(patsubst %.cpp,%.d,$(CPPSRC:.cpp=.d))
+	rm -f $(patsubst %.cpp,%.su,$(CPPSRC:.cpp=.su))
+	rm -f $(patsubst %.cpp,%.o,$(CPPSRC:.cpp=.o))
+	rm -f *.d *.su *.o
 
 -include $(DEPS)

--- a/project/amebad/make/chip_main/bridge_app_port/Makefile
+++ b/project/amebad/make/chip_main/bridge_app_port/Makefile
@@ -88,10 +88,9 @@ CPPSRC += $(MATTER_EXAMPLEDIR)/bridge/matter_drivers.cpp
 #*****************************************************************************#
 #                              OBJECT FILE LIST                               #
 #*****************************************************************************#
-CPPOBJS = $(notdir $(CPPSRC:.cpp=.o))
+CPPOBJS = $(CPPSRC:.cpp=.o)
 COBJS = $(notdir $(CSRC:.c=.o))
-OBJS = $(CPPOBJS)
-OBJS += $(COBJS)
+OBJS = $(CPPOBJS) $(COBJS)
 STATIC_LIB = lib_main.a
 
 #*****************************************************************************#
@@ -107,21 +106,27 @@ all: CORE_TARGETS
 #*****************************************************************************#
 #                              GENERATE OBJECT FILE                           #
 #*****************************************************************************#
-CORE_TARGETS: $(OBJS) $(STATIC_LIB)
+CORE_TARGETS: $(CPPOBJS) $(COBJS) $(STATIC_LIB)
+
+$(CPPOBJS): %.o: %.cpp
+	$(CC) -ffunction-sections $(CPPFLAGS) $(MODULE_IFLAGS) -c $< -o $@
+	foldername=$$(basename $$(dirname $<)); \
+	mkdir -p $${foldername}; \
+	cp $@ $${foldername}/$(notdir $@)
+
 $(STATIC_LIB):$(OBJS)
-	$(AR) rvs $@ $^
+	$(AR) rvs $@ *.o */*.o
 	$(MOVE) -f $@ $(ROOTDIR)/lib/application
 
 #*****************************************************************************#
 #                              CLEAN GENERATED FILES                          #
 #*****************************************************************************#
 clean:
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/bridge_app_port/*.o
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/bridge_app_port/*.i
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/bridge_app_port/*.s
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/bridge_app_port/*.d
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/bridge_app_port/*.ii
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/bridge_app_port/*.su
+	find $(MATTER_BUILDDIR)/make/chip_main/air_purifier_app/ -mindepth 1 -type d -exec rm -r {} +
+	rm -f $(patsubst %.cpp,%.d,$(CPPSRC:.cpp=.d))
+	rm -f $(patsubst %.cpp,%.su,$(CPPSRC:.cpp=.su))
+	rm -f $(patsubst %.cpp,%.o,$(CPPSRC:.cpp=.o))
+	rm -f *.d *.su *.o
 	rm -f $(MATTER_EXAMPLEDIR)/bridge/bridge-app.matter
 
 -include $(DEPS)

--- a/project/amebad/make/chip_main/bridge_app_port_dm/Makefile
+++ b/project/amebad/make/chip_main/bridge_app_port_dm/Makefile
@@ -86,10 +86,9 @@ CPPSRC += $(MATTER_EXAMPLEDIR)/bridge_dm/matter_drivers.cpp
 #*****************************************************************************#
 #                              OBJECT FILE LIST                               #
 #*****************************************************************************#
-CPPOBJS = $(notdir $(CPPSRC:.cpp=.o))
+CPPOBJS = $(CPPSRC:.cpp=.o)
 COBJS = $(notdir $(CSRC:.c=.o))
-OBJS = $(CPPOBJS)
-OBJS += $(COBJS)
+OBJS = $(CPPOBJS) $(COBJS)
 STATIC_LIB = lib_main.a
 
 #*****************************************************************************#
@@ -105,21 +104,27 @@ all: CORE_TARGETS
 #*****************************************************************************#
 #                              GENERATE OBJECT FILE                           #
 #*****************************************************************************#
-CORE_TARGETS: $(OBJS) $(STATIC_LIB)
+CORE_TARGETS: $(CPPOBJS) $(COBJS) $(STATIC_LIB)
+
+$(CPPOBJS): %.o: %.cpp
+	$(CC) -ffunction-sections $(CPPFLAGS) $(MODULE_IFLAGS) -c $< -o $@
+	foldername=$$(basename $$(dirname $<)); \
+	mkdir -p $${foldername}; \
+	cp $@ $${foldername}/$(notdir $@)
+
 $(STATIC_LIB):$(OBJS)
-	$(AR) rvs $@ $^
+	$(AR) rvs $@ *.o */*.o
 	$(MOVE) -f $@ $(ROOTDIR)/lib/application
 
 #*****************************************************************************#
 #                              CLEAN GENERATED FILES                          #
 #*****************************************************************************#
 clean:
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/bridge_app_port_dm/*.o
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/bridge_app_port_dm/*.i
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/bridge_app_port_dm/*.s
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/bridge_app_port_dm/*.d
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/bridge_app_port_dm/*.ii
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/bridge_app_port_dm/*.su
+	find $(MATTER_BUILDDIR)/make/chip_main/bridge_app_port_dm/ -mindepth 1 -type d -exec rm -r {} +
+	rm -f $(patsubst %.cpp,%.d,$(CPPSRC:.cpp=.d))
+	rm -f $(patsubst %.cpp,%.su,$(CPPSRC:.cpp=.su))
+	rm -f $(patsubst %.cpp,%.o,$(CPPSRC:.cpp=.o))
+	rm -f *.d *.su *.o
 	rm -f $(MATTER_EXAMPLEDIR)/bridge_dm/bridge-app.matter
 
 -include $(DEPS)

--- a/project/amebad/make/chip_main/dishwasher_app_port/Makefile
+++ b/project/amebad/make/chip_main/dishwasher_app_port/Makefile
@@ -88,10 +88,9 @@ CPPSRC += $(MATTER_EXAMPLEDIR)/dishwasher/matter_drivers.cpp
 #*****************************************************************************#
 #                              OBJECT FILE LIST                               #
 #*****************************************************************************#
-CPPOBJS = $(notdir $(CPPSRC:.cpp=.o))
+CPPOBJS = $(CPPSRC:.cpp=.o)
 COBJS = $(notdir $(CSRC:.c=.o))
-OBJS = $(CPPOBJS)
-OBJS += $(COBJS)
+OBJS = $(CPPOBJS) $(COBJS)
 STATIC_LIB = lib_main.a
 
 #*****************************************************************************#
@@ -107,21 +106,27 @@ all: CORE_TARGETS
 #*****************************************************************************#
 #                              GENERATE OBJECT FILE                           #
 #*****************************************************************************#
-CORE_TARGETS: $(OBJS) $(STATIC_LIB)
+CORE_TARGETS: $(CPPOBJS) $(COBJS) $(STATIC_LIB)
+
+$(CPPOBJS): %.o: %.cpp
+	$(CC) -ffunction-sections $(CPPFLAGS) $(MODULE_IFLAGS) -c $< -o $@
+	foldername=$$(basename $$(dirname $<)); \
+	mkdir -p $${foldername}; \
+	cp $@ $${foldername}/$(notdir $@)
+
 $(STATIC_LIB):$(OBJS)
-	$(AR) rvs $@ $^
+	$(AR) rvs $@ *.o */*.o
 	$(MOVE) -f $@ $(ROOTDIR)/lib/application
 
 #*****************************************************************************#
 #                              CLEAN GENERATED FILES                          #
 #*****************************************************************************#
 clean:
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/dishwasher_app_port/*.o
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/dishwasher_app_port/*.i
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/dishwasher_app_port/*.s
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/dishwasher_app_port/*.d
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/dishwasher_app_port/*.ii
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/dishwasher_app_port/*.su
+	find $(MATTER_BUILDDIR)/make/chip_main/dishwasher_app_port/ -mindepth 1 -type d -exec rm -r {} +
+	rm -f $(patsubst %.cpp,%.d,$(CPPSRC:.cpp=.d))
+	rm -f $(patsubst %.cpp,%.su,$(CPPSRC:.cpp=.su))
+	rm -f $(patsubst %.cpp,%.o,$(CPPSRC:.cpp=.o))
+	rm -f *.d *.su *.o
 	rm -f $(MATTER_EXAMPLEDIR)/dishwasher/dishwasher-app.matter
 
 -include $(DEPS)

--- a/project/amebad/make/chip_main/fan_app_port/Makefile
+++ b/project/amebad/make/chip_main/fan_app_port/Makefile
@@ -82,10 +82,9 @@ CPPSRC += $(MATTER_EXAMPLEDIR)/fan/matter_drivers.cpp
 #*****************************************************************************#
 #                              OBJECT FILE LIST                               #
 #*****************************************************************************#
-CPPOBJS = $(notdir $(CPPSRC:.cpp=.o))
+CPPOBJS = $(CPPSRC:.cpp=.o)
 COBJS = $(notdir $(CSRC:.c=.o))
-OBJS = $(CPPOBJS)
-OBJS += $(COBJS)
+OBJS = $(CPPOBJS) $(COBJS)
 STATIC_LIB = lib_main.a
 
 #*****************************************************************************#
@@ -101,21 +100,27 @@ all: CORE_TARGETS
 #*****************************************************************************#
 #                              GENERATE OBJECT FILE                           #
 #*****************************************************************************#
-CORE_TARGETS: $(OBJS) $(STATIC_LIB)
+CORE_TARGETS: $(CPPOBJS) $(COBJS) $(STATIC_LIB)
+
+$(CPPOBJS): %.o: %.cpp
+	$(CC) -ffunction-sections $(CPPFLAGS) $(MODULE_IFLAGS) -c $< -o $@
+	foldername=$$(basename $$(dirname $<)); \
+	mkdir -p $${foldername}; \
+	cp $@ $${foldername}/$(notdir $@)
+
 $(STATIC_LIB):$(OBJS)
-	$(AR) rvs $@ $^
+	$(AR) rvs $@ *.o */*.o
 	$(MOVE) -f $@ $(ROOTDIR)/lib/application
 
 #*****************************************************************************#
 #                              CLEAN GENERATED FILES                          #
 #*****************************************************************************#
 clean:
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/fan_app_port/*.o
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/fan_app_port/*.i
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/fan_app_port/*.s
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/fan_app_port/*.d
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/fan_app_port/*.ii
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/fan_app_port/*.su
+	find $(MATTER_BUILDDIR)/make/chip_main/fan_app_port/ -mindepth 1 -type d -exec rm -r {} +
+	rm -f $(patsubst %.cpp,%.d,$(CPPSRC:.cpp=.d))
+	rm -f $(patsubst %.cpp,%.su,$(CPPSRC:.cpp=.su))
+	rm -f $(patsubst %.cpp,%.o,$(CPPSRC:.cpp=.o))
+	rm -f *.d *.su *.o
 	rm -f $(MATTER_EXAMPLEDIR)/fan/fan-app.matter
 
 -include $(DEPS)

--- a/project/amebad/make/chip_main/generic_switch_app_port/Makefile
+++ b/project/amebad/make/chip_main/generic_switch_app_port/Makefile
@@ -83,10 +83,9 @@ CPPSRC += $(MATTER_EXAMPLEDIR)/generic_switch/matter_drivers.cpp
 #*****************************************************************************#
 #                              OBJECT FILE LIST                               #
 #*****************************************************************************#
-CPPOBJS = $(notdir $(CPPSRC:.cpp=.o))
+CPPOBJS = $(CPPSRC:.cpp=.o)
 COBJS = $(notdir $(CSRC:.c=.o))
-OBJS = $(CPPOBJS)
-OBJS += $(COBJS)
+OBJS = $(CPPOBJS) $(COBJS)
 STATIC_LIB = lib_main.a
 
 #*****************************************************************************#
@@ -102,21 +101,27 @@ all: CORE_TARGETS
 #*****************************************************************************#
 #                              GENERATE OBJECT FILE                           #
 #*****************************************************************************#
-CORE_TARGETS: $(OBJS) $(STATIC_LIB)
+CORE_TARGETS: $(CPPOBJS) $(COBJS) $(STATIC_LIB)
+
+$(CPPOBJS): %.o: %.cpp
+	$(CC) -ffunction-sections $(CPPFLAGS) $(MODULE_IFLAGS) -c $< -o $@
+	foldername=$$(basename $$(dirname $<)); \
+	mkdir -p $${foldername}; \
+	cp $@ $${foldername}/$(notdir $@)
+
 $(STATIC_LIB):$(OBJS)
-	$(AR) rvs $@ $^
+	$(AR) rvs $@ *.o */*.o
 	$(MOVE) -f $@ $(ROOTDIR)/lib/application
 
 #*****************************************************************************#
 #                              CLEAN GENERATED FILES                          #
 #*****************************************************************************#
 clean:
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/generic_switch_app_port/*.o
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/generic_switch_app_port/*.i
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/generic_switch_app_port/*.s
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/generic_switch_app_port/*.d
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/generic_switch_app_port/*.ii
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/generic_switch_app_port/*.su
+	find $(MATTER_BUILDDIR)/make/chip_main/generic_switch_app_port/ -mindepth 1 -type d -exec rm -r {} +
+	rm -f $(patsubst %.cpp,%.d,$(CPPSRC:.cpp=.d))
+	rm -f $(patsubst %.cpp,%.su,$(CPPSRC:.cpp=.su))
+	rm -f $(patsubst %.cpp,%.o,$(CPPSRC:.cpp=.o))
+	rm -f *.d *.su *.o
 	rm -f $(MATTER_EXAMPLEDIR)/generic_switch/generic-switch-app.matter
 
 -include $(DEPS)

--- a/project/amebad/make/chip_main/laundrywasher_app_port/Makefile
+++ b/project/amebad/make/chip_main/laundrywasher_app_port/Makefile
@@ -85,10 +85,9 @@ CPPSRC += $(MATTER_EXAMPLEDIR)/laundrywasher/matter_drivers.cpp
 #*****************************************************************************#
 #                              OBJECT FILE LIST                               #
 #*****************************************************************************#
-CPPOBJS = $(notdir $(CPPSRC:.cpp=.o))
+CPPOBJS = $(CPPSRC:.cpp=.o)
 COBJS = $(notdir $(CSRC:.c=.o))
-OBJS = $(CPPOBJS)
-OBJS += $(COBJS)
+OBJS = $(CPPOBJS) $(COBJS)
 STATIC_LIB = lib_main.a
 
 #*****************************************************************************#
@@ -104,21 +103,27 @@ all: CORE_TARGETS
 #*****************************************************************************#
 #                              GENERATE OBJECT FILE                           #
 #*****************************************************************************#
-CORE_TARGETS: $(OBJS) $(STATIC_LIB)
+CORE_TARGETS: $(CPPOBJS) $(COBJS) $(STATIC_LIB)
+
+$(CPPOBJS): %.o: %.cpp
+	$(CC) -ffunction-sections $(CPPFLAGS) $(MODULE_IFLAGS) -c $< -o $@
+	foldername=$$(basename $$(dirname $<)); \
+	mkdir -p $${foldername}; \
+	cp $@ $${foldername}/$(notdir $@)
+
 $(STATIC_LIB):$(OBJS)
-	$(AR) rvs $@ $^
+	$(AR) rvs $@ *.o */*.o
 	$(MOVE) -f $@ $(ROOTDIR)/lib/application
 
 #*****************************************************************************#
 #                              CLEAN GENERATED FILES                          #
 #*****************************************************************************#
 clean:
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/laundrywasher_app_port/*.o
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/laundrywasher_app_port/*.i
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/laundrywasher_app_port/*.s
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/laundrywasher_app_port/*.d
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/laundrywasher_app_port/*.ii
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/laundrywasher_app_port/*.su
+	find $(MATTER_BUILDDIR)/make/chip_main/laundrywasher_app_port/ -mindepth 1 -type d -exec rm -r {} +
+	rm -f $(patsubst %.cpp,%.d,$(CPPSRC:.cpp=.d))
+	rm -f $(patsubst %.cpp,%.su,$(CPPSRC:.cpp=.su))
+	rm -f $(patsubst %.cpp,%.o,$(CPPSRC:.cpp=.o))
+	rm -f *.d *.su *.o
 	rm -f $(MATTER_EXAMPLEDIR)/laundrywasher/laundrywasher-app.matter
 
 -include $(DEPS)

--- a/project/amebad/make/chip_main/light_switch_app/Makefile
+++ b/project/amebad/make/chip_main/light_switch_app/Makefile
@@ -88,10 +88,9 @@ CPPSRC += $(CHIPDIR)/examples/platform/ameba/shell/launch_shell.cpp
 #*****************************************************************************#
 #                              OBJECT FILE LIST                               #
 #*****************************************************************************#
-CPPOBJS = $(notdir $(CPPSRC:.cpp=.o))
+CPPOBJS = $(CPPSRC:.cpp=.o)
 COBJS = $(notdir $(CSRC:.c=.o))
-OBJS = $(CPPOBJS)
-OBJS += $(COBJS)
+OBJS = $(CPPOBJS) $(COBJS)
 STATIC_LIB = lib_main.a
 
 #*****************************************************************************#
@@ -107,20 +106,26 @@ all: CORE_TARGETS
 #*****************************************************************************#
 #                              GENERATE OBJECT FILE                           #
 #*****************************************************************************#
-CORE_TARGETS: $(OBJS) $(STATIC_LIB)
+CORE_TARGETS: $(CPPOBJS) $(COBJS) $(STATIC_LIB)
+
+$(CPPOBJS): %.o: %.cpp
+	$(CC) -ffunction-sections $(CPPFLAGS) $(MODULE_IFLAGS) -c $< -o $@
+	foldername=$$(basename $$(dirname $<)); \
+	mkdir -p $${foldername}; \
+	cp $@ $${foldername}/$(notdir $@)
+
 $(STATIC_LIB):$(OBJS)
-	$(AR) rvs $@ $^
+	$(AR) rvs $@ *.o */*.o
 	$(MOVE) -f $@ $(ROOTDIR)/lib/application
 
 #*****************************************************************************#
 #                              CLEAN GENERATED FILES                          #
 #*****************************************************************************#
 clean:
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/light-switch_app/*.o
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/light-switch_app/*.i
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/light-switch_app/*.s
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/light-switch_app/*.d
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/light-switch_app/*.ii
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/light-switch_app/*.su
+	find $(MATTER_BUILDDIR)/make/chip_main/light_switch_app/ -mindepth 1 -type d -exec rm -r {} +
+	rm -f $(patsubst %.cpp,%.d,$(CPPSRC:.cpp=.d))
+	rm -f $(patsubst %.cpp,%.su,$(CPPSRC:.cpp=.su))
+	rm -f $(patsubst %.cpp,%.o,$(CPPSRC:.cpp=.o))
+	rm -f *.d *.su *.o
 
 -include $(DEPS)

--- a/project/amebad/make/chip_main/lighting_app/Makefile
+++ b/project/amebad/make/chip_main/lighting_app/Makefile
@@ -83,10 +83,9 @@ endif
 #*****************************************************************************#
 #                              OBJECT FILE LIST                               #
 #*****************************************************************************#
-CPPOBJS = $(notdir $(CPPSRC:.cpp=.o))
+CPPOBJS = $(CPPSRC:.cpp=.o)
 COBJS = $(notdir $(CSRC:.c=.o))
-OBJS = $(CPPOBJS)
-OBJS += $(COBJS)
+OBJS = $(CPPOBJS) $(COBJS)
 STATIC_LIB = lib_main.a
 
 #*****************************************************************************#
@@ -102,20 +101,26 @@ all: CORE_TARGETS
 #*****************************************************************************#
 #                              GENERATE OBJECT FILE                           #
 #*****************************************************************************#
-CORE_TARGETS: $(OBJS) $(STATIC_LIB)
+CORE_TARGETS: $(CPPOBJS) $(COBJS) $(STATIC_LIB)
+
+$(CPPOBJS): %.o: %.cpp
+	$(CC) -ffunction-sections $(CPPFLAGS) $(MODULE_IFLAGS) -c $< -o $@
+	foldername=$$(basename $$(dirname $<)); \
+	mkdir -p $${foldername}; \
+	cp $@ $${foldername}/$(notdir $@)
+
 $(STATIC_LIB):$(OBJS)
-	$(AR) rvs $@ $^
+	$(AR) rvs $@ *.o */*.o
 	$(MOVE) -f $@ $(ROOTDIR)/lib/application
 
 #*****************************************************************************#
 #                              CLEAN GENERATED FILES                          #
 #*****************************************************************************#
 clean:
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/lighting_app/*.o
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/lighting_app/*.i
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/lighting_app/*.s
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/lighting_app/*.d
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/lighting_app/*.ii
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/lighting_app/*.su
+	find $(MATTER_BUILDDIR)/make/chip_main/lighting_app/ -mindepth 1 -type d -exec rm -r {} +
+	rm -f $(patsubst %.cpp,%.d,$(CPPSRC:.cpp=.d))
+	rm -f $(patsubst %.cpp,%.su,$(CPPSRC:.cpp=.su))
+	rm -f $(patsubst %.cpp,%.o,$(CPPSRC:.cpp=.o))
+	rm -f *.d *.su *.o
 
 -include $(DEPS)

--- a/project/amebad/make/chip_main/lighting_app_port/Makefile
+++ b/project/amebad/make/chip_main/lighting_app_port/Makefile
@@ -86,10 +86,9 @@ CPPSRC += $(MATTER_EXAMPLEDIR)/light/matter_drivers.cpp
 #*****************************************************************************#
 #                              OBJECT FILE LIST                               #
 #*****************************************************************************#
-CPPOBJS = $(notdir $(CPPSRC:.cpp=.o))
+CPPOBJS = $(CPPSRC:.cpp=.o)
 COBJS = $(notdir $(CSRC:.c=.o))
-OBJS = $(CPPOBJS)
-OBJS += $(COBJS)
+OBJS = $(CPPOBJS) $(COBJS)
 STATIC_LIB = lib_main.a
 
 #*****************************************************************************#
@@ -105,20 +104,26 @@ all: CORE_TARGETS
 #*****************************************************************************#
 #                              GENERATE OBJECT FILE                           #
 #*****************************************************************************#
-CORE_TARGETS: $(OBJS) $(STATIC_LIB)
+CORE_TARGETS: $(CPPOBJS) $(COBJS) $(STATIC_LIB)
+
+$(CPPOBJS): %.o: %.cpp
+	$(CC) -ffunction-sections $(CPPFLAGS) $(MODULE_IFLAGS) -c $< -o $@
+	foldername=$$(basename $$(dirname $<)); \
+	mkdir -p $${foldername}; \
+	cp $@ $${foldername}/$(notdir $@)
+
 $(STATIC_LIB):$(OBJS)
-	$(AR) rvs $@ $^
+	$(AR) rvs $@ *.o */*.o
 	$(MOVE) -f $@ $(ROOTDIR)/lib/application
 
 #*****************************************************************************#
 #                              CLEAN GENERATED FILES                          #
 #*****************************************************************************#
 clean:
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/lighting_app_port/*.o
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/lighting_app_port/*.i
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/lighting_app_port/*.s
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/lighting_app_port/*.d
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/lighting_app_port/*.ii
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/lighting_app_port/*.su
+	find $(MATTER_BUILDDIR)/make/chip_main/lighting_app_port/ -mindepth 1 -type d -exec rm -r {} +
+	rm -f $(patsubst %.cpp,%.d,$(CPPSRC:.cpp=.d))
+	rm -f $(patsubst %.cpp,%.su,$(CPPSRC:.cpp=.su))
+	rm -f $(patsubst %.cpp,%.o,$(CPPSRC:.cpp=.o))
+	rm -f *.d *.su *.o
 
 -include $(DEPS)

--- a/project/amebad/make/chip_main/lighting_app_port_dm/Makefile
+++ b/project/amebad/make/chip_main/lighting_app_port_dm/Makefile
@@ -91,10 +91,9 @@ CPPSRC += $(MATTER_EXAMPLEDIR)/light_dm/matter_drivers.cpp
 #*****************************************************************************#
 #                              OBJECT FILE LIST                               #
 #*****************************************************************************#
-CPPOBJS = $(notdir $(CPPSRC:.cpp=.o))
+CPPOBJS = $(CPPSRC:.cpp=.o)
 COBJS = $(notdir $(CSRC:.c=.o))
-OBJS = $(CPPOBJS)
-OBJS += $(COBJS)
+OBJS = $(CPPOBJS) $(COBJS)
 STATIC_LIB = lib_main.a
 
 #*****************************************************************************#
@@ -110,20 +109,26 @@ all: CORE_TARGETS
 #*****************************************************************************#
 #                              GENERATE OBJECT FILE                           #
 #*****************************************************************************#
-CORE_TARGETS: $(OBJS) $(STATIC_LIB)
+CORE_TARGETS: $(CPPOBJS) $(COBJS) $(STATIC_LIB)
+
+$(CPPOBJS): %.o: %.cpp
+	$(CC) -ffunction-sections $(CPPFLAGS) $(MODULE_IFLAGS) -c $< -o $@
+	foldername=$$(basename $$(dirname $<)); \
+	mkdir -p $${foldername}; \
+	cp $@ $${foldername}/$(notdir $@)
+
 $(STATIC_LIB):$(OBJS)
-	$(AR) rvs $@ $^
+	$(AR) rvs $@ *.o */*.o
 	$(MOVE) -f $@ $(ROOTDIR)/lib/application
 
 #*****************************************************************************#
 #                              CLEAN GENERATED FILES                          #
 #*****************************************************************************#
 clean:
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/lighting_app_port_dm/*.o
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/lighting_app_port_dm/*.i
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/lighting_app_port_dm/*.s
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/lighting_app_port_dm/*.d
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/lighting_app_port_dm/*.ii
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/lighting_app_port_dm/*.su
+	find $(MATTER_BUILDDIR)/make/chip_main/lighting_app_port_dm/ -mindepth 1 -type d -exec rm -r {} +
+	rm -f $(patsubst %.cpp,%.d,$(CPPSRC:.cpp=.d))
+	rm -f $(patsubst %.cpp,%.su,$(CPPSRC:.cpp=.su))
+	rm -f $(patsubst %.cpp,%.o,$(CPPSRC:.cpp=.o))
+	rm -f *.d *.su *.o
 
 -include $(DEPS)

--- a/project/amebad/make/chip_main/microwaveoven_app_port/Makefile
+++ b/project/amebad/make/chip_main/microwaveoven_app_port/Makefile
@@ -75,7 +75,7 @@ CPPSRC += $(BASEDIR)/component/common/application/matter/core/matter_ota_initial
 endif
 
 # microwaveoven-app src files
-CPPSRC += $(BASEDIR)/component/common/application/matter/driver/device/microwaveoven_driver.cpp
+CPPSRC += $(BASEDIR)/component/common/application/matter/drivers/device/microwaveoven_driver.cpp
 CPPSRC += $(MATTER_DRIVER)/microwave_oven/ameba_microwave_oven_device.cpp
 CPPSRC += $(MATTER_EXAMPLEDIR)/microwaveoven/example_matter_microwave_oven.cpp
 CPPSRC += $(MATTER_EXAMPLEDIR)/microwaveoven/matter_drivers.cpp
@@ -83,10 +83,9 @@ CPPSRC += $(MATTER_EXAMPLEDIR)/microwaveoven/matter_drivers.cpp
 #*****************************************************************************#
 #                              OBJECT FILE LIST                               #
 #*****************************************************************************#
-CPPOBJS = $(notdir $(CPPSRC:.cpp=.o))
+CPPOBJS = $(CPPSRC:.cpp=.o)
 COBJS = $(notdir $(CSRC:.c=.o))
-OBJS = $(CPPOBJS)
-OBJS += $(COBJS)
+OBJS = $(CPPOBJS) $(COBJS)
 STATIC_LIB = lib_main.a
 
 #*****************************************************************************#
@@ -102,21 +101,27 @@ all: CORE_TARGETS
 #*****************************************************************************#
 #                              GENERATE OBJECT FILE                           #
 #*****************************************************************************#
-CORE_TARGETS: $(OBJS) $(STATIC_LIB)
+CORE_TARGETS: $(CPPOBJS) $(COBJS) $(STATIC_LIB)
+
+$(CPPOBJS): %.o: %.cpp
+	$(CC) -ffunction-sections $(CPPFLAGS) $(MODULE_IFLAGS) -c $< -o $@
+	foldername=$$(basename $$(dirname $<)); \
+	mkdir -p $${foldername}; \
+	cp $@ $${foldername}/$(notdir $@)
+
 $(STATIC_LIB):$(OBJS)
-	$(AR) rvs $@ $^
+	$(AR) rvs $@ *.o */*.o
 	$(MOVE) -f $@ $(ROOTDIR)/lib/application
 
 #*****************************************************************************#
 #                              CLEAN GENERATED FILES                          #
 #*****************************************************************************#
 clean:
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/microwaveoven_app_port/*.o
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/microwaveoven_app_port/*.i
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/microwaveoven_app_port/*.s
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/microwaveoven_app_port/*.d
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/microwaveoven_app_port/*.ii
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/microwaveoven_app_port/*.su
+	find $(MATTER_BUILDDIR)/make/chip_main/microwaveoven_app_port/ -mindepth 1 -type d -exec rm -r {} +
+	rm -f $(patsubst %.cpp,%.d,$(CPPSRC:.cpp=.d))
+	rm -f $(patsubst %.cpp,%.su,$(CPPSRC:.cpp=.su))
+	rm -f $(patsubst %.cpp,%.o,$(CPPSRC:.cpp=.o))
+	rm -f *.d *.su *.o
 	rm -f $(MATTER_EXAMPLEDIR)/microwaveoven/microwaveoven-app.matter
 
 -include $(DEPS)

--- a/project/amebad/make/chip_main/ota_requestor_app/Makefile
+++ b/project/amebad/make/chip_main/ota_requestor_app/Makefile
@@ -84,10 +84,9 @@ endif
 #*****************************************************************************#
 #                              OBJECT FILE LIST                               #
 #*****************************************************************************#
-CPPOBJS = $(notdir $(CPPSRC:.cpp=.o))
+CPPOBJS = $(CPPSRC:.cpp=.o)
 COBJS = $(notdir $(CSRC:.c=.o))
-OBJS = $(CPPOBJS)
-OBJS += $(COBJS)
+OBJS = $(CPPOBJS) $(COBJS)
 STATIC_LIB = lib_main.a
 
 #*****************************************************************************#
@@ -103,20 +102,26 @@ all: CORE_TARGETS
 #*****************************************************************************#
 #                              GENERATE OBJECT FILE                           #
 #*****************************************************************************#
-CORE_TARGETS: $(OBJS) $(STATIC_LIB)
+CORE_TARGETS: $(CPPOBJS) $(COBJS) $(STATIC_LIB)
+
+$(CPPOBJS): %.o: %.cpp
+	$(CC) -ffunction-sections $(CPPFLAGS) $(MODULE_IFLAGS) -c $< -o $@
+	foldername=$$(basename $$(dirname $<)); \
+	mkdir -p $${foldername}; \
+	cp $@ $${foldername}/$(notdir $@)
+
 $(STATIC_LIB):$(OBJS)
-	$(AR) rvs $@ $^
+	$(AR) rvs $@ *.o */*.o
 	$(MOVE) -f $@ $(ROOTDIR)/lib/application
 
 #*****************************************************************************#
 #                              CLEAN GENERATED FILES                          #
 #*****************************************************************************#
 clean:
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/ota_requestor_app/*.o
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/ota_requestor_app/*.i
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/ota_requestor_app/*.s
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/ota_requestor_app/*.d
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/ota_requestor_app/*.ii
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/ota_requestor_app/*.su
+	find $(MATTER_BUILDDIR)/make/chip_main/ota_requestor_app/ -mindepth 1 -type d -exec rm -r {} +
+	rm -f $(patsubst %.cpp,%.d,$(CPPSRC:.cpp=.d))
+	rm -f $(patsubst %.cpp,%.su,$(CPPSRC:.cpp=.su))
+	rm -f $(patsubst %.cpp,%.o,$(CPPSRC:.cpp=.o))
+	rm -f *.d *.su *.o
 
 -include $(DEPS)

--- a/project/amebad/make/chip_main/refrigerator_app_port/Makefile
+++ b/project/amebad/make/chip_main/refrigerator_app_port/Makefile
@@ -83,10 +83,9 @@ CPPSRC += $(MATTER_EXAMPLEDIR)/refrigerator/matter_drivers.cpp
 #*****************************************************************************#
 #                              OBJECT FILE LIST                               #
 #*****************************************************************************#
-CPPOBJS = $(notdir $(CPPSRC:.cpp=.o))
+CPPOBJS = $(CPPSRC:.cpp=.o)
 COBJS = $(notdir $(CSRC:.c=.o))
-OBJS = $(CPPOBJS)
-OBJS += $(COBJS)
+OBJS = $(CPPOBJS) $(COBJS)
 STATIC_LIB = lib_main.a
 
 #*****************************************************************************#
@@ -102,21 +101,27 @@ all: CORE_TARGETS
 #*****************************************************************************#
 #                              GENERATE OBJECT FILE                           #
 #*****************************************************************************#
-CORE_TARGETS: $(OBJS) $(STATIC_LIB)
+CORE_TARGETS: $(CPPOBJS) $(COBJS) $(STATIC_LIB)
+
+$(CPPOBJS): %.o: %.cpp
+	$(CC) -ffunction-sections $(CPPFLAGS) $(MODULE_IFLAGS) -c $< -o $@
+	foldername=$$(basename $$(dirname $<)); \
+	mkdir -p $${foldername}; \
+	cp $@ $${foldername}/$(notdir $@)
+
 $(STATIC_LIB):$(OBJS)
-	$(AR) rvs $@ $^
+	$(AR) rvs $@ *.o */*.o
 	$(MOVE) -f $@ $(ROOTDIR)/lib/application
 
 #*****************************************************************************#
 #                              CLEAN GENERATED FILES                          #
 #*****************************************************************************#
 clean:
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/refrigerator_app_port/*.o
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/refrigerator_app_port/*.i
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/refrigerator_app_port/*.s
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/refrigerator_app_port/*.d
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/refrigerator_app_port/*.ii
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/refrigerator_app_port/*.su
+	find $(MATTER_BUILDDIR)/make/chip_main/refrigerator_app_port/ -mindepth 1 -type d -exec rm -r {} +
+	rm -f $(patsubst %.cpp,%.d,$(CPPSRC:.cpp=.d))
+	rm -f $(patsubst %.cpp,%.su,$(CPPSRC:.cpp=.su))
+	rm -f $(patsubst %.cpp,%.o,$(CPPSRC:.cpp=.o))
+	rm -f *.d *.su *.o
 	rm -f $(MATTER_EXAMPLEDIR)/refrigerator/refrigerator-app.matter
 
 -include $(DEPS)

--- a/project/amebad/make/chip_main/temperature_sensor_app_port/Makefile
+++ b/project/amebad/make/chip_main/temperature_sensor_app_port/Makefile
@@ -82,10 +82,9 @@ CPPSRC += $(MATTER_EXAMPLEDIR)/temperature_sensor/matter_drivers.cpp
 #*****************************************************************************#
 #                              OBJECT FILE LIST                               #
 #*****************************************************************************#
-CPPOBJS = $(notdir $(CPPSRC:.cpp=.o))
+CPPOBJS = $(CPPSRC:.cpp=.o)
 COBJS = $(notdir $(CSRC:.c=.o))
-OBJS = $(CPPOBJS)
-OBJS += $(COBJS)
+OBJS = $(CPPOBJS) $(COBJS)
 STATIC_LIB = lib_main.a
 
 #*****************************************************************************#
@@ -101,21 +100,27 @@ all: CORE_TARGETS
 #*****************************************************************************#
 #                              GENERATE OBJECT FILE                           #
 #*****************************************************************************#
-CORE_TARGETS: $(OBJS) $(STATIC_LIB)
+CORE_TARGETS: $(CPPOBJS) $(COBJS) $(STATIC_LIB)
+
+$(CPPOBJS): %.o: %.cpp
+	$(CC) -ffunction-sections $(CPPFLAGS) $(MODULE_IFLAGS) -c $< -o $@
+	foldername=$$(basename $$(dirname $<)); \
+	mkdir -p $${foldername}; \
+	cp $@ $${foldername}/$(notdir $@)
+
 $(STATIC_LIB):$(OBJS)
-	$(AR) rvs $@ $^
+	$(AR) rvs $@ *.o */*.o
 	$(MOVE) -f $@ $(ROOTDIR)/lib/application
 
 #*****************************************************************************#
 #                              CLEAN GENERATED FILES                          #
 #*****************************************************************************#
 clean:
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/temperature_sensor_app_port/*.o
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/temperature_sensor_app_port/*.i
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/temperature_sensor_app_port/*.s
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/temperature_sensor_app_port/*.d
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/temperature_sensor_app_port/*.ii
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/temperature_sensor_app_port/*.su
+	find $(MATTER_BUILDDIR)/make/chip_main/temperature_sensor_app_port/ -mindepth 1 -type d -exec rm -r {} +
+	rm -f $(patsubst %.cpp,%.d,$(CPPSRC:.cpp=.d))
+	rm -f $(patsubst %.cpp,%.su,$(CPPSRC:.cpp=.su))
+	rm -f $(patsubst %.cpp,%.o,$(CPPSRC:.cpp=.o))
+	rm -f *.d *.su *.o
 	rm -f $(MATTER_EXAMPLEDIR)/temperature_sensor/temp-sensor-app.matter
 
 -include $(DEPS)

--- a/project/amebad/make/chip_main/thermostat_app_port/Makefile
+++ b/project/amebad/make/chip_main/thermostat_app_port/Makefile
@@ -86,10 +86,9 @@ CPPSRC += $(MATTER_EXAMPLEDIR)/thermostat/matter_drivers.cpp
 #*****************************************************************************#
 #                              OBJECT FILE LIST                               #
 #*****************************************************************************#
-CPPOBJS = $(notdir $(CPPSRC:.cpp=.o))
+CPPOBJS = $(CPPSRC:.cpp=.o)
 COBJS = $(notdir $(CSRC:.c=.o))
-OBJS = $(CPPOBJS)
-OBJS += $(COBJS)
+OBJS = $(CPPOBJS) $(COBJS)
 STATIC_LIB = lib_main.a
 
 #*****************************************************************************#
@@ -105,20 +104,26 @@ all: CORE_TARGETS
 #*****************************************************************************#
 #                              GENERATE OBJECT FILE                           #
 #*****************************************************************************#
-CORE_TARGETS: $(OBJS) $(STATIC_LIB)
+CORE_TARGETS: $(CPPOBJS) $(COBJS) $(STATIC_LIB)
+
+$(CPPOBJS): %.o: %.cpp
+	$(CC) -ffunction-sections $(CPPFLAGS) $(MODULE_IFLAGS) -c $< -o $@
+	foldername=$$(basename $$(dirname $<)); \
+	mkdir -p $${foldername}; \
+	cp $@ $${foldername}/$(notdir $@)
+
 $(STATIC_LIB):$(OBJS)
-	$(AR) rvs $@ $^
+	$(AR) rvs $@ *.o */*.o
 	$(MOVE) -f $@ $(ROOTDIR)/lib/application
 
 #*****************************************************************************#
 #                              CLEAN GENERATED FILES                          #
 #*****************************************************************************#
 clean:
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/thermostat_app_port/*.o
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/thermostat_app_port/*.i
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/thermostat_app_port/*.s
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/thermostat_app_port/*.d
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/thermostat_app_port/*.ii
-	rm -f $(MATTER_BUILDDIR)/make/chip_main/thermostat_app_port/*.su
+	find $(MATTER_BUILDDIR)/make/chip_main/thermostat_app_port/ -mindepth 1 -type d -exec rm -r {} +
+	rm -f $(patsubst %.cpp,%.d,$(CPPSRC:.cpp=.d))
+	rm -f $(patsubst %.cpp,%.su,$(CPPSRC:.cpp=.su))
+	rm -f $(patsubst %.cpp,%.o,$(CPPSRC:.cpp=.o))
+	rm -f *.d *.su *.o
 
 -include $(DEPS)

--- a/project/amebaz2/make/air_purifier/lib_chip_air_purifier_main.mk
+++ b/project/amebaz2/make/air_purifier/lib_chip_air_purifier_main.mk
@@ -140,7 +140,7 @@ CPPFLAGS += $(CFLAGS)
 
 .PHONY: lib_main
 lib_main: prerequirement $(SRC_O) $(DRAM_O) $(SRC_OO)
-	$(AR) crv $(BIN_DIR)/$(TARGET).a $(OBJ_CPP_LIST) $(OBJ_LIST) $(VER_O)
+	$(AR) crv $(BIN_DIR)/$(TARGET).a $(OBJ_DIR)/*/*.oo $(OBJ_LIST) $(VER_O)
 	cp $(BIN_DIR)/$(TARGET).a $(SDKROOTDIR)/component/soc/realtek/8710c/misc/bsp/lib/common/GCC/$(TARGET).a
 
 # Manipulate Image
@@ -175,11 +175,14 @@ prerequirement:
 
 $(SRC_OO): %_$(TARGET).oo : %.cpp | prerequirement
 	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -o $@
-	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -MM -MT $@ -MF $(OBJ_DIR)/$(notdir $(patsubst %.oo,%.d,$@))
-	cp $@ $(OBJ_DIR)/$(notdir $@)
-	cp $*_$(TARGET).ii $(INFO_DIR)
-	cp $*_$(TARGET).s $(INFO_DIR)
-	chmod 777 $(OBJ_DIR)/$(notdir $@)
+	foldername=$$(basename $$(dirname $<)); \
+	mkdir -p $(OBJ_DIR)/$${foldername}; \
+	mkdir -p $(INFO_DIR)/$${foldername}; \
+	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -MM -MT $@ -MF $(OBJ_DIR)/$${foldername}/$(notdir $(patsubst %.oo,%.d,$@)); \
+	cp $@ $(OBJ_DIR)/$${foldername}/$(notdir $@); \
+	cp $*_$(TARGET).ii $(INFO_DIR)/$${foldername}/$(notdir $@).ii; \
+	cp $*_$(TARGET).s $(INFO_DIR)/$${foldername}/$(notdir $@).s; \
+	chmod 777 $(OBJ_DIR)/$${foldername}/$(notdir $@);
 
 $(SRC_O): %_$(TARGET).o : %.c | prerequirement
 	$(CC) $(CFLAGS) $(INCLUDES) -c $< -o $@

--- a/project/amebaz2/make/aircon/lib_chip_aircon_main.mk
+++ b/project/amebaz2/make/aircon/lib_chip_aircon_main.mk
@@ -140,7 +140,7 @@ CPPFLAGS += $(CFLAGS)
 
 .PHONY: lib_main
 lib_main: prerequirement $(SRC_O) $(DRAM_O) $(SRC_OO)
-	$(AR) crv $(BIN_DIR)/$(TARGET).a $(OBJ_CPP_LIST) $(OBJ_LIST) $(VER_O)
+	$(AR) crv $(BIN_DIR)/$(TARGET).a $(OBJ_DIR)/*/*.oo $(OBJ_LIST) $(VER_O)
 	cp $(BIN_DIR)/$(TARGET).a $(SDKROOTDIR)/component/soc/realtek/8710c/misc/bsp/lib/common/GCC/$(TARGET).a
 
 # Manipulate Image
@@ -175,11 +175,14 @@ prerequirement:
 
 $(SRC_OO): %_$(TARGET).oo : %.cpp | prerequirement
 	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -o $@
-	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -MM -MT $@ -MF $(OBJ_DIR)/$(notdir $(patsubst %.oo,%.d,$@))
-	mv $@ $(OBJ_DIR)/$(notdir $@)
-	mv $*_$(TARGET).ii $(INFO_DIR)
-	mv $*_$(TARGET).s $(INFO_DIR)
-	chmod 777 $(OBJ_DIR)/$(notdir $@)
+	foldername=$$(basename $$(dirname $<)); \
+	mkdir -p $(OBJ_DIR)/$${foldername}; \
+	mkdir -p $(INFO_DIR)/$${foldername}; \
+	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -MM -MT $@ -MF $(OBJ_DIR)/$${foldername}/$(notdir $(patsubst %.oo,%.d,$@)); \
+	cp $@ $(OBJ_DIR)/$${foldername}/$(notdir $@); \
+	cp $*_$(TARGET).ii $(INFO_DIR)/$${foldername}/$(notdir $@).ii; \
+	cp $*_$(TARGET).s $(INFO_DIR)/$${foldername}/$(notdir $@).s; \
+	chmod 777 $(OBJ_DIR)/$${foldername}/$(notdir $@);
 
 $(SRC_O): %_$(TARGET).o : %.c | prerequirement
 	$(CC) $(CFLAGS) $(INCLUDES) -c $< -o $@

--- a/project/amebaz2/make/all_clusters/lib_chip_main.mk
+++ b/project/amebaz2/make/all_clusters/lib_chip_main.mk
@@ -199,7 +199,7 @@ CPPFLAGS += $(CFLAGS)
 
 .PHONY: lib_main
 lib_main: prerequirement $(SRC_O) $(DRAM_O) $(SRC_OO)
-	$(AR) crv $(BIN_DIR)/$(TARGET).a $(OBJ_CPP_LIST) $(OBJ_LIST) $(VER_O)
+	$(AR) crv $(BIN_DIR)/$(TARGET).a $(OBJ_DIR)/*/*.oo $(OBJ_LIST) $(VER_O)
 	cp $(BIN_DIR)/$(TARGET).a $(SDKROOTDIR)/component/soc/realtek/8710c/misc/bsp/lib/common/GCC/$(TARGET).a
 
 # Manipulate Image
@@ -234,11 +234,14 @@ prerequirement:
 
 $(SRC_OO): %_$(TARGET).oo : %.cpp | prerequirement
 	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -o $@
-	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -MM -MT $@ -MF $(OBJ_DIR)/$(notdir $(patsubst %.oo,%.d,$@))
-	cp $@ $(OBJ_DIR)/$(notdir $@)
-	cp $*_$(TARGET).ii $(INFO_DIR)
-	cp $*_$(TARGET).s $(INFO_DIR)
-	chmod 777 $(OBJ_DIR)/$(notdir $@)
+	foldername=$$(basename $$(dirname $<)); \
+	mkdir -p $(OBJ_DIR)/$${foldername}; \
+	mkdir -p $(INFO_DIR)/$${foldername}; \
+	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -MM -MT $@ -MF $(OBJ_DIR)/$${foldername}/$(notdir $(patsubst %.oo,%.d,$@)); \
+	cp $@ $(OBJ_DIR)/$${foldername}/$(notdir $@); \
+	cp $*_$(TARGET).ii $(INFO_DIR)/$${foldername}/$(notdir $@).ii; \
+	cp $*_$(TARGET).s $(INFO_DIR)/$${foldername}/$(notdir $@).s; \
+	chmod 777 $(OBJ_DIR)/$${foldername}/$(notdir $@);
 
 $(SRC_O): %_$(TARGET).o : %.c | prerequirement
 	$(CC) $(CFLAGS) $(INCLUDES) -c $< -o $@

--- a/project/amebaz2/make/bridge_dm/lib_chip_bridge_main.mk
+++ b/project/amebaz2/make/bridge_dm/lib_chip_bridge_main.mk
@@ -143,7 +143,7 @@ CPPFLAGS += $(CFLAGS)
 
 .PHONY: lib_main
 lib_main: prerequirement $(SRC_O) $(DRAM_O) $(SRC_OO)
-	$(AR) crv $(BIN_DIR)/$(TARGET).a $(OBJ_CPP_LIST) $(OBJ_LIST) $(VER_O)
+	$(AR) crv $(BIN_DIR)/$(TARGET).a $(OBJ_DIR)/*/*.oo $(OBJ_LIST) $(VER_O)
 	cp $(BIN_DIR)/$(TARGET).a $(SDKROOTDIR)/component/soc/realtek/8710c/misc/bsp/lib/common/GCC/$(TARGET).a
 
 # Manipulate Image
@@ -178,9 +178,12 @@ prerequirement:
 
 $(SRC_OO): %_$(TARGET).oo : %.cpp | prerequirement
 	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -o $@
-	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -MM -MT $@ -MF $(OBJ_DIR)/$(notdir $(patsubst %.oo,%.d,$@))
-	cp $@ $(OBJ_DIR)/$(notdir $@)
-	chmod 777 $(OBJ_DIR)/$(notdir $@)
+	foldername=$$(basename $$(dirname $<)); \
+	mkdir -p $(OBJ_DIR)/$${foldername}; \
+	mkdir -p $(INFO_DIR)/$${foldername}; \
+	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -MM -MT $@ -MF $(OBJ_DIR)/$${foldername}/$(notdir $(patsubst %.oo,%.d,$@)); \
+	cp $@ $(OBJ_DIR)/$${foldername}/$(notdir $@); \
+	chmod 777 $(OBJ_DIR)/$${foldername}/$(notdir $@);
 
 $(SRC_O): %_$(TARGET).o : %.c | prerequirement
 	$(CC) $(CFLAGS) $(INCLUDES) -c $< -o $@

--- a/project/amebaz2/make/chef/lib_chip_chef_main.mk
+++ b/project/amebaz2/make/chef/lib_chip_chef_main.mk
@@ -138,7 +138,7 @@ CPPFLAGS += $(CFLAGS)
 
 .PHONY: lib_main
 lib_main: prerequirement $(SRC_O) $(DRAM_O) $(SRC_OO)
-	$(AR) crv $(BIN_DIR)/$(TARGET).a $(OBJ_CPP_LIST) $(OBJ_LIST) $(VER_O)
+	$(AR) crv $(BIN_DIR)/$(TARGET).a $(OBJ_DIR)/*/*.oo $(OBJ_LIST) $(VER_O)
 	cp $(BIN_DIR)/$(TARGET).a $(SDKROOTDIR)/component/soc/realtek/8710c/misc/bsp/lib/common/GCC/$(TARGET).a
 
 # Manipulate Image
@@ -173,11 +173,14 @@ prerequirement:
 
 $(SRC_OO): %_$(TARGET).oo : %.cpp | prerequirement
 	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -o $@
-	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -MM -MT $@ -MF $(OBJ_DIR)/$(notdir $(patsubst %.oo,%.d,$@))
-	cp $@ $(OBJ_DIR)/$(notdir $@)
-	cp $*_$(TARGET).ii $(INFO_DIR)
-	cp $*_$(TARGET).s $(INFO_DIR)
-	chmod 777 $(OBJ_DIR)/$(notdir $@)
+	foldername=$$(basename $$(dirname $<)); \
+	mkdir -p $(OBJ_DIR)/$${foldername}; \
+	mkdir -p $(INFO_DIR)/$${foldername}; \
+	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -MM -MT $@ -MF $(OBJ_DIR)/$${foldername}/$(notdir $(patsubst %.oo,%.d,$@)); \
+	cp $@ $(OBJ_DIR)/$${foldername}/$(notdir $@); \
+	cp $*_$(TARGET).ii $(INFO_DIR)/$${foldername}/$(notdir $@).ii; \
+	cp $*_$(TARGET).s $(INFO_DIR)/$${foldername}/$(notdir $@).s; \
+	chmod 777 $(OBJ_DIR)/$${foldername}/$(notdir $@);
 
 $(SRC_O): %_$(TARGET).o : %.c | prerequirement
 	$(CC) $(CFLAGS) $(INCLUDES) -c $< -o $@

--- a/project/amebaz2/make/dishwasher/lib_chip_dishwasher_main.mk
+++ b/project/amebaz2/make/dishwasher/lib_chip_dishwasher_main.mk
@@ -142,7 +142,7 @@ CPPFLAGS += $(CFLAGS)
 
 .PHONY: lib_main
 lib_main: prerequirement $(SRC_O) $(DRAM_O) $(SRC_OO)
-	$(AR) crv $(BIN_DIR)/$(TARGET).a $(OBJ_CPP_LIST) $(OBJ_LIST) $(VER_O)
+	$(AR) crv $(BIN_DIR)/$(TARGET).a $(OBJ_DIR)/*/*.oo $(OBJ_LIST) $(VER_O)
 	cp $(BIN_DIR)/$(TARGET).a $(SDKROOTDIR)/component/soc/realtek/8710c/misc/bsp/lib/common/GCC/$(TARGET).a
 
 # Manipulate Image
@@ -177,11 +177,14 @@ prerequirement:
 
 $(SRC_OO): %_$(TARGET).oo : %.cpp | prerequirement
 	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -o $@
-	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -MM -MT $@ -MF $(OBJ_DIR)/$(notdir $(patsubst %.oo,%.d,$@))
-	cp $@ $(OBJ_DIR)/$(notdir $@)
-	cp $*_$(TARGET).ii $(INFO_DIR)
-	cp $*_$(TARGET).s $(INFO_DIR)
-	chmod 777 $(OBJ_DIR)/$(notdir $@)
+	foldername=$$(basename $$(dirname $<)); \
+	mkdir -p $(OBJ_DIR)/$${foldername}; \
+	mkdir -p $(INFO_DIR)/$${foldername}; \
+	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -MM -MT $@ -MF $(OBJ_DIR)/$${foldername}/$(notdir $(patsubst %.oo,%.d,$@)); \
+	cp $@ $(OBJ_DIR)/$${foldername}/$(notdir $@); \
+	cp $*_$(TARGET).ii $(INFO_DIR)/$${foldername}/$(notdir $@).ii; \
+	cp $*_$(TARGET).s $(INFO_DIR)/$${foldername}/$(notdir $@).s; \
+	chmod 777 $(OBJ_DIR)/$${foldername}/$(notdir $@);
 
 $(SRC_O): %_$(TARGET).o : %.c | prerequirement
 	$(CC) $(CFLAGS) $(INCLUDES) -c $< -o $@

--- a/project/amebaz2/make/fan/lib_chip_fan_main.mk
+++ b/project/amebaz2/make/fan/lib_chip_fan_main.mk
@@ -139,7 +139,7 @@ CPPFLAGS += $(CFLAGS)
 
 .PHONY: lib_main
 lib_main: prerequirement $(SRC_O) $(DRAM_O) $(SRC_OO)
-	$(AR) crv $(BIN_DIR)/$(TARGET).a $(OBJ_CPP_LIST) $(OBJ_LIST) $(VER_O)
+	$(AR) crv $(BIN_DIR)/$(TARGET).a $(OBJ_DIR)/*/*.oo $(OBJ_LIST) $(VER_O)
 	cp $(BIN_DIR)/$(TARGET).a $(SDKROOTDIR)/component/soc/realtek/8710c/misc/bsp/lib/common/GCC/$(TARGET).a
 
 # Manipulate Image
@@ -174,11 +174,14 @@ prerequirement:
 
 $(SRC_OO): %_$(TARGET).oo : %.cpp | prerequirement
 	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -o $@
-	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -MM -MT $@ -MF $(OBJ_DIR)/$(notdir $(patsubst %.oo,%.d,$@))
-	cp $@ $(OBJ_DIR)/$(notdir $@)
-	cp $*_$(TARGET).ii $(INFO_DIR)
-	cp $*_$(TARGET).s $(INFO_DIR)
-	chmod 777 $(OBJ_DIR)/$(notdir $@)
+	foldername=$$(basename $$(dirname $<)); \
+	mkdir -p $(OBJ_DIR)/$${foldername}; \
+	mkdir -p $(INFO_DIR)/$${foldername}; \
+	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -MM -MT $@ -MF $(OBJ_DIR)/$${foldername}/$(notdir $(patsubst %.oo,%.d,$@)); \
+	cp $@ $(OBJ_DIR)/$${foldername}/$(notdir $@); \
+	cp $*_$(TARGET).ii $(INFO_DIR)/$${foldername}/$(notdir $@).ii; \
+	cp $*_$(TARGET).s $(INFO_DIR)/$${foldername}/$(notdir $@).s; \
+	chmod 777 $(OBJ_DIR)/$${foldername}/$(notdir $@);
 
 $(SRC_O): %_$(TARGET).o : %.c | prerequirement
 	$(CC) $(CFLAGS) $(INCLUDES) -c $< -o $@

--- a/project/amebaz2/make/generic_switch/lib_chip_generic_switch_main.mk
+++ b/project/amebaz2/make/generic_switch/lib_chip_generic_switch_main.mk
@@ -140,7 +140,7 @@ CPPFLAGS += $(CFLAGS)
 
 .PHONY: lib_main
 lib_main: prerequirement $(SRC_O) $(DRAM_O) $(SRC_OO)
-	$(AR) crv $(BIN_DIR)/$(TARGET).a $(OBJ_CPP_LIST) $(OBJ_LIST) $(VER_O)
+	$(AR) crv $(BIN_DIR)/$(TARGET).a $(OBJ_DIR)/*/*.oo $(OBJ_LIST) $(VER_O)
 	cp $(BIN_DIR)/$(TARGET).a $(SDKROOTDIR)/component/soc/realtek/8710c/misc/bsp/lib/common/GCC/$(TARGET).a
 
 # Manipulate Image
@@ -175,11 +175,14 @@ prerequirement:
 
 $(SRC_OO): %_$(TARGET).oo : %.cpp | prerequirement
 	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -o $@
-	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -MM -MT $@ -MF $(OBJ_DIR)/$(notdir $(patsubst %.oo,%.d,$@))
-	cp $@ $(OBJ_DIR)/$(notdir $@)
-	cp $*_$(TARGET).ii $(INFO_DIR)
-	cp $*_$(TARGET).s $(INFO_DIR)
-	chmod 777 $(OBJ_DIR)/$(notdir $@)
+	foldername=$$(basename $$(dirname $<)); \
+	mkdir -p $(OBJ_DIR)/$${foldername}; \
+	mkdir -p $(INFO_DIR)/$${foldername}; \
+	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -MM -MT $@ -MF $(OBJ_DIR)/$${foldername}/$(notdir $(patsubst %.oo,%.d,$@)); \
+	cp $@ $(OBJ_DIR)/$${foldername}/$(notdir $@); \
+	cp $*_$(TARGET).ii $(INFO_DIR)/$${foldername}/$(notdir $@).ii; \
+	cp $*_$(TARGET).s $(INFO_DIR)/$${foldername}/$(notdir $@).s; \
+	chmod 777 $(OBJ_DIR)/$${foldername}/$(notdir $@);
 
 $(SRC_O): %_$(TARGET).o : %.c | prerequirement
 	$(CC) $(CFLAGS) $(INCLUDES) -c $< -o $@

--- a/project/amebaz2/make/laundrywasher/lib_chip_laundrywasher_main.mk
+++ b/project/amebaz2/make/laundrywasher/lib_chip_laundrywasher_main.mk
@@ -143,7 +143,7 @@ CPPFLAGS += $(CFLAGS)
 
 .PHONY: lib_main
 lib_main: prerequirement $(SRC_O) $(DRAM_O) $(SRC_OO)
-	$(AR) crv $(BIN_DIR)/$(TARGET).a $(OBJ_CPP_LIST) $(OBJ_LIST) $(VER_O)
+	$(AR) crv $(BIN_DIR)/$(TARGET).a $(OBJ_DIR)/*/*.oo $(OBJ_LIST) $(VER_O)
 	cp $(BIN_DIR)/$(TARGET).a $(SDKROOTDIR)/component/soc/realtek/8710c/misc/bsp/lib/common/GCC/$(TARGET).a
 
 # Manipulate Image
@@ -178,11 +178,14 @@ prerequirement:
 
 $(SRC_OO): %_$(TARGET).oo : %.cpp | prerequirement
 	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -o $@
-	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -MM -MT $@ -MF $(OBJ_DIR)/$(notdir $(patsubst %.oo,%.d,$@))
-	cp $@ $(OBJ_DIR)/$(notdir $@)
-	cp $*_$(TARGET).ii $(INFO_DIR)
-	cp $*_$(TARGET).s $(INFO_DIR)
-	chmod 777 $(OBJ_DIR)/$(notdir $@)
+	foldername=$$(basename $$(dirname $<)); \
+	mkdir -p $(OBJ_DIR)/$${foldername}; \
+	mkdir -p $(INFO_DIR)/$${foldername}; \
+	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -MM -MT $@ -MF $(OBJ_DIR)/$${foldername}/$(notdir $(patsubst %.oo,%.d,$@)); \
+	cp $@ $(OBJ_DIR)/$${foldername}/$(notdir $@); \
+	cp $*_$(TARGET).ii $(INFO_DIR)/$${foldername}/$(notdir $@).ii; \
+	cp $*_$(TARGET).s $(INFO_DIR)/$${foldername}/$(notdir $@).s; \
+	chmod 777 $(OBJ_DIR)/$${foldername}/$(notdir $@);
 
 $(SRC_O): %_$(TARGET).o : %.c | prerequirement
 	$(CC) $(CFLAGS) $(INCLUDES) -c $< -o $@

--- a/project/amebaz2/make/light_dm/lib_chip_light_main.mk
+++ b/project/amebaz2/make/light_dm/lib_chip_light_main.mk
@@ -144,7 +144,7 @@ CPPFLAGS += $(CFLAGS)
 
 .PHONY: lib_main
 lib_main: prerequirement $(SRC_O) $(DRAM_O) $(SRC_OO)
-	$(AR) crv $(BIN_DIR)/$(TARGET).a $(OBJ_CPP_LIST) $(OBJ_LIST) $(VER_O)
+	$(AR) crv $(BIN_DIR)/$(TARGET).a $(OBJ_DIR)/*/*.oo $(OBJ_LIST) $(VER_O)
 	cp $(BIN_DIR)/$(TARGET).a $(SDKROOTDIR)/component/soc/realtek/8710c/misc/bsp/lib/common/GCC/$(TARGET).a
 
 # Manipulate Image
@@ -179,9 +179,12 @@ prerequirement:
 
 $(SRC_OO): %_$(TARGET).oo : %.cpp | prerequirement
 	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -o $@
-	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -MM -MT $@ -MF $(OBJ_DIR)/$(notdir $(patsubst %.oo,%.d,$@))
-	cp $@ $(OBJ_DIR)/$(notdir $@)
-	chmod 777 $(OBJ_DIR)/$(notdir $@)
+	foldername=$$(basename $$(dirname $<)); \
+	mkdir -p $(OBJ_DIR)/$${foldername}; \
+	mkdir -p $(INFO_DIR)/$${foldername}; \
+	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -MM -MT $@ -MF $(OBJ_DIR)/$${foldername}/$(notdir $(patsubst %.oo,%.d,$@)); \
+	cp $@ $(OBJ_DIR)/$${foldername}/$(notdir $@); \
+	chmod 777 $(OBJ_DIR)/$${foldername}/$(notdir $@);
 
 $(SRC_O): %_$(TARGET).o : %.c | prerequirement
 	$(CC) $(CFLAGS) $(INCLUDES) -c $< -o $@

--- a/project/amebaz2/make/light_port/lib_chip_light_main.mk
+++ b/project/amebaz2/make/light_port/lib_chip_light_main.mk
@@ -141,7 +141,7 @@ CPPFLAGS += $(CFLAGS)
 
 .PHONY: lib_main
 lib_main: prerequirement $(SRC_O) $(DRAM_O) $(SRC_OO)
-	$(AR) crv $(BIN_DIR)/$(TARGET).a $(OBJ_CPP_LIST) $(OBJ_LIST) $(VER_O)
+	$(AR) crv $(BIN_DIR)/$(TARGET).a $(OBJ_DIR)/*/*.oo $(OBJ_LIST) $(VER_O)
 	cp $(BIN_DIR)/$(TARGET).a $(SDKROOTDIR)/component/soc/realtek/8710c/misc/bsp/lib/common/GCC/$(TARGET).a
 
 # Manipulate Image
@@ -176,11 +176,14 @@ prerequirement:
 
 $(SRC_OO): %_$(TARGET).oo : %.cpp | prerequirement
 	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -o $@
-	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -MM -MT $@ -MF $(OBJ_DIR)/$(notdir $(patsubst %.oo,%.d,$@))
-	cp $@ $(OBJ_DIR)/$(notdir $@)
-	cp $*_$(TARGET).ii $(INFO_DIR)
-	cp $*_$(TARGET).s $(INFO_DIR)
-	chmod 777 $(OBJ_DIR)/$(notdir $@)
+	foldername=$$(basename $$(dirname $<)); \
+	mkdir -p $(OBJ_DIR)/$${foldername}; \
+	mkdir -p $(INFO_DIR)/$${foldername}; \
+	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -MM -MT $@ -MF $(OBJ_DIR)/$${foldername}/$(notdir $(patsubst %.oo,%.d,$@)); \
+	cp $@ $(OBJ_DIR)/$${foldername}/$(notdir $@); \
+	cp $*_$(TARGET).ii $(INFO_DIR)/$${foldername}/$(notdir $@).ii; \
+	cp $*_$(TARGET).s $(INFO_DIR)/$${foldername}/$(notdir $@).s; \
+	chmod 777 $(OBJ_DIR)/$${foldername}/$(notdir $@);
 
 $(SRC_O): %_$(TARGET).o : %.c | prerequirement
 	$(CC) $(CFLAGS) $(INCLUDES) -c $< -o $@

--- a/project/amebaz2/make/light_switch/lib_chip_light_switch_main.mk
+++ b/project/amebaz2/make/light_switch/lib_chip_light_switch_main.mk
@@ -144,7 +144,7 @@ CPPFLAGS += $(CFLAGS)
 
 .PHONY: lib_main
 lib_main: prerequirement $(SRC_O) $(DRAM_O) $(SRC_OO)
-	$(AR) crv $(BIN_DIR)/$(TARGET).a $(OBJ_CPP_LIST) $(OBJ_LIST) $(VER_O)
+	$(AR) crv $(BIN_DIR)/$(TARGET).a $(OBJ_DIR)/*/*.oo $(OBJ_LIST) $(VER_O)
 	cp $(BIN_DIR)/$(TARGET).a $(SDKROOTDIR)/component/soc/realtek/8710c/misc/bsp/lib/common/GCC/$(TARGET).a
 
 # Manipulate Image
@@ -179,11 +179,14 @@ prerequirement:
 
 $(SRC_OO): %_$(TARGET).oo : %.cpp | prerequirement
 	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -o $@
-	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -MM -MT $@ -MF $(OBJ_DIR)/$(notdir $(patsubst %.oo,%.d,$@))
-	cp $@ $(OBJ_DIR)/$(notdir $@)
-	cp $*_$(TARGET).ii $(INFO_DIR)
-	cp $*_$(TARGET).s $(INFO_DIR)
-	chmod 777 $(OBJ_DIR)/$(notdir $@)
+	foldername=$$(basename $$(dirname $<)); \
+	mkdir -p $(OBJ_DIR)/$${foldername}; \
+	mkdir -p $(INFO_DIR)/$${foldername}; \
+	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -MM -MT $@ -MF $(OBJ_DIR)/$${foldername}/$(notdir $(patsubst %.oo,%.d,$@)); \
+	cp $@ $(OBJ_DIR)/$${foldername}/$(notdir $@); \
+	cp $*_$(TARGET).ii $(INFO_DIR)/$${foldername}/$(notdir $@).ii; \
+	cp $*_$(TARGET).s $(INFO_DIR)/$${foldername}/$(notdir $@).s; \
+	chmod 777 $(OBJ_DIR)/$${foldername}/$(notdir $@);
 
 $(SRC_O): %_$(TARGET).o : %.c | prerequirement
 	$(CC) $(CFLAGS) $(INCLUDES) -c $< -o $@

--- a/project/amebaz2/make/microwaveoven/lib_chip_microwaveoven_main.mk
+++ b/project/amebaz2/make/microwaveoven/lib_chip_microwaveoven_main.mk
@@ -144,7 +144,7 @@ CPPFLAGS += $(CFLAGS)
 
 .PHONY: lib_main
 lib_main: prerequirement $(SRC_O) $(DRAM_O) $(SRC_OO)
-	$(AR) crv $(BIN_DIR)/$(TARGET).a $(OBJ_CPP_LIST) $(OBJ_LIST) $(VER_O)
+	$(AR) crv $(BIN_DIR)/$(TARGET).a $(OBJ_DIR)/*/*.oo $(OBJ_LIST) $(VER_O)
 	cp $(BIN_DIR)/$(TARGET).a $(SDKROOTDIR)/component/soc/realtek/8710c/misc/bsp/lib/common/GCC/$(TARGET).a
 
 # Manipulate Image
@@ -179,11 +179,14 @@ prerequirement:
 
 $(SRC_OO): %_$(TARGET).oo : %.cpp | prerequirement
 	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -o $@
-	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -MM -MT $@ -MF $(OBJ_DIR)/$(notdir $(patsubst %.oo,%.d,$@))
-	cp $@ $(OBJ_DIR)/$(notdir $@)
-	cp $*_$(TARGET).ii $(INFO_DIR)
-	cp $*_$(TARGET).s $(INFO_DIR)
-	chmod 777 $(OBJ_DIR)/$(notdir $@)
+	foldername=$$(basename $$(dirname $<)); \
+	mkdir -p $(OBJ_DIR)/$${foldername}; \
+	mkdir -p $(INFO_DIR)/$${foldername}; \
+	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -MM -MT $@ -MF $(OBJ_DIR)/$${foldername}/$(notdir $(patsubst %.oo,%.d,$@)); \
+	cp $@ $(OBJ_DIR)/$${foldername}/$(notdir $@); \
+	cp $*_$(TARGET).ii $(INFO_DIR)/$${foldername}/$(notdir $@).ii; \
+	cp $*_$(TARGET).s $(INFO_DIR)/$${foldername}/$(notdir $@).s; \
+	chmod 777 $(OBJ_DIR)/$${foldername}/$(notdir $@);
 
 $(SRC_O): %_$(TARGET).o : %.c | prerequirement
 	$(CC) $(CFLAGS) $(INCLUDES) -c $< -o $@

--- a/project/amebaz2/make/otar/lib_chip_otar_main.mk
+++ b/project/amebaz2/make/otar/lib_chip_otar_main.mk
@@ -134,7 +134,7 @@ CPPFLAGS += $(CFLAGS)
 
 .PHONY: lib_main
 lib_main: prerequirement $(SRC_O) $(DRAM_O) $(SRC_OO)
-	$(AR) crv $(BIN_DIR)/$(TARGET).a $(OBJ_CPP_LIST) $(OBJ_LIST) $(VER_O)
+	$(AR) crv $(BIN_DIR)/$(TARGET).a $(OBJ_DIR)/*/*.oo $(OBJ_LIST) $(VER_O)
 	cp $(BIN_DIR)/$(TARGET).a $(SDKROOTDIR)/component/soc/realtek/8710c/misc/bsp/lib/common/GCC/$(TARGET).a
 
 # Manipulate Image
@@ -169,11 +169,14 @@ prerequirement:
 
 $(SRC_OO): %_$(TARGET).oo : %.cpp | prerequirement
 	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -o $@
-	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -MM -MT $@ -MF $(OBJ_DIR)/$(notdir $(patsubst %.oo,%.d,$@))
-	cp $@ $(OBJ_DIR)/$(notdir $@)
-	cp $*_$(TARGET).ii $(INFO_DIR)
-	cp $*_$(TARGET).s $(INFO_DIR)
-	chmod 777 $(OBJ_DIR)/$(notdir $@)
+	foldername=$$(basename $$(dirname $<)); \
+	mkdir -p $(OBJ_DIR)/$${foldername}; \
+	mkdir -p $(INFO_DIR)/$${foldername}; \
+	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -MM -MT $@ -MF $(OBJ_DIR)/$${foldername}/$(notdir $(patsubst %.oo,%.d,$@)); \
+	cp $@ $(OBJ_DIR)/$${foldername}/$(notdir $@); \
+	cp $*_$(TARGET).ii $(INFO_DIR)/$${foldername}/$(notdir $@).ii; \
+	cp $*_$(TARGET).s $(INFO_DIR)/$${foldername}/$(notdir $@).s; \
+	chmod 777 $(OBJ_DIR)/$${foldername}/$(notdir $@);
 
 $(SRC_O): %_$(TARGET).o : %.c | prerequirement
 	$(CC) $(CFLAGS) $(INCLUDES) -c $< -o $@

--- a/project/amebaz2/make/refrigerator/lib_chip_refrigerator_main.mk
+++ b/project/amebaz2/make/refrigerator/lib_chip_refrigerator_main.mk
@@ -141,7 +141,7 @@ CPPFLAGS += $(CFLAGS)
 
 .PHONY: lib_main
 lib_main: prerequirement $(SRC_O) $(DRAM_O) $(SRC_OO)
-	$(AR) crv $(BIN_DIR)/$(TARGET).a $(OBJ_CPP_LIST) $(OBJ_LIST) $(VER_O)
+	$(AR) crv $(BIN_DIR)/$(TARGET).a $(OBJ_DIR)/*/*.oo $(OBJ_LIST) $(VER_O)
 	cp $(BIN_DIR)/$(TARGET).a $(SDKROOTDIR)/component/soc/realtek/8710c/misc/bsp/lib/common/GCC/$(TARGET).a
 
 # Manipulate Image
@@ -176,11 +176,14 @@ prerequirement:
 
 $(SRC_OO): %_$(TARGET).oo : %.cpp | prerequirement
 	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -o $@
-	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -MM -MT $@ -MF $(OBJ_DIR)/$(notdir $(patsubst %.oo,%.d,$@))
-	cp $@ $(OBJ_DIR)/$(notdir $@)
-	cp $*_$(TARGET).ii $(INFO_DIR)
-	cp $*_$(TARGET).s $(INFO_DIR)
-	chmod 777 $(OBJ_DIR)/$(notdir $@)
+	foldername=$$(basename $$(dirname $<)); \
+	mkdir -p $(OBJ_DIR)/$${foldername}; \
+	mkdir -p $(INFO_DIR)/$${foldername}; \
+	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -MM -MT $@ -MF $(OBJ_DIR)/$${foldername}/$(notdir $(patsubst %.oo,%.d,$@)); \
+	cp $@ $(OBJ_DIR)/$${foldername}/$(notdir $@); \
+	cp $*_$(TARGET).ii $(INFO_DIR)/$${foldername}/$(notdir $@).ii; \
+	cp $*_$(TARGET).s $(INFO_DIR)/$${foldername}/$(notdir $@).s; \
+	chmod 777 $(OBJ_DIR)/$${foldername}/$(notdir $@);
 
 $(SRC_O): %_$(TARGET).o : %.c | prerequirement
 	$(CC) $(CFLAGS) $(INCLUDES) -c $< -o $@

--- a/project/amebaz2/make/temperature_sensor/lib_chip_temp_sensor_main.mk
+++ b/project/amebaz2/make/temperature_sensor/lib_chip_temp_sensor_main.mk
@@ -138,7 +138,7 @@ CPPFLAGS += $(CFLAGS)
 
 .PHONY: lib_main
 lib_main: prerequirement $(SRC_O) $(DRAM_O) $(SRC_OO)
-	$(AR) crv $(BIN_DIR)/$(TARGET).a $(OBJ_CPP_LIST) $(OBJ_LIST) $(VER_O)
+	$(AR) crv $(BIN_DIR)/$(TARGET).a $(OBJ_DIR)/*/*.oo $(OBJ_LIST) $(VER_O)
 	cp $(BIN_DIR)/$(TARGET).a $(SDKROOTDIR)/component/soc/realtek/8710c/misc/bsp/lib/common/GCC/$(TARGET).a
 
 # Manipulate Image
@@ -173,11 +173,14 @@ prerequirement:
 
 $(SRC_OO): %_$(TARGET).oo : %.cpp | prerequirement
 	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -o $@
-	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -MM -MT $@ -MF $(OBJ_DIR)/$(notdir $(patsubst %.oo,%.d,$@))
-	cp $@ $(OBJ_DIR)/$(notdir $@)
-	cp $*_$(TARGET).ii $(INFO_DIR)
-	cp $*_$(TARGET).s $(INFO_DIR)
-	chmod 777 $(OBJ_DIR)/$(notdir $@)
+	foldername=$$(basename $$(dirname $<)); \
+	mkdir -p $(OBJ_DIR)/$${foldername}; \
+	mkdir -p $(INFO_DIR)/$${foldername}; \
+	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -MM -MT $@ -MF $(OBJ_DIR)/$${foldername}/$(notdir $(patsubst %.oo,%.d,$@)); \
+	cp $@ $(OBJ_DIR)/$${foldername}/$(notdir $@); \
+	cp $*_$(TARGET).ii $(INFO_DIR)/$${foldername}/$(notdir $@).ii; \
+	cp $*_$(TARGET).s $(INFO_DIR)/$${foldername}/$(notdir $@).s; \
+	chmod 777 $(OBJ_DIR)/$${foldername}/$(notdir $@);
 
 $(SRC_O): %_$(TARGET).o : %.c | prerequirement
 	$(CC) $(CFLAGS) $(INCLUDES) -c $< -o $@

--- a/project/amebaz2/make/thermostat/lib_chip_thermostat_main.mk
+++ b/project/amebaz2/make/thermostat/lib_chip_thermostat_main.mk
@@ -142,7 +142,7 @@ CPPFLAGS += $(CFLAGS)
 
 .PHONY: lib_main
 lib_main: prerequirement $(SRC_O) $(DRAM_O) $(SRC_OO)
-	$(AR) crv $(BIN_DIR)/$(TARGET).a $(OBJ_CPP_LIST) $(OBJ_LIST) $(VER_O)
+	$(AR) crv $(BIN_DIR)/$(TARGET).a $(OBJ_DIR)/*/*.oo $(OBJ_LIST) $(VER_O)
 	cp $(BIN_DIR)/$(TARGET).a $(SDKROOTDIR)/component/soc/realtek/8710c/misc/bsp/lib/common/GCC/$(TARGET).a
 
 # Manipulate Image
@@ -177,11 +177,14 @@ prerequirement:
 
 $(SRC_OO): %_$(TARGET).oo : %.cpp | prerequirement
 	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -o $@
-	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -MM -MT $@ -MF $(OBJ_DIR)/$(notdir $(patsubst %.oo,%.d,$@))
-	cp $@ $(OBJ_DIR)/$(notdir $@)
-	cp $*_$(TARGET).ii $(INFO_DIR)
-	cp $*_$(TARGET).s $(INFO_DIR)
-	chmod 777 $(OBJ_DIR)/$(notdir $@)
+	foldername=$$(basename $$(dirname $<)); \
+	mkdir -p $(OBJ_DIR)/$${foldername}; \
+	mkdir -p $(INFO_DIR)/$${foldername}; \
+	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -MM -MT $@ -MF $(OBJ_DIR)/$${foldername}/$(notdir $(patsubst %.oo,%.d,$@)); \
+	cp $@ $(OBJ_DIR)/$${foldername}/$(notdir $@); \
+	cp $*_$(TARGET).ii $(INFO_DIR)/$${foldername}/$(notdir $@).ii; \
+	cp $*_$(TARGET).s $(INFO_DIR)/$${foldername}/$(notdir $@).s; \
+	chmod 777 $(OBJ_DIR)/$${foldername}/$(notdir $@);
 
 $(SRC_O): %_$(TARGET).o : %.c | prerequirement
 	$(CC) $(CFLAGS) $(INCLUDES) -c $< -o $@

--- a/project/amebaz2plus/make/air_purifier/lib_chip_air_purifier_main.mk
+++ b/project/amebaz2plus/make/air_purifier/lib_chip_air_purifier_main.mk
@@ -140,7 +140,7 @@ CPPFLAGS += $(CFLAGS)
 
 .PHONY: lib_main
 lib_main: prerequirement $(SRC_O) $(DRAM_O) $(SRC_OO)
-	$(AR) crv $(BIN_DIR)/$(TARGET).a $(OBJ_CPP_LIST) $(OBJ_LIST) $(VER_O)
+	$(AR) crv $(BIN_DIR)/$(TARGET).a $(OBJ_DIR)/*/*.oo $(OBJ_LIST) $(VER_O)
 	cp $(BIN_DIR)/$(TARGET).a $(SDKROOTDIR)/component/soc/realtek/8710c/misc/bsp/lib/common/GCC/$(TARGET).a
 
 # Manipulate Image
@@ -175,11 +175,14 @@ prerequirement:
 
 $(SRC_OO): %_$(TARGET).oo : %.cpp | prerequirement
 	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -o $@
-	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -MM -MT $@ -MF $(OBJ_DIR)/$(notdir $(patsubst %.oo,%.d,$@))
-	cp $@ $(OBJ_DIR)/$(notdir $@)
-	cp $*_$(TARGET).ii $(INFO_DIR)
-	cp $*_$(TARGET).s $(INFO_DIR)
-	chmod 777 $(OBJ_DIR)/$(notdir $@)
+	foldername=$$(basename $$(dirname $<)); \
+	mkdir -p $(OBJ_DIR)/$${foldername}; \
+	mkdir -p $(INFO_DIR)/$${foldername}; \
+	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -MM -MT $@ -MF $(OBJ_DIR)/$${foldername}/$(notdir $(patsubst %.oo,%.d,$@)); \
+	cp $@ $(OBJ_DIR)/$${foldername}/$(notdir $@); \
+	cp $*_$(TARGET).ii $(INFO_DIR)/$${foldername}/$(notdir $@).ii; \
+	cp $*_$(TARGET).s $(INFO_DIR)/$${foldername}/$(notdir $@).s; \
+	chmod 777 $(OBJ_DIR)/$${foldername}/$(notdir $@);
 
 $(SRC_O): %_$(TARGET).o : %.c | prerequirement
 	$(CC) $(CFLAGS) $(INCLUDES) -c $< -o $@

--- a/project/amebaz2plus/make/aircon/lib_chip_aircon_main.mk
+++ b/project/amebaz2plus/make/aircon/lib_chip_aircon_main.mk
@@ -140,7 +140,7 @@ CPPFLAGS += $(CFLAGS)
 
 .PHONY: lib_main
 lib_main: prerequirement $(SRC_O) $(DRAM_O) $(SRC_OO)
-	$(AR) crv $(BIN_DIR)/$(TARGET).a $(OBJ_CPP_LIST) $(OBJ_LIST) $(VER_O)
+	$(AR) crv $(BIN_DIR)/$(TARGET).a $(OBJ_DIR)/*/*.oo $(OBJ_LIST) $(VER_O)
 	cp $(BIN_DIR)/$(TARGET).a $(SDKROOTDIR)/component/soc/realtek/8710c/misc/bsp/lib/common/GCC/$(TARGET).a
 
 # Manipulate Image
@@ -175,11 +175,14 @@ prerequirement:
 
 $(SRC_OO): %_$(TARGET).oo : %.cpp | prerequirement
 	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -o $@
-	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -MM -MT $@ -MF $(OBJ_DIR)/$(notdir $(patsubst %.oo,%.d,$@))
-	mv $@ $(OBJ_DIR)/$(notdir $@)
-	mv $*_$(TARGET).ii $(INFO_DIR)
-	mv $*_$(TARGET).s $(INFO_DIR)
-	chmod 777 $(OBJ_DIR)/$(notdir $@)
+	foldername=$$(basename $$(dirname $<)); \
+	mkdir -p $(OBJ_DIR)/$${foldername}; \
+	mkdir -p $(INFO_DIR)/$${foldername}; \
+	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -MM -MT $@ -MF $(OBJ_DIR)/$${foldername}/$(notdir $(patsubst %.oo,%.d,$@)); \
+	cp $@ $(OBJ_DIR)/$${foldername}/$(notdir $@); \
+	cp $*_$(TARGET).ii $(INFO_DIR)/$${foldername}/$(notdir $@).ii; \
+	cp $*_$(TARGET).s $(INFO_DIR)/$${foldername}/$(notdir $@).s; \
+	chmod 777 $(OBJ_DIR)/$${foldername}/$(notdir $@);
 
 $(SRC_O): %_$(TARGET).o : %.c | prerequirement
 	$(CC) $(CFLAGS) $(INCLUDES) -c $< -o $@

--- a/project/amebaz2plus/make/all_clusters/lib_chip_main.mk
+++ b/project/amebaz2plus/make/all_clusters/lib_chip_main.mk
@@ -199,7 +199,7 @@ CPPFLAGS += $(CFLAGS)
 
 .PHONY: lib_main
 lib_main: prerequirement $(SRC_O) $(DRAM_O) $(SRC_OO)
-	$(AR) crv $(BIN_DIR)/$(TARGET).a $(OBJ_CPP_LIST) $(OBJ_LIST) $(VER_O)
+	$(AR) crv $(BIN_DIR)/$(TARGET).a $(OBJ_DIR)/*/*.oo $(OBJ_LIST) $(VER_O)
 	cp $(BIN_DIR)/$(TARGET).a $(SDKROOTDIR)/component/soc/realtek/8710c/misc/bsp/lib/common/GCC/$(TARGET).a
 
 # Manipulate Image
@@ -234,11 +234,14 @@ prerequirement:
 
 $(SRC_OO): %_$(TARGET).oo : %.cpp | prerequirement
 	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -o $@
-	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -MM -MT $@ -MF $(OBJ_DIR)/$(notdir $(patsubst %.oo,%.d,$@))
-	cp $@ $(OBJ_DIR)/$(notdir $@)
-	cp $*_$(TARGET).ii $(INFO_DIR)
-	cp $*_$(TARGET).s $(INFO_DIR)
-	chmod 777 $(OBJ_DIR)/$(notdir $@)
+	foldername=$$(basename $$(dirname $<)); \
+	mkdir -p $(OBJ_DIR)/$${foldername}; \
+	mkdir -p $(INFO_DIR)/$${foldername}; \
+	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -MM -MT $@ -MF $(OBJ_DIR)/$${foldername}/$(notdir $(patsubst %.oo,%.d,$@)); \
+	cp $@ $(OBJ_DIR)/$${foldername}/$(notdir $@); \
+	cp $*_$(TARGET).ii $(INFO_DIR)/$${foldername}/$(notdir $@).ii; \
+	cp $*_$(TARGET).s $(INFO_DIR)/$${foldername}/$(notdir $@).s; \
+	chmod 777 $(OBJ_DIR)/$${foldername}/$(notdir $@);
 
 $(SRC_O): %_$(TARGET).o : %.c | prerequirement
 	$(CC) $(CFLAGS) $(INCLUDES) -c $< -o $@

--- a/project/amebaz2plus/make/bridge_dm/lib_chip_bridge_main.mk
+++ b/project/amebaz2plus/make/bridge_dm/lib_chip_bridge_main.mk
@@ -143,7 +143,7 @@ CPPFLAGS += $(CFLAGS)
 
 .PHONY: lib_main
 lib_main: prerequirement $(SRC_O) $(DRAM_O) $(SRC_OO)
-	$(AR) crv $(BIN_DIR)/$(TARGET).a $(OBJ_CPP_LIST) $(OBJ_LIST) $(VER_O)
+	$(AR) crv $(BIN_DIR)/$(TARGET).a $(OBJ_DIR)/*/*.oo $(OBJ_LIST) $(VER_O)
 	cp $(BIN_DIR)/$(TARGET).a $(SDKROOTDIR)/component/soc/realtek/8710c/misc/bsp/lib/common/GCC/$(TARGET).a
 
 # Manipulate Image
@@ -178,9 +178,12 @@ prerequirement:
 
 $(SRC_OO): %_$(TARGET).oo : %.cpp | prerequirement
 	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -o $@
-	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -MM -MT $@ -MF $(OBJ_DIR)/$(notdir $(patsubst %.oo,%.d,$@))
-	cp $@ $(OBJ_DIR)/$(notdir $@)
-	chmod 777 $(OBJ_DIR)/$(notdir $@)
+	foldername=$$(basename $$(dirname $<)); \
+	mkdir -p $(OBJ_DIR)/$${foldername}; \
+	mkdir -p $(INFO_DIR)/$${foldername}; \
+	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -MM -MT $@ -MF $(OBJ_DIR)/$${foldername}/$(notdir $(patsubst %.oo,%.d,$@)); \
+	cp $@ $(OBJ_DIR)/$${foldername}/$(notdir $@); \
+	chmod 777 $(OBJ_DIR)/$${foldername}/$(notdir $@);
 
 $(SRC_O): %_$(TARGET).o : %.c | prerequirement
 	$(CC) $(CFLAGS) $(INCLUDES) -c $< -o $@

--- a/project/amebaz2plus/make/chef/lib_chip_chef_main.mk
+++ b/project/amebaz2plus/make/chef/lib_chip_chef_main.mk
@@ -138,7 +138,7 @@ CPPFLAGS += $(CFLAGS)
 
 .PHONY: lib_main
 lib_main: prerequirement $(SRC_O) $(DRAM_O) $(SRC_OO)
-	$(AR) crv $(BIN_DIR)/$(TARGET).a $(OBJ_CPP_LIST) $(OBJ_LIST) $(VER_O)
+	$(AR) crv $(BIN_DIR)/$(TARGET).a $(OBJ_DIR)/*/*.oo $(OBJ_LIST) $(VER_O)
 	cp $(BIN_DIR)/$(TARGET).a $(SDKROOTDIR)/component/soc/realtek/8710c/misc/bsp/lib/common/GCC/$(TARGET).a
 
 # Manipulate Image
@@ -173,11 +173,14 @@ prerequirement:
 
 $(SRC_OO): %_$(TARGET).oo : %.cpp | prerequirement
 	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -o $@
-	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -MM -MT $@ -MF $(OBJ_DIR)/$(notdir $(patsubst %.oo,%.d,$@))
-	cp $@ $(OBJ_DIR)/$(notdir $@)
-	cp $*_$(TARGET).ii $(INFO_DIR)
-	cp $*_$(TARGET).s $(INFO_DIR)
-	chmod 777 $(OBJ_DIR)/$(notdir $@)
+	foldername=$$(basename $$(dirname $<)); \
+	mkdir -p $(OBJ_DIR)/$${foldername}; \
+	mkdir -p $(INFO_DIR)/$${foldername}; \
+	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -MM -MT $@ -MF $(OBJ_DIR)/$${foldername}/$(notdir $(patsubst %.oo,%.d,$@)); \
+	cp $@ $(OBJ_DIR)/$${foldername}/$(notdir $@); \
+	cp $*_$(TARGET).ii $(INFO_DIR)/$${foldername}/$(notdir $@).ii; \
+	cp $*_$(TARGET).s $(INFO_DIR)/$${foldername}/$(notdir $@).s; \
+	chmod 777 $(OBJ_DIR)/$${foldername}/$(notdir $@);
 
 $(SRC_O): %_$(TARGET).o : %.c | prerequirement
 	$(CC) $(CFLAGS) $(INCLUDES) -c $< -o $@

--- a/project/amebaz2plus/make/dishwasher/lib_chip_dishwasher_main.mk
+++ b/project/amebaz2plus/make/dishwasher/lib_chip_dishwasher_main.mk
@@ -142,7 +142,7 @@ CPPFLAGS += $(CFLAGS)
 
 .PHONY: lib_main
 lib_main: prerequirement $(SRC_O) $(DRAM_O) $(SRC_OO)
-	$(AR) crv $(BIN_DIR)/$(TARGET).a $(OBJ_CPP_LIST) $(OBJ_LIST) $(VER_O)
+	$(AR) crv $(BIN_DIR)/$(TARGET).a $(OBJ_DIR)/*/*.oo $(OBJ_LIST) $(VER_O)
 	cp $(BIN_DIR)/$(TARGET).a $(SDKROOTDIR)/component/soc/realtek/8710c/misc/bsp/lib/common/GCC/$(TARGET).a
 
 # Manipulate Image
@@ -177,11 +177,14 @@ prerequirement:
 
 $(SRC_OO): %_$(TARGET).oo : %.cpp | prerequirement
 	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -o $@
-	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -MM -MT $@ -MF $(OBJ_DIR)/$(notdir $(patsubst %.oo,%.d,$@))
-	cp $@ $(OBJ_DIR)/$(notdir $@)
-	cp $*_$(TARGET).ii $(INFO_DIR)
-	cp $*_$(TARGET).s $(INFO_DIR)
-	chmod 777 $(OBJ_DIR)/$(notdir $@)
+	foldername=$$(basename $$(dirname $<)); \
+	mkdir -p $(OBJ_DIR)/$${foldername}; \
+	mkdir -p $(INFO_DIR)/$${foldername}; \
+	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -MM -MT $@ -MF $(OBJ_DIR)/$${foldername}/$(notdir $(patsubst %.oo,%.d,$@)); \
+	cp $@ $(OBJ_DIR)/$${foldername}/$(notdir $@); \
+	cp $*_$(TARGET).ii $(INFO_DIR)/$${foldername}/$(notdir $@).ii; \
+	cp $*_$(TARGET).s $(INFO_DIR)/$${foldername}/$(notdir $@).s; \
+	chmod 777 $(OBJ_DIR)/$${foldername}/$(notdir $@);
 
 $(SRC_O): %_$(TARGET).o : %.c | prerequirement
 	$(CC) $(CFLAGS) $(INCLUDES) -c $< -o $@

--- a/project/amebaz2plus/make/fan/lib_chip_fan_main.mk
+++ b/project/amebaz2plus/make/fan/lib_chip_fan_main.mk
@@ -139,7 +139,7 @@ CPPFLAGS += $(CFLAGS)
 
 .PHONY: lib_main
 lib_main: prerequirement $(SRC_O) $(DRAM_O) $(SRC_OO)
-	$(AR) crv $(BIN_DIR)/$(TARGET).a $(OBJ_CPP_LIST) $(OBJ_LIST) $(VER_O)
+	$(AR) crv $(BIN_DIR)/$(TARGET).a $(OBJ_DIR)/*/*.oo $(OBJ_LIST) $(VER_O)
 	cp $(BIN_DIR)/$(TARGET).a $(SDKROOTDIR)/component/soc/realtek/8710c/misc/bsp/lib/common/GCC/$(TARGET).a
 
 # Manipulate Image
@@ -174,11 +174,14 @@ prerequirement:
 
 $(SRC_OO): %_$(TARGET).oo : %.cpp | prerequirement
 	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -o $@
-	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -MM -MT $@ -MF $(OBJ_DIR)/$(notdir $(patsubst %.oo,%.d,$@))
-	cp $@ $(OBJ_DIR)/$(notdir $@)
-	cp $*_$(TARGET).ii $(INFO_DIR)
-	cp $*_$(TARGET).s $(INFO_DIR)
-	chmod 777 $(OBJ_DIR)/$(notdir $@)
+	foldername=$$(basename $$(dirname $<)); \
+	mkdir -p $(OBJ_DIR)/$${foldername}; \
+	mkdir -p $(INFO_DIR)/$${foldername}; \
+	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -MM -MT $@ -MF $(OBJ_DIR)/$${foldername}/$(notdir $(patsubst %.oo,%.d,$@)); \
+	cp $@ $(OBJ_DIR)/$${foldername}/$(notdir $@); \
+	cp $*_$(TARGET).ii $(INFO_DIR)/$${foldername}/$(notdir $@).ii; \
+	cp $*_$(TARGET).s $(INFO_DIR)/$${foldername}/$(notdir $@).s; \
+	chmod 777 $(OBJ_DIR)/$${foldername}/$(notdir $@);
 
 $(SRC_O): %_$(TARGET).o : %.c | prerequirement
 	$(CC) $(CFLAGS) $(INCLUDES) -c $< -o $@

--- a/project/amebaz2plus/make/generic_switch/lib_chip_generic_switch_main.mk
+++ b/project/amebaz2plus/make/generic_switch/lib_chip_generic_switch_main.mk
@@ -140,7 +140,7 @@ CPPFLAGS += $(CFLAGS)
 
 .PHONY: lib_main
 lib_main: prerequirement $(SRC_O) $(DRAM_O) $(SRC_OO)
-	$(AR) crv $(BIN_DIR)/$(TARGET).a $(OBJ_CPP_LIST) $(OBJ_LIST) $(VER_O)
+	$(AR) crv $(BIN_DIR)/$(TARGET).a $(OBJ_DIR)/*/*.oo $(OBJ_LIST) $(VER_O)
 	cp $(BIN_DIR)/$(TARGET).a $(SDKROOTDIR)/component/soc/realtek/8710c/misc/bsp/lib/common/GCC/$(TARGET).a
 
 # Manipulate Image
@@ -175,11 +175,14 @@ prerequirement:
 
 $(SRC_OO): %_$(TARGET).oo : %.cpp | prerequirement
 	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -o $@
-	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -MM -MT $@ -MF $(OBJ_DIR)/$(notdir $(patsubst %.oo,%.d,$@))
-	cp $@ $(OBJ_DIR)/$(notdir $@)
-	cp $*_$(TARGET).ii $(INFO_DIR)
-	cp $*_$(TARGET).s $(INFO_DIR)
-	chmod 777 $(OBJ_DIR)/$(notdir $@)
+	foldername=$$(basename $$(dirname $<)); \
+	mkdir -p $(OBJ_DIR)/$${foldername}; \
+	mkdir -p $(INFO_DIR)/$${foldername}; \
+	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -MM -MT $@ -MF $(OBJ_DIR)/$${foldername}/$(notdir $(patsubst %.oo,%.d,$@)); \
+	cp $@ $(OBJ_DIR)/$${foldername}/$(notdir $@); \
+	cp $*_$(TARGET).ii $(INFO_DIR)/$${foldername}/$(notdir $@).ii; \
+	cp $*_$(TARGET).s $(INFO_DIR)/$${foldername}/$(notdir $@).s; \
+	chmod 777 $(OBJ_DIR)/$${foldername}/$(notdir $@);
 
 $(SRC_O): %_$(TARGET).o : %.c | prerequirement
 	$(CC) $(CFLAGS) $(INCLUDES) -c $< -o $@

--- a/project/amebaz2plus/make/laundrywasher/lib_chip_laundrywasher_main.mk
+++ b/project/amebaz2plus/make/laundrywasher/lib_chip_laundrywasher_main.mk
@@ -143,7 +143,7 @@ CPPFLAGS += $(CFLAGS)
 
 .PHONY: lib_main
 lib_main: prerequirement $(SRC_O) $(DRAM_O) $(SRC_OO)
-	$(AR) crv $(BIN_DIR)/$(TARGET).a $(OBJ_CPP_LIST) $(OBJ_LIST) $(VER_O)
+	$(AR) crv $(BIN_DIR)/$(TARGET).a $(OBJ_DIR)/*/*.oo $(OBJ_LIST) $(VER_O)
 	cp $(BIN_DIR)/$(TARGET).a $(SDKROOTDIR)/component/soc/realtek/8710c/misc/bsp/lib/common/GCC/$(TARGET).a
 
 # Manipulate Image
@@ -178,11 +178,14 @@ prerequirement:
 
 $(SRC_OO): %_$(TARGET).oo : %.cpp | prerequirement
 	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -o $@
-	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -MM -MT $@ -MF $(OBJ_DIR)/$(notdir $(patsubst %.oo,%.d,$@))
-	cp $@ $(OBJ_DIR)/$(notdir $@)
-	cp $*_$(TARGET).ii $(INFO_DIR)
-	cp $*_$(TARGET).s $(INFO_DIR)
-	chmod 777 $(OBJ_DIR)/$(notdir $@)
+	foldername=$$(basename $$(dirname $<)); \
+	mkdir -p $(OBJ_DIR)/$${foldername}; \
+	mkdir -p $(INFO_DIR)/$${foldername}; \
+	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -MM -MT $@ -MF $(OBJ_DIR)/$${foldername}/$(notdir $(patsubst %.oo,%.d,$@)); \
+	cp $@ $(OBJ_DIR)/$${foldername}/$(notdir $@); \
+	cp $*_$(TARGET).ii $(INFO_DIR)/$${foldername}/$(notdir $@).ii; \
+	cp $*_$(TARGET).s $(INFO_DIR)/$${foldername}/$(notdir $@).s; \
+	chmod 777 $(OBJ_DIR)/$${foldername}/$(notdir $@);
 
 $(SRC_O): %_$(TARGET).o : %.c | prerequirement
 	$(CC) $(CFLAGS) $(INCLUDES) -c $< -o $@

--- a/project/amebaz2plus/make/light_dm/lib_chip_light_main.mk
+++ b/project/amebaz2plus/make/light_dm/lib_chip_light_main.mk
@@ -144,7 +144,7 @@ CPPFLAGS += $(CFLAGS)
 
 .PHONY: lib_main
 lib_main: prerequirement $(SRC_O) $(DRAM_O) $(SRC_OO)
-	$(AR) crv $(BIN_DIR)/$(TARGET).a $(OBJ_CPP_LIST) $(OBJ_LIST) $(VER_O)
+	$(AR) crv $(BIN_DIR)/$(TARGET).a $(OBJ_DIR)/*/*.oo $(OBJ_LIST) $(VER_O)
 	cp $(BIN_DIR)/$(TARGET).a $(SDKROOTDIR)/component/soc/realtek/8710c/misc/bsp/lib/common/GCC/$(TARGET).a
 
 # Manipulate Image
@@ -179,9 +179,12 @@ prerequirement:
 
 $(SRC_OO): %_$(TARGET).oo : %.cpp | prerequirement
 	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -o $@
-	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -MM -MT $@ -MF $(OBJ_DIR)/$(notdir $(patsubst %.oo,%.d,$@))
-	cp $@ $(OBJ_DIR)/$(notdir $@)
-	chmod 777 $(OBJ_DIR)/$(notdir $@)
+	foldername=$$(basename $$(dirname $<)); \
+	mkdir -p $(OBJ_DIR)/$${foldername}; \
+	mkdir -p $(INFO_DIR)/$${foldername}; \
+	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -MM -MT $@ -MF $(OBJ_DIR)/$${foldername}/$(notdir $(patsubst %.oo,%.d,$@)); \
+	cp $@ $(OBJ_DIR)/$${foldername}/$(notdir $@); \
+	chmod 777 $(OBJ_DIR)/$${foldername}/$(notdir $@);
 
 $(SRC_O): %_$(TARGET).o : %.c | prerequirement
 	$(CC) $(CFLAGS) $(INCLUDES) -c $< -o $@

--- a/project/amebaz2plus/make/light_port/lib_chip_light_main.mk
+++ b/project/amebaz2plus/make/light_port/lib_chip_light_main.mk
@@ -141,7 +141,7 @@ CPPFLAGS += $(CFLAGS)
 
 .PHONY: lib_main
 lib_main: prerequirement $(SRC_O) $(DRAM_O) $(SRC_OO)
-	$(AR) crv $(BIN_DIR)/$(TARGET).a $(OBJ_CPP_LIST) $(OBJ_LIST) $(VER_O)
+	$(AR) crv $(BIN_DIR)/$(TARGET).a $(OBJ_DIR)/*/*.oo $(OBJ_LIST) $(VER_O)
 	cp $(BIN_DIR)/$(TARGET).a $(SDKROOTDIR)/component/soc/realtek/8710c/misc/bsp/lib/common/GCC/$(TARGET).a
 
 # Manipulate Image
@@ -176,11 +176,14 @@ prerequirement:
 
 $(SRC_OO): %_$(TARGET).oo : %.cpp | prerequirement
 	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -o $@
-	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -MM -MT $@ -MF $(OBJ_DIR)/$(notdir $(patsubst %.oo,%.d,$@))
-	cp $@ $(OBJ_DIR)/$(notdir $@)
-	cp $*_$(TARGET).ii $(INFO_DIR)
-	cp $*_$(TARGET).s $(INFO_DIR)
-	chmod 777 $(OBJ_DIR)/$(notdir $@)
+	foldername=$$(basename $$(dirname $<)); \
+	mkdir -p $(OBJ_DIR)/$${foldername}; \
+	mkdir -p $(INFO_DIR)/$${foldername}; \
+	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -MM -MT $@ -MF $(OBJ_DIR)/$${foldername}/$(notdir $(patsubst %.oo,%.d,$@)); \
+	cp $@ $(OBJ_DIR)/$${foldername}/$(notdir $@); \
+	cp $*_$(TARGET).ii $(INFO_DIR)/$${foldername}/$(notdir $@).ii; \
+	cp $*_$(TARGET).s $(INFO_DIR)/$${foldername}/$(notdir $@).s; \
+	chmod 777 $(OBJ_DIR)/$${foldername}/$(notdir $@);
 
 $(SRC_O): %_$(TARGET).o : %.c | prerequirement
 	$(CC) $(CFLAGS) $(INCLUDES) -c $< -o $@

--- a/project/amebaz2plus/make/light_switch/lib_chip_light_switch_main.mk
+++ b/project/amebaz2plus/make/light_switch/lib_chip_light_switch_main.mk
@@ -144,7 +144,7 @@ CPPFLAGS += $(CFLAGS)
 
 .PHONY: lib_main
 lib_main: prerequirement $(SRC_O) $(DRAM_O) $(SRC_OO)
-	$(AR) crv $(BIN_DIR)/$(TARGET).a $(OBJ_CPP_LIST) $(OBJ_LIST) $(VER_O)
+	$(AR) crv $(BIN_DIR)/$(TARGET).a $(OBJ_DIR)/*/*.oo $(OBJ_LIST) $(VER_O)
 	cp $(BIN_DIR)/$(TARGET).a $(SDKROOTDIR)/component/soc/realtek/8710c/misc/bsp/lib/common/GCC/$(TARGET).a
 
 # Manipulate Image
@@ -179,11 +179,14 @@ prerequirement:
 
 $(SRC_OO): %_$(TARGET).oo : %.cpp | prerequirement
 	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -o $@
-	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -MM -MT $@ -MF $(OBJ_DIR)/$(notdir $(patsubst %.oo,%.d,$@))
-	cp $@ $(OBJ_DIR)/$(notdir $@)
-	cp $*_$(TARGET).ii $(INFO_DIR)
-	cp $*_$(TARGET).s $(INFO_DIR)
-	chmod 777 $(OBJ_DIR)/$(notdir $@)
+	foldername=$$(basename $$(dirname $<)); \
+	mkdir -p $(OBJ_DIR)/$${foldername}; \
+	mkdir -p $(INFO_DIR)/$${foldername}; \
+	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -MM -MT $@ -MF $(OBJ_DIR)/$${foldername}/$(notdir $(patsubst %.oo,%.d,$@)); \
+	cp $@ $(OBJ_DIR)/$${foldername}/$(notdir $@); \
+	cp $*_$(TARGET).ii $(INFO_DIR)/$${foldername}/$(notdir $@).ii; \
+	cp $*_$(TARGET).s $(INFO_DIR)/$${foldername}/$(notdir $@).s; \
+	chmod 777 $(OBJ_DIR)/$${foldername}/$(notdir $@);
 
 $(SRC_O): %_$(TARGET).o : %.c | prerequirement
 	$(CC) $(CFLAGS) $(INCLUDES) -c $< -o $@

--- a/project/amebaz2plus/make/microwaveoven/lib_chip_microwaveoven_main.mk
+++ b/project/amebaz2plus/make/microwaveoven/lib_chip_microwaveoven_main.mk
@@ -144,7 +144,7 @@ CPPFLAGS += $(CFLAGS)
 
 .PHONY: lib_main
 lib_main: prerequirement $(SRC_O) $(DRAM_O) $(SRC_OO)
-	$(AR) crv $(BIN_DIR)/$(TARGET).a $(OBJ_CPP_LIST) $(OBJ_LIST) $(VER_O)
+	$(AR) crv $(BIN_DIR)/$(TARGET).a $(OBJ_DIR)/*/*.oo $(OBJ_LIST) $(VER_O)
 	cp $(BIN_DIR)/$(TARGET).a $(SDKROOTDIR)/component/soc/realtek/8710c/misc/bsp/lib/common/GCC/$(TARGET).a
 
 # Manipulate Image
@@ -179,11 +179,14 @@ prerequirement:
 
 $(SRC_OO): %_$(TARGET).oo : %.cpp | prerequirement
 	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -o $@
-	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -MM -MT $@ -MF $(OBJ_DIR)/$(notdir $(patsubst %.oo,%.d,$@))
-	cp $@ $(OBJ_DIR)/$(notdir $@)
-	cp $*_$(TARGET).ii $(INFO_DIR)
-	cp $*_$(TARGET).s $(INFO_DIR)
-	chmod 777 $(OBJ_DIR)/$(notdir $@)
+	foldername=$$(basename $$(dirname $<)); \
+	mkdir -p $(OBJ_DIR)/$${foldername}; \
+	mkdir -p $(INFO_DIR)/$${foldername}; \
+	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -MM -MT $@ -MF $(OBJ_DIR)/$${foldername}/$(notdir $(patsubst %.oo,%.d,$@)); \
+	cp $@ $(OBJ_DIR)/$${foldername}/$(notdir $@); \
+	cp $*_$(TARGET).ii $(INFO_DIR)/$${foldername}/$(notdir $@).ii; \
+	cp $*_$(TARGET).s $(INFO_DIR)/$${foldername}/$(notdir $@).s; \
+	chmod 777 $(OBJ_DIR)/$${foldername}/$(notdir $@);
 
 $(SRC_O): %_$(TARGET).o : %.c | prerequirement
 	$(CC) $(CFLAGS) $(INCLUDES) -c $< -o $@

--- a/project/amebaz2plus/make/otar/lib_chip_otar_main.mk
+++ b/project/amebaz2plus/make/otar/lib_chip_otar_main.mk
@@ -134,7 +134,7 @@ CPPFLAGS += $(CFLAGS)
 
 .PHONY: lib_main
 lib_main: prerequirement $(SRC_O) $(DRAM_O) $(SRC_OO)
-	$(AR) crv $(BIN_DIR)/$(TARGET).a $(OBJ_CPP_LIST) $(OBJ_LIST) $(VER_O)
+	$(AR) crv $(BIN_DIR)/$(TARGET).a $(OBJ_DIR)/*/*.oo $(OBJ_LIST) $(VER_O)
 	cp $(BIN_DIR)/$(TARGET).a $(SDKROOTDIR)/component/soc/realtek/8710c/misc/bsp/lib/common/GCC/$(TARGET).a
 
 # Manipulate Image
@@ -169,11 +169,14 @@ prerequirement:
 
 $(SRC_OO): %_$(TARGET).oo : %.cpp | prerequirement
 	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -o $@
-	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -MM -MT $@ -MF $(OBJ_DIR)/$(notdir $(patsubst %.oo,%.d,$@))
-	cp $@ $(OBJ_DIR)/$(notdir $@)
-	cp $*_$(TARGET).ii $(INFO_DIR)
-	cp $*_$(TARGET).s $(INFO_DIR)
-	chmod 777 $(OBJ_DIR)/$(notdir $@)
+	foldername=$$(basename $$(dirname $<)); \
+	mkdir -p $(OBJ_DIR)/$${foldername}; \
+	mkdir -p $(INFO_DIR)/$${foldername}; \
+	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -MM -MT $@ -MF $(OBJ_DIR)/$${foldername}/$(notdir $(patsubst %.oo,%.d,$@)); \
+	cp $@ $(OBJ_DIR)/$${foldername}/$(notdir $@); \
+	cp $*_$(TARGET).ii $(INFO_DIR)/$${foldername}/$(notdir $@).ii; \
+	cp $*_$(TARGET).s $(INFO_DIR)/$${foldername}/$(notdir $@).s; \
+	chmod 777 $(OBJ_DIR)/$${foldername}/$(notdir $@);
 
 $(SRC_O): %_$(TARGET).o : %.c | prerequirement
 	$(CC) $(CFLAGS) $(INCLUDES) -c $< -o $@

--- a/project/amebaz2plus/make/refrigerator/lib_chip_refrigerator_main.mk
+++ b/project/amebaz2plus/make/refrigerator/lib_chip_refrigerator_main.mk
@@ -141,7 +141,7 @@ CPPFLAGS += $(CFLAGS)
 
 .PHONY: lib_main
 lib_main: prerequirement $(SRC_O) $(DRAM_O) $(SRC_OO)
-	$(AR) crv $(BIN_DIR)/$(TARGET).a $(OBJ_CPP_LIST) $(OBJ_LIST) $(VER_O)
+	$(AR) crv $(BIN_DIR)/$(TARGET).a $(OBJ_DIR)/*/*.oo $(OBJ_LIST) $(VER_O)
 	cp $(BIN_DIR)/$(TARGET).a $(SDKROOTDIR)/component/soc/realtek/8710c/misc/bsp/lib/common/GCC/$(TARGET).a
 
 # Manipulate Image
@@ -176,11 +176,14 @@ prerequirement:
 
 $(SRC_OO): %_$(TARGET).oo : %.cpp | prerequirement
 	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -o $@
-	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -MM -MT $@ -MF $(OBJ_DIR)/$(notdir $(patsubst %.oo,%.d,$@))
-	cp $@ $(OBJ_DIR)/$(notdir $@)
-	cp $*_$(TARGET).ii $(INFO_DIR)
-	cp $*_$(TARGET).s $(INFO_DIR)
-	chmod 777 $(OBJ_DIR)/$(notdir $@)
+	foldername=$$(basename $$(dirname $<)); \
+	mkdir -p $(OBJ_DIR)/$${foldername}; \
+	mkdir -p $(INFO_DIR)/$${foldername}; \
+	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -MM -MT $@ -MF $(OBJ_DIR)/$${foldername}/$(notdir $(patsubst %.oo,%.d,$@)); \
+	cp $@ $(OBJ_DIR)/$${foldername}/$(notdir $@); \
+	cp $*_$(TARGET).ii $(INFO_DIR)/$${foldername}/$(notdir $@).ii; \
+	cp $*_$(TARGET).s $(INFO_DIR)/$${foldername}/$(notdir $@).s; \
+	chmod 777 $(OBJ_DIR)/$${foldername}/$(notdir $@);
 
 $(SRC_O): %_$(TARGET).o : %.c | prerequirement
 	$(CC) $(CFLAGS) $(INCLUDES) -c $< -o $@

--- a/project/amebaz2plus/make/temperature_sensor/lib_chip_temp_sensor_main.mk
+++ b/project/amebaz2plus/make/temperature_sensor/lib_chip_temp_sensor_main.mk
@@ -138,7 +138,7 @@ CPPFLAGS += $(CFLAGS)
 
 .PHONY: lib_main
 lib_main: prerequirement $(SRC_O) $(DRAM_O) $(SRC_OO)
-	$(AR) crv $(BIN_DIR)/$(TARGET).a $(OBJ_CPP_LIST) $(OBJ_LIST) $(VER_O)
+	$(AR) crv $(BIN_DIR)/$(TARGET).a $(OBJ_DIR)/*/*.oo $(OBJ_LIST) $(VER_O)
 	cp $(BIN_DIR)/$(TARGET).a $(SDKROOTDIR)/component/soc/realtek/8710c/misc/bsp/lib/common/GCC/$(TARGET).a
 
 # Manipulate Image
@@ -173,11 +173,14 @@ prerequirement:
 
 $(SRC_OO): %_$(TARGET).oo : %.cpp | prerequirement
 	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -o $@
-	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -MM -MT $@ -MF $(OBJ_DIR)/$(notdir $(patsubst %.oo,%.d,$@))
-	cp $@ $(OBJ_DIR)/$(notdir $@)
-	cp $*_$(TARGET).ii $(INFO_DIR)
-	cp $*_$(TARGET).s $(INFO_DIR)
-	chmod 777 $(OBJ_DIR)/$(notdir $@)
+	foldername=$$(basename $$(dirname $<)); \
+	mkdir -p $(OBJ_DIR)/$${foldername}; \
+	mkdir -p $(INFO_DIR)/$${foldername}; \
+	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -MM -MT $@ -MF $(OBJ_DIR)/$${foldername}/$(notdir $(patsubst %.oo,%.d,$@)); \
+	cp $@ $(OBJ_DIR)/$${foldername}/$(notdir $@); \
+	cp $*_$(TARGET).ii $(INFO_DIR)/$${foldername}/$(notdir $@).ii; \
+	cp $*_$(TARGET).s $(INFO_DIR)/$${foldername}/$(notdir $@).s; \
+	chmod 777 $(OBJ_DIR)/$${foldername}/$(notdir $@);
 
 $(SRC_O): %_$(TARGET).o : %.c | prerequirement
 	$(CC) $(CFLAGS) $(INCLUDES) -c $< -o $@

--- a/project/amebaz2plus/make/thermostat/lib_chip_thermostat_main.mk
+++ b/project/amebaz2plus/make/thermostat/lib_chip_thermostat_main.mk
@@ -142,7 +142,7 @@ CPPFLAGS += $(CFLAGS)
 
 .PHONY: lib_main
 lib_main: prerequirement $(SRC_O) $(DRAM_O) $(SRC_OO)
-	$(AR) crv $(BIN_DIR)/$(TARGET).a $(OBJ_CPP_LIST) $(OBJ_LIST) $(VER_O)
+	$(AR) crv $(BIN_DIR)/$(TARGET).a $(OBJ_DIR)/*/*.oo $(OBJ_LIST) $(VER_O)
 	cp $(BIN_DIR)/$(TARGET).a $(SDKROOTDIR)/component/soc/realtek/8710c/misc/bsp/lib/common/GCC/$(TARGET).a
 
 # Manipulate Image
@@ -177,11 +177,14 @@ prerequirement:
 
 $(SRC_OO): %_$(TARGET).oo : %.cpp | prerequirement
 	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -o $@
-	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -MM -MT $@ -MF $(OBJ_DIR)/$(notdir $(patsubst %.oo,%.d,$@))
-	cp $@ $(OBJ_DIR)/$(notdir $@)
-	cp $*_$(TARGET).ii $(INFO_DIR)
-	cp $*_$(TARGET).s $(INFO_DIR)
-	chmod 777 $(OBJ_DIR)/$(notdir $@)
+	foldername=$$(basename $$(dirname $<)); \
+	mkdir -p $(OBJ_DIR)/$${foldername}; \
+	mkdir -p $(INFO_DIR)/$${foldername}; \
+	$(CC) $(CPPFLAGS) $(INCLUDES) -c $< -MM -MT $@ -MF $(OBJ_DIR)/$${foldername}/$(notdir $(patsubst %.oo,%.d,$@)); \
+	cp $@ $(OBJ_DIR)/$${foldername}/$(notdir $@); \
+	cp $*_$(TARGET).ii $(INFO_DIR)/$${foldername}/$(notdir $@).ii; \
+	cp $*_$(TARGET).s $(INFO_DIR)/$${foldername}/$(notdir $@).s; \
+	chmod 777 $(OBJ_DIR)/$${foldername}/$(notdir $@);
 
 $(SRC_O): %_$(TARGET).o : %.c | prerequirement
 	$(CC) $(CFLAGS) $(INCLUDES) -c $< -o $@

--- a/tools/codegen_helpers/parse_clusters.py
+++ b/tools/codegen_helpers/parse_clusters.py
@@ -9,6 +9,7 @@ import os
 
 excluded_files = [
     "TemporaryTestCoupling.cpp",
+    "access-control-server/ArlEncoder.cpp",
 ]
 
 def parse_zapfile_clusters(cluster_file, chip_path):
@@ -32,6 +33,10 @@ def parse_zapfile_clusters(cluster_file, chip_path):
         for clusters_cpp in glob.glob(chip_cluster_path + '/' + cluster + "/*.cpp"):
             cpp_filename = os.path.basename(clusters_cpp)
             if cpp_filename in excluded_files:
+                continue  # Skip excluded files
+            relative_path = os.path.relpath(clusters_cpp, chip_cluster_path)
+            print(relative_path)
+            if relative_path in excluded_files:
                 continue  # Skip excluded files
             cpp_path = chip_cluster_path + '/' + cluster + '/' + cpp_filename
             f.write(cpp_path + '\n')

--- a/tools/docker/amebad/Dockerfile
+++ b/tools/docker/amebad/Dockerfile
@@ -3,7 +3,7 @@ FROM ameba-rtos-matter:common
 
 # Redefine following build arguments to respective repo and tag/branch
 ARG AMEBA_MATTER_REPO=https://github.com/xshuqun/ameba-rtos-matter.git
-ARG TAG_NAME=ameba/update_sdk_250609
+ARG TAG_NAME=ameba/update_sdk_250623
 
 # Define fixed build arguments
 ARG AMBD_REPO=https://github.com/Ameba-AIoT/ameba-rtos-d.git

--- a/tools/docker/amebaz2/Dockerfile
+++ b/tools/docker/amebaz2/Dockerfile
@@ -3,7 +3,7 @@ FROM ameba-rtos-matter:common
 
 # Redefine following build arguments to respective repo and tag/branch
 ARG AMEBA_MATTER_REPO=https://github.com/xshuqun/ameba-rtos-matter.git
-ARG TAG_NAME=ameba/update_sdk_250609
+ARG TAG_NAME=ameba/update_sdk_250623
 
 # Define fixed build arguments
 ARG AMBZ2_REPO=https://github.com/Ameba-AIoT/ameba-rtos-z2.git


### PR DESCRIPTION
This PR addresses:

* Previously, when building source files with the same filename from different directories, the generated `.oo` files would be copied into the same directory and overwrite each other, causing only the latter to take effect.
* This update creates subfolders to store build artifacts, ensuring `.oo` files from different directories are separated.
* The `arm-none-eabi-ar` tool will correctly traverse these subfolders to generate the final static library.

Verification:
* Build on amebaZ2 and amebaD respectively to check that same filename are included into library.
* Also ensured that the final built image runs well on both platform.