### PR TITLE
[general][sdk] add data provider, attribute callback and event trigger

### DIFF
--- a/common/port/matter_data_providers.c
+++ b/common/port/matter_data_providers.c
@@ -1,0 +1,357 @@
+/*
+ *    This module is a confidential and proprietary property of RealTek and
+ *    possession or use of this module requires written permission of RealTek.
+ *
+ *    Copyright(c) 2025, Realtek Semiconductor Corporation. All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#include <platform_opts.h>
+#include <platform/platform_stdlib.h>
+
+#include <matter_data_providers.h>
+#include <matter_dcts.h>
+#include <dct.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/******************************************************
+ *           Key Value Declarations
+ ******************************************************/
+static const char *kFixedLabelKey         = "fixed_label";
+static const char *kSupportedLocalesKey   = "supported_locales";
+static const char *kCalendarTypeKey       = "calendar_type";
+
+/******************************************************
+ *           Default Declarations
+ ******************************************************/
+static const ameba_fixed_label_t sDefaultFixedLabel[] =
+{
+    { "room", "bedroom 2" },
+    { "orientation", "North" },
+    { "floor", "2" },
+    { "direction", "up" },
+};
+static const size_t sDefaultFixedLabelCount = sizeof(sDefaultFixedLabel) / sizeof(sDefaultFixedLabel[0]);
+
+static const char *sDefaultSupportedLocales[] =
+{
+    "en-US", "de-DE", "fr-FR", "en-GB",
+    "es-ES", "zh-CN", "it-IT", "ja-JP"
+};
+static size_t sDefaultSupportedLocalesCount = sizeof(sDefaultSupportedLocales) / sizeof(sDefaultSupportedLocales[0]);
+
+static const uint8_t sDefaultCalendarTypes[MAX_CALENDAR_TYPE_COUNT] =
+{
+    CALENDAR_BUDDHIST,
+    CALENDAR_CHINESE,
+    CALENDAR_COPTIC,
+    CALENDAR_ETHIOPIAN,
+    CALENDAR_GREGORIAN,
+    CALENDAR_HEBREW,
+    CALENDAR_INDIAN,
+    CALENDAR_ISLAMIC,
+    CALENDAR_JAPANESE,
+    CALENDAR_KOREAN,
+    CALENDAR_PERSIAN,
+    CALENDAR_TAIWANESE,
+};
+static const size_t sDefaultCalendarTypeCount = sizeof(sDefaultCalendarTypes) / sizeof(sDefaultCalendarTypes[0]);
+
+/******************************************************
+ *           Ameba Default Declaration
+ ******************************************************/
+static ameba_fixed_label_t sAmebaFixedLabel[MAX_FIXED_LABELS_COUNT] = { 0 };
+static const char *sAmebaSupportedLocales[MAX_ACTIVE_LOCALE_LENGTH] = { 0 };
+static uint8_t sAmebaCalendarTypes[MAX_CALENDAR_TYPE_COUNT] = { 0 };
+
+static size_t sAmebaFixedLabelCount = 0;
+static size_t sAmebaSupportedLocalesCount = 0;
+static size_t sAmebaCalendarTypeCount = 0;
+
+/******************************************************
+ *           Fixed Label Functions
+ ******************************************************/
+
+bool matter_set_fixed_label(uint8_t index, const char *key, const char *value)
+{
+    if (index >= MAX_FIXED_LABELS_COUNT || key == NULL || value == NULL)
+    {
+        return false;
+    }
+
+    strncpy(sAmebaFixedLabel[index].key, key, MAX_LABEL_NAME_LENGTH - 1);
+    sAmebaFixedLabel[index].key[MAX_LABEL_NAME_LENGTH - 1] = '\0';
+
+    strncpy(sAmebaFixedLabel[index].value, value, MAX_LABEL_VALUE_LENGTH - 1);
+    sAmebaFixedLabel[index].value[MAX_LABEL_VALUE_LENGTH - 1] = '\0';
+
+    sAmebaFixedLabel[index].isSet = true;
+    return true;
+}
+
+size_t matter_get_fixed_label_count(void)
+{
+    return sAmebaFixedLabelCount > 0 ? sAmebaFixedLabelCount : sDefaultFixedLabelCount;
+}
+
+const char *matter_get_fixed_label_name(uint8_t index)
+{
+    if (index >= MAX_FIXED_LABELS_COUNT)
+    {
+        return NULL;
+    }
+
+    return sAmebaFixedLabel[index].isSet ? sAmebaFixedLabel[index].key : sDefaultFixedLabel[index].key;
+}
+
+const char *matter_get_fixed_label_value(uint8_t index)
+{
+    if (index >= MAX_FIXED_LABELS_COUNT)
+    {
+        return NULL;
+    }
+
+    return sAmebaFixedLabel[index].isSet ? sAmebaFixedLabel[index].value : sDefaultFixedLabel[index].value;
+}
+
+/******************************************************
+ *           Localization Configuration Functions
+ ******************************************************/
+
+void matter_init_supported_locale(void)
+{
+    size_t len = 0;
+    size_t max_size = sizeof(sAmebaSupportedLocales);
+    uint8_t *buf = (uint8_t *)malloc(max_size);
+
+    if (buf == NULL)
+    {
+        printf("Failed to allocate buffer for supported locales\n");
+        return;
+    }
+
+    if (getPref_str_new(kSupportedLocalesKey, kSupportedLocalesKey, (char *)buf, max_size, &len) == DCT_SUCCESS)
+    {
+        if (len > 0)
+        {
+            buf[len - 1] = '\0'; // Ensure null-terminated
+
+            char *p = (char *)buf;
+            size_t index = 0;
+
+            while ((p - (char *)buf) < (ptrdiff_t)len && index < MAX_ACTIVE_LOCALE_LENGTH)
+            {
+                size_t str_len = strlen(p);
+                if (str_len == 0)
+                {
+                    break;
+                }
+
+                sAmebaSupportedLocales[index] = strdup(p);
+                p += str_len + 1;
+                index++;
+            }
+            sAmebaSupportedLocalesCount = index;
+        }
+    }
+    free(buf);
+}
+
+void matter_deinit_supported_locales(void)
+{
+    for (size_t i = 0; i < sAmebaSupportedLocalesCount; ++i)
+    {
+        if (sAmebaSupportedLocales[i] != NULL)
+        {
+            free((void *)sAmebaSupportedLocales[i]);
+            sAmebaSupportedLocales[i] = NULL;
+        }
+    }
+    sAmebaSupportedLocalesCount = 0;
+}
+
+size_t matter_get_supported_locale_count(void)
+{
+    return sAmebaSupportedLocalesCount > 0 ? sAmebaSupportedLocalesCount : sDefaultSupportedLocalesCount;
+}
+
+const char *matter_get_supported_locale_value(uint8_t index)
+{
+    if (index < sAmebaSupportedLocalesCount)
+    {
+        return sAmebaSupportedLocales[index];
+    }
+
+    if (index < sDefaultSupportedLocalesCount)
+    {
+        return sDefaultSupportedLocales[index];
+    }
+
+    return NULL;
+}
+
+/******************************************************
+ *           Time Format Localization Declaration
+ ******************************************************/
+
+void matter_init_calendar_type(void)
+{
+    size_t len = 0;
+    size_t max_size = MAX_CALENDAR_TYPE_COUNT;
+
+    if (getPref_bin_new(kCalendarTypeKey, kCalendarTypeKey, sAmebaCalendarTypes, max_size, &len) == DCT_SUCCESS)
+    {
+        if (len > 0 && len <= max_size)
+        {
+            for (int i = 0; i < len; i++)
+            {
+                if (sAmebaCalendarTypes[i] >= CALENDAR_UNKNOWN)
+                {
+                    len--;
+                }
+            }
+            sAmebaCalendarTypeCount = len;
+        }
+    }
+}
+
+size_t matter_get_calendar_type_count(void)
+{
+    return sAmebaCalendarTypeCount > 0 ? sAmebaCalendarTypeCount : sDefaultCalendarTypeCount;
+}
+
+bool matter_get_calendar_type_value(uint8_t index, uint8_t *output)
+{
+    if (output == NULL)
+    {
+        return false;
+    }
+
+    if (sAmebaCalendarTypeCount != 0)
+    {
+        *output = sAmebaCalendarTypes[index];
+    }
+    else
+    {
+        *output = sDefaultCalendarTypes[index];
+    }
+
+    return true;
+}
+
+bool matter_data_provider_set_key_value(const char *key, uint8_t *value, size_t size)
+{
+    if (key == NULL || value == NULL || size == 0)
+    {
+        return false;
+    }
+
+    deleteKey(key, key);
+
+    s32 ret = setPref_new(key, key, value, size);
+    return (ret == DCT_SUCCESS) ? true : false;
+}
+
+void matter_data_provider_init(void)
+{
+    // Please set the fixed label, supported locale and calendar type!
+#if AMEBA_DATA_PROVIDER_TEST
+    test_example_set_fixed_label();
+    test_example_set_supported_locale();
+    test_example_set_calendar_type();
+#endif
+    matter_init_supported_locale();
+    matter_init_calendar_type();
+}
+
+void matter_data_provider_deinit(void)
+{
+    matter_deinit_supported_locales();
+
+    sAmebaFixedLabelCount = 0;
+    memset(sAmebaFixedLabel, 0, sizeof(sAmebaFixedLabel));
+
+    sAmebaCalendarTypeCount = 0;
+    memset(sAmebaCalendarTypes, 0, sizeof(sAmebaCalendarTypes));
+}
+
+#if AMEBA_DATA_PROVIDER_TEST
+void test_example_set_fixed_label(void)
+{
+    matter_set_fixed_label(0, "room", "office");
+    matter_set_fixed_label(1, "orientation", "east");
+    matter_set_fixed_label(2, "floor", "3");
+    matter_set_fixed_label(3, "direction", "down");
+
+    sAmebaFixedLabelCount = 4;
+}
+
+void test_example_set_supported_locale(void)
+{
+    const char *sTestSupportedLocales[] =
+    {
+        "en-US",
+        "zh-CN",
+        "ja-JP"
+    };
+
+    size_t count = sizeof(sTestSupportedLocales) / sizeof(sTestSupportedLocales[0]);
+
+    size_t total_len = 0;
+    for (size_t i = 0; i < count; i++)
+    {
+        total_len += strlen(sTestSupportedLocales[i]) + 1;
+    }
+
+    char *buf = (char *)malloc(total_len);
+    if (buf == NULL)
+    {
+        printf("Failed to allocate buffer\n");
+        return;
+    }
+
+    char *ptr = buf;
+    for (size_t i = 0; i < count; i++)
+    {
+        size_t len = strlen(sTestSupportedLocales[i]) + 1;
+        memcpy(ptr, sTestSupportedLocales[i], len);
+        ptr += len;
+    }
+
+    if (matter_data_provider_set_key_value(kSupportedLocalesKey, (uint8_t *)buf, total_len) != true)
+    {
+        printf("Set supported locales failed\n");
+    }
+
+    free(buf);
+}
+
+void test_example_set_calendar_type(void)
+{
+    uint8_t sTestCalendarTypes[] = {CALENDAR_CHINESE, CALENDAR_TAIWANESE};
+
+    size_t count = sizeof(sTestCalendarTypes) / sizeof(sTestCalendarTypes[0]);
+
+    if (matter_data_provider_set_key_value(kCalendarTypeKey, sTestCalendarTypes, count) != true)
+    {
+        printf("Set calendar type failed\n");
+    }
+}
+#endif
+
+#ifdef __cplusplus
+}
+#endif

--- a/common/port/matter_data_providers.h
+++ b/common/port/matter_data_providers.h
@@ -1,0 +1,180 @@
+/*
+ *    This module is a confidential and proprietary property of RealTek and
+ *    possession or use of this module requires written permission of RealTek.
+ *
+ *    Copyright(c) 2025, Realtek Semiconductor Corporation. All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#ifndef MATTER_DATA_PROVIDERS_H
+#define MATTER_DATA_PROVIDERS_H
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+/******************************************************
+ *           Matter Data Providers Declaration
+ ******************************************************/
+
+#define AMEBA_DATA_PROVIDER_TEST    0
+
+#define MAX_FIXED_LABELS_COUNT      4
+#define MAX_CALENDAR_TYPE_COUNT     12
+#define MAX_ACTIVE_LOCALE_LENGTH    35
+#define MAX_LABEL_NAME_LENGTH       16
+#define MAX_LABEL_VALUE_LENGTH      16
+
+/******************************************************
+ *           Matter Data Providers Enumerate
+ ******************************************************/
+
+typedef enum
+{
+    CALENDAR_BUDDHIST  = 0x0,
+    CALENDAR_CHINESE   = 0x1,
+    CALENDAR_COPTIC    = 0x2,
+    CALENDAR_ETHIOPIAN = 0x3,
+    CALENDAR_GREGORIAN = 0x4,
+    CALENDAR_HEBREW    = 0x5,
+    CALENDAR_INDIAN    = 0x6,
+    CALENDAR_ISLAMIC   = 0x7,
+    CALENDAR_JAPANESE  = 0x8,
+    CALENDAR_KOREAN    = 0x9,
+    CALENDAR_PERSIAN   = 0xA,
+    CALENDAR_TAIWANESE = 0xB,
+    CALENDAR_UNKNOWN   = 0xC
+} CalenderTypeEnum;
+
+/******************************************************
+ *           Matter Data Providers Structure
+ ******************************************************/
+
+typedef struct
+{
+    char key[MAX_LABEL_NAME_LENGTH];
+    char value[MAX_LABEL_VALUE_LENGTH];
+    bool isSet;
+} ameba_fixed_label_t;
+
+/******************************************************
+ *           Matter Data Providers Function
+ ******************************************************/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Set a fixed label key-value pair at a specific index.
+ *
+ * @param index Index to store the label.
+ * @param key Label key name.
+ * @param value Label value.
+ * @return true if the label is set successfully, false otherwise.
+ */
+bool matter_set_fixed_label(uint8_t index, const char *key, const char *value);
+
+/**
+ * @brief Get the total number of fixed labels configured.
+ *
+ * @return Number of fixed labels.
+ */
+size_t matter_get_fixed_label_count(void);
+
+/**
+ * @brief Retrieve the fixed label key by index.
+ *
+ * @param index Index of the label.
+ * @return The key name if valid, NULL otherwise.
+ */
+const char *matter_get_fixed_label_name(uint8_t index);
+
+/**
+ * @brief Retrieve the fixed label value by index.
+ *
+ * @param index Index of the label.
+ * @return The value string if valid, NULL otherwise.
+ */
+const char *matter_get_fixed_label_value(uint8_t index);
+
+/**
+ * @brief Get the count of supported locales available.
+ *
+ * @return Number of supported locales.
+ */
+size_t matter_get_supported_locale_count(void);
+
+/**
+ * @brief Retrieve the supported locale value by index.
+ *
+ * @param index Index of the locale.
+ * @return Locale string if valid, NULL otherwise.
+ */
+const char *matter_get_supported_locale_value(uint8_t index);
+
+/**
+ * @brief Get the number of available calendar types.
+ *
+ * @return Number of supported calendar types.
+ */
+size_t matter_get_calendar_type_count(void);
+
+/**
+ * @brief Retrieve a calendar type value by index.
+ *
+ * @param index Index of the calendar type.
+ * @param output Pointer to store the calendar type value.
+ * @return true if the value is retrieved successfully, false otherwise.
+ */
+bool matter_get_calendar_type_value(uint8_t index, uint8_t *output);
+
+/**
+ * @brief Initialize the Ameba data provider for Matter.
+ *
+ * Prepares the Ameba platform's data provider, setting up any necessary resources
+ * for Matter data operations.
+ */
+void matter_data_provider_init(void);
+
+/**
+ * @brief Deinitialize the Ameba data provider for Matter.
+ *
+ * Cleans up and releases resources allocated by the Ameba data provider
+ * for Matter, ensuring proper shutdown.
+ */
+void matter_data_provider_deinit(void);
+
+#if AMEBA_DATA_PROVIDER_TEST
+/**
+ * @brief Test function to set example fixed labels.
+ */
+void test_example_set_fixed_label(void);
+
+/**
+ * @brief Test function to set example supported locales.
+ */
+void test_example_set_supported_locale(void);
+
+/**
+ * @brief Test function to set example calendar types.
+ */
+void test_example_set_calendar_type(void);
+#endif // AMEBA_DATA_PROVIDER_TEST
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // MATTER_DATA_PROVIDERS_H

--- a/core/matter_attribute_callbacks.cpp
+++ b/core/matter_attribute_callbacks.cpp
@@ -1,0 +1,35 @@
+/*
+ *    This module is a confidential and proprietary property of RealTek and
+ *    possession or use of this module requires written permission of RealTek.
+ *
+ *    Copyright(c) 2025, Realtek Semiconductor Corporation. All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#include <matter_attribute_callbacks.h>
+#include <app-common/zap-generated/attributes/Accessors.h>
+
+using namespace chip;
+using namespace chip::app;
+using namespace chip::app::Clusters;
+using Protocols::InteractionModel::Status;
+
+void AmebaDeviceManager::AmebaPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId,
+        uint8_t type, uint16_t size, uint8_t *value)
+{
+    switch (clusterId)
+    {
+    default:
+        break;
+    }
+}

--- a/core/matter_attribute_callbacks.h
+++ b/core/matter_attribute_callbacks.h
@@ -1,0 +1,57 @@
+/*
+ *    This module is a confidential and proprietary property of RealTek and
+ *    possession or use of this module requires written permission of RealTek.
+ *
+ *    Copyright(c) 2025, Realtek Semiconductor Corporation. All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#pragma once
+
+#include <app/util/af-types.h>
+#include <lib/core/CHIPCore.h>
+#include <lib/core/CHIPError.h>
+
+namespace chip {
+namespace app {
+namespace Clusters {
+
+class AmebaDeviceManager
+{
+public:
+    AmebaDeviceManager(EndpointId endpointId) : mEndpointId(endpointId) {}
+
+    static void InitInstance(EndpointId aEndpointId)
+    {
+        if (mInstance == nullptr)
+        {
+            mInstance = new AmebaDeviceManager(aEndpointId);
+        }
+    };
+
+    static AmebaDeviceManager *GetInstance()
+    {
+        return mInstance;
+    };
+
+    void AmebaPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId,
+                                          uint8_t type, uint16_t size, uint8_t *value);
+
+private:
+    inline static AmebaDeviceManager *mInstance;
+    EndpointId mEndpointId;
+};
+
+} // namespace Clusters
+} // namespace app
+} // namespace chip

--- a/core/matter_core.cpp
+++ b/core/matter_core.cpp
@@ -2,6 +2,7 @@
 #include <stdint.h>
 
 #include <matter_core.h>
+#include <matter_data_providers.h>
 #include <matter_events.h>
 #include <matter_interaction.h>
 #include <matter_ota_initializer.h>
@@ -88,10 +89,11 @@ DeferredAttribute gDeferredAttributeArray[] =
 
 // Deferred persistence will be auto-initialized as soon as the default persistence is initialized
 DefaultAttributePersistenceProvider gSimpleAttributePersistence;
-DeferredAttributePersistenceProvider gDeferredAttributePersister(gSimpleAttributePersistence, Span<DeferredAttribute>(gDeferredAttributeArray, 6), System::Clock::Milliseconds32(5000));
+DeferredAttributePersistenceProvider gDeferredAttributePersister(gSimpleAttributePersistence, Span<DeferredAttribute>(gDeferredAttributeArray, 6),
+        System::Clock::Milliseconds32(5000));
 
 app::Clusters::NetworkCommissioning::Instance
-    sWiFiNetworkCommissioningInstance(0 /* Endpoint Id */, &(NetworkCommissioning::AmebaWiFiDriver::GetInstance()));
+sWiFiNetworkCommissioningInstance(0 /* Endpoint Id */, &(NetworkCommissioning::AmebaWiFiDriver::GetInstance()));
 
 chip::DeviceLayer::DeviceInfoProviderImpl gExampleDeviceInfoProvider;
 chip::DeviceLayer::FactoryDataProvider mFactoryDataProvider;
@@ -139,7 +141,7 @@ void matter_core_device_callback_internal(const ChipDeviceEvent *event, intptr_t
         break;
     case DeviceEventType::kInterfaceIpAddressChanged:
         if ((event->InterfaceIpAddressChanged.Type == InterfaceIpChangeType::kIpV4_Assigned) ||
-            (event->InterfaceIpAddressChanged.Type == InterfaceIpChangeType::kIpV6_Assigned))
+                (event->InterfaceIpAddressChanged.Type == InterfaceIpChangeType::kIpV6_Assigned))
         {
             // MDNS server restart on any ip assignment: if link local ipv6 is configured, that
             // will not trigger a 'internet connectivity change' as there is no internet
@@ -226,8 +228,8 @@ void matter_core_init_server(intptr_t context)
 
 #if defined(CHIP_ENABLE_AMEBA_TERMS_AND_CONDITION) && (CHIP_ENABLE_AMEBA_TERMS_AND_CONDITION == 1)
     const Optional<app::TermsAndConditions> termsAndConditions = Optional<app::TermsAndConditions>(
-        app::TermsAndConditions(CHIP_AMEBA_TC_REQUIRED_ACKNOWLEDGEMENTS, CHIP_AMEBA_TC_MIN_REQUIRED_VERSION));
-    PersistentStorageDelegate & persistentStorageDelegate = Server::GetInstance().GetPersistentStorage();
+                app::TermsAndConditions(CHIP_AMEBA_TC_REQUIRED_ACKNOWLEDGEMENTS, CHIP_AMEBA_TC_MIN_REQUIRED_VERSION));
+    PersistentStorageDelegate &persistentStorageDelegate = Server::GetInstance().GetPersistentStorage();
     chip::app::TermsAndConditionsManager::GetInstance()->Init(&persistentStorageDelegate, termsAndConditions);
 #endif
 
@@ -325,6 +327,8 @@ CHIP_ERROR matter_core_start(void)
 #endif
 
     wifi_set_autoreconnect(0); //Disable default autoreconnect
+
+    matter_data_provider_init(); // initialize data
 
     return matter_core_init();
 }

--- a/core/matter_device_utils.cpp
+++ b/core/matter_device_utils.cpp
@@ -26,15 +26,15 @@ uint8_t matter_get_total_operational_hour(uint32_t *totalOperationalHours)
     }
 
     CHIP_ERROR err;
-    DiagnosticDataProvider & diagProvider = chip::DeviceLayer::GetDiagnosticDataProviderImpl();
+    DiagnosticDataProvider &diagProvider = chip::DeviceLayer::GetDiagnosticDataProviderImpl();
 
     if (&diagProvider != NULL)
     {
         err = diagProvider.GetTotalOperationalHours(*totalOperationalHours);
         if (err != CHIP_NO_ERROR)
         {
-             printf("%s: GetTotalOperationalHours Failed err=%d\n", __FUNCTION__, err);
-             return -1;
+            printf("%s: GetTotalOperationalHours Failed err=%d\n", __FUNCTION__, err);
+            return -1;
         }
     }
     else
@@ -60,7 +60,7 @@ static void matter_op_hours_task(void *pvParameters)
     char key[] = "temp_hour";
 
     // 1. Check if "temp_hour" exist in NVS
-    if (checkExist(key, key) != DCT_SUCCESS)
+    if (checkExist(key, key) != true)
     {
         // 2. If "temp_hour" exist, get "temp_hour" and set as "total_hour" into NVS
         if (getPref_u32_new(key, key, &prev_hour) == DCT_SUCCESS)
@@ -76,7 +76,6 @@ static void matter_op_hours_task(void *pvParameters)
         }
         else
         {
-            printf("getPref_u32_new: %s not found\n", key);
             goto loop;
         }
     }
@@ -106,7 +105,7 @@ loop:
 
 void matter_op_hours(void)
 {
-    if (xTaskCreate(matter_op_hours_task, ((const char*)"matter_op_hours_task"), 2048, NULL, tskIDLE_PRIORITY + 1, NULL) != pdPASS)
+    if (xTaskCreate(matter_op_hours_task, ((const char *)"matter_op_hours_task"), 2048, NULL, tskIDLE_PRIORITY + 1, NULL) != pdPASS)
     {
         printf("\n\r%s xTaskCreate(matter_op_hours) failed", __FUNCTION__);
     }

--- a/core/matter_test_event_trigger.cpp
+++ b/core/matter_test_event_trigger.cpp
@@ -1,0 +1,56 @@
+/*
+ *    This module is a confidential and proprietary property of RealTek and
+ *    possession or use of this module requires written permission of RealTek.
+ *
+ *    Copyright(c) 2025, Realtek Semiconductor Corporation. All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <matter_test_event_trigger.h>
+
+#include <app/util/af-types.h>
+#include <lib/core/CHIPCore.h>
+#include <lib/core/CHIPError.h>
+#include <lib/support/CodeUtils.h>
+#include <test_event_trigger/AmebaTestEventTriggerDelegate.h>
+
+using namespace chip;
+using namespace chip::app;
+using namespace chip::app::Clusters;
+using namespace chip::app::Clusters::DeviceEnergyManagement;
+
+bool AmebaHandleGlobalTestEventTrigger(uint64_t eventTrigger)
+{
+    ChipLogDetail(Support, "Received Event Trigger: 0x%016llx, not handled!", eventTrigger);
+    return false;
+}
+
+namespace chip {
+
+bool AmebaTestEventTriggerDelegate::DoesEnableKeyMatch(const ByteSpan &enableKey) const
+{
+    return !mEnableKey.empty() && mEnableKey.data_equal(enableKey);
+}
+
+CHIP_ERROR AmebaTestEventTriggerDelegate::HandleEventTrigger(uint64_t eventTrigger)
+{
+    eventTrigger = clearEndpointInEventTrigger(eventTrigger);
+    if (AmebaHandleGlobalTestEventTrigger(eventTrigger))
+    {
+        return CHIP_NO_ERROR;
+    }
+    return CHIP_ERROR_INVALID_ARGUMENT;
+}
+
+} // namespace chip

--- a/core/matter_test_event_trigger.h
+++ b/core/matter_test_event_trigger.h
@@ -1,0 +1,26 @@
+/*
+ *    This module is a confidential and proprietary property of RealTek and
+ *    possession or use of this module requires written permission of RealTek.
+ *
+ *    Copyright(c) 2025, Realtek Semiconductor Corporation. All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#pragma once
+
+#include <stdint.h>
+
+#include <app/TestEventTriggerDelegate.h>
+#include <lib/core/CHIPError.h>
+#include <lib/support/CodeUtils.h>
+#include <lib/support/Span.h>

--- a/examples/chiptest/ameba_main_task.cpp
+++ b/examples/chiptest/ameba_main_task.cpp
@@ -17,20 +17,22 @@
 
 #include <CHIPDeviceManager.h>
 
+#include <matter_attribute_callbacks.h>
 #include <matter_command.h>
+
 #include <device_energy_management/ameba_energy_management_common_main.h>
 #include <microwave_oven/ameba_microwave_oven_device.h>
 #include <valve_control/ameba_valve_control_delegate.h>
 #include <water_heater_management/ameba_water_heater_management_main.h>
 #include <mode_select/ameba_modes_manager.h>
 #include <temperature_levels/ameba_temperature_levels.h>
+#include <app/clusters/valve-configuration-and-control-server/valve-configuration-and-control-server.h>
 #if CONFIG_ENABLE_AMEBA_TEST_EVENT_TRIGGER
 #include <app/clusters/smoke-co-alarm-server/SmokeCOTestEventTriggerHandler.h>
 #include <app/clusters/water-heater-management-server/WaterHeaterManagementTestEventTriggerHandler.h>
 #include <test_event_trigger/AmebaTestEventTriggerDelegate.h>
 #include <app/server/Server.h>
 #endif
-#include <app/clusters/valve-configuration-and-control-server/valve-configuration-and-control-server.h>
 
 using namespace chip;
 using namespace chip::app;
@@ -45,8 +47,14 @@ app::Clusters::ModeSelect::StaticSupportedModesManager sStaticSupportedModesMana
 app::Clusters::ValveConfigurationAndControl::ValveControlDelegate sValveDelegate;
 } // namespace
 
+static void InitAmebaDeviceManager(void)
+{
+    AmebaDeviceManager::InitInstance(1);  // for Endpoint 1
+}
+
 void AppTaskInit(void)
 {
+    InitAmebaDeviceManager();
 #if CONFIG_ENABLE_CHIP_SHELL
     InitManualOperation();
 #endif

--- a/examples/chiptest/example_matter.c
+++ b/examples/chiptest/example_matter.c
@@ -10,6 +10,7 @@
 #include <diagnostic_logs/ameba_logging_faultlog.h>
 #include <diagnostic_logs/ameba_logging_redirect_wrapper.h>
 #endif
+#include <matter_data_providers.h>
 
 #if defined(CONFIG_ENABLE_AMEBA_OPHOURS) && (CONFIG_ENABLE_AMEBA_OPHOURS == 1)
 extern void matter_op_hours_wrapper(void);
@@ -42,6 +43,8 @@ static void example_matter_task_thread(void *pvParameters)
 #endif
 
     ChipTest();
+
+    matter_data_provider_init();
 
 #if defined(CONFIG_ENABLE_AMEBA_OPHOURS) && (CONFIG_ENABLE_AMEBA_OPHOURS == 1)
     matter_op_hours_wrapper();

--- a/project/amebad/make/application/Makefile
+++ b/project/amebad/make/application/Makefile
@@ -30,6 +30,7 @@ CSRC += $(BTDIR)/matter_blemgr_common.c
 
 # Matter Common code porting
 CSRC += $(PORTDIR)/DsoHandle.c \
+        $(PORTDIR)/matter_data_providers.c \
         $(PORTDIR)/matter_dcts.c \
         $(PORTDIR)/matter_lwip.c \
         $(PORTDIR)/matter_timers.c \

--- a/project/amebad/make/chip_main/all_clusters_app/Makefile
+++ b/project/amebad/make/chip_main/all_clusters_app/Makefile
@@ -54,7 +54,8 @@ CHIP_ENABLE_OTA_REQUESTOR = $(shell grep 'chip_enable_ota_requestor' $(OUTPUT_DI
 GLOBAL_CFLAGS += -DCHIP_PROJECT=1
 GLOBAL_CFLAGS += -DSTD_PRINTF=1
 GLOBAL_CFLAGS += -DCHIP_ADDRESS_RESOLVE_IMPL_INCLUDE_HEADER=\"lib/address_resolve/AddressResolve_DefaultImpl.h\"
-GLOBAL_CFLAGS += -DCHIP_AMEBA_APP_TASK=1
+GLOBAL_CFLAGS += -DCONFIG_ENABLE_AMEBA_APP_TASK=1
+GLOBAL_CFLAGS += -DCONFIG_ENABLE_AMEBA_ATTRIBUTE_CALLBACK=1
 
 # matter blemgr adapter options
 ifeq ($(CONFIG_BLE_MATTER_ADAPTER),y)
@@ -78,7 +79,6 @@ IFLAGS += -I$(BASEDIR)/component/common/application/matter/examples/chiptest
 #                              SOURCE FILE LIST                               #
 #*****************************************************************************#
 # all-clusters-app clusters source files
-CPPSRC += $(MATTER_DIR)/drivers/matter_consoles/matter_command.cpp
 CPPSRC += $(MATTER_DRIVER)/action/ameba_bridged_actions_stubs.cpp
 CPPSRC += $(MATTER_DRIVER)/air_quality/ameba_air_quality_instance.cpp
 CPPSRC += $(MATTER_DRIVER)/device_energy_management/ameba_concentration_measurement_instances.cpp
@@ -125,7 +125,9 @@ CPPSRC += $(MATTER_DRIVER)/water_heater_management/ameba_water_heater_management
 CPPSRC += $(MATTER_DRIVER)/water_heater_management/ameba_water_heater_management_main.cpp
 CPPSRC += $(MATTER_DRIVER)/water_heater_management/ameba_water_heater_management_manufacturer.cpp
 CPPSRC += $(MATTER_DRIVER)/water_heater_mode/ameba_water_heater_mode.cpp
-CPPSRC += $(BASEDIR)/component/common/application/matter/examples/chiptest/ameba_main_task.cpp
+CPPSRC += $(MATTER_DIR)/drivers/matter_consoles/matter_command.cpp
+CPPSRC += $(MATTER_DIR)/core/matter_attribute_callbacks.cpp
+CPPSRC += $(MATTER_DIR)/examples/chiptest/ameba_main_task.cpp
 
 CPPSRC += $(CHIPDIR)/examples/all-clusters-app/ameba/main/chipinterface.cpp
 CPPSRC += $(CHIPDIR)/examples/all-clusters-app/ameba/main/BindingHandler.cpp
@@ -139,7 +141,6 @@ ifeq ($(CHIP_ENABLE_OTA_REQUESTOR), true)
 CPPSRC += $(CHIPDIR)/examples/platform/ameba/ota/OTAInitializer.cpp
 endif
 CPPSRC += $(CHIPDIR)/examples/platform/ameba/shell/launch_shell.cpp
-CPPSRC += $(CHIPDIR)/examples/platform/ameba/test_event_trigger/AmebaTestEventTriggerDelegate.cpp
 
 #*****************************************************************************#
 #                              OBJECT FILE LIST                               #

--- a/project/amebad/make/chip_main/matter_main_sources.mk
+++ b/project/amebad/make/chip_main/matter_main_sources.mk
@@ -38,8 +38,6 @@ IFLAGS += -I$(CHIPDIR)/zzz_generated/app-common
 CSRC += $(CHIPDIR)/examples/platform/ameba/route_hook/ameba_route_hook.c
 CSRC += $(CHIPDIR)/examples/platform/ameba/route_hook/ameba_route_table.c
 
-CPPSRC += $(CHIPDIR)/examples/providers/DeviceInfoProviderImpl.cpp
-
 # connectedhomeip - src - app
 CPPSRC += $(CHIPDIR)/src/app/SafeAttributePersistenceProvider.cpp
 CPPSRC += $(CHIPDIR)/src/app/StorageDelegateWrapper.cpp
@@ -61,8 +59,9 @@ CPPSRC += $(CHIPDIR)/src/app/server/TermsAndConditionsManager.cpp
 endif
 
 # connectedhomeip - src - app - server-cluster
-CPPSRC += $(CHIPDIR)/src/app/server-cluster/ServerClusterInterface.cpp
+CPPSRC += $(CHIPDIR)/src/app/server-cluster/AttributeListBuilder.cpp
 CPPSRC += $(CHIPDIR)/src/app/server-cluster/DefaultServerCluster.cpp
+CPPSRC += $(CHIPDIR)/src/app/server-cluster/ServerClusterInterface.cpp
 
 # connectedhomeip - src - app - util
 CPPSRC += $(CHIPDIR)/src/app/util/attribute-storage.cpp
@@ -104,3 +103,4 @@ CPPSRC += $(MATTER_DIR)/api/matter_api.cpp
 
 # matter - core
 CPPSRC += $(MATTER_DIR)/core/matter_device_utils.cpp
+CPPSRC += $(MATTER_DIR)/core/matter_test_event_trigger.cpp # Not using AmebaTestEventTriggerDelegate.cpp

--- a/project/amebaz2/Makefile.include.app.list
+++ b/project/amebaz2/Makefile.include.app.list
@@ -35,6 +35,7 @@ SRC_C += ../../../component/common/application/matter/common/atcmd/atcmd_matter.
 SRC_C += ../../../component/common/application/matter/common/bluetooth/matter_blemgr_common.c
 
 #matter - app - port
+SRC_C += ../../../component/common/application/matter/common/port/matter_data_providers.c
 SRC_C += ../../../component/common/application/matter/common/port/matter_dcts.c
 SRC_C += ../../../component/common/application/matter/common/port/matter_fs.c
 SRC_C += ../../../component/common/application/matter/common/port/matter_lwip.c

--- a/project/amebaz2/make/all_clusters/lib_chip_main.mk
+++ b/project/amebaz2/make/all_clusters/lib_chip_main.mk
@@ -77,7 +77,6 @@ SRC_C =
 SRC_CPP =
 
 # all-clusters-app clusters source files
-SRC_CPP += $(SDKROOTDIR)/component/common/application/matter/drivers/matter_consoles/matter_command.cpp
 SRC_CPP += $(MATTER_DRIVER)/action/ameba_bridged_actions_stubs.cpp
 SRC_CPP += $(MATTER_DRIVER)/air_quality/ameba_air_quality_instance.cpp
 SRC_CPP += $(MATTER_DRIVER)/device_energy_management/ameba_concentration_measurement_instances.cpp
@@ -124,7 +123,9 @@ SRC_CPP += $(MATTER_DRIVER)/water_heater_management/ameba_water_heater_managemen
 SRC_CPP += $(MATTER_DRIVER)/water_heater_management/ameba_water_heater_management_main.cpp
 SRC_CPP += $(MATTER_DRIVER)/water_heater_management/ameba_water_heater_management_manufacturer.cpp
 SRC_CPP += $(MATTER_DRIVER)/water_heater_mode/ameba_water_heater_mode.cpp
-SRC_CPP += $(SDKROOTDIR)/component/common/application/matter/examples/chiptest/ameba_main_task.cpp
+SRC_CPP += $(MATTER_DIR)/drivers/matter_consoles/matter_command.cpp
+SRC_CPP += $(MATTER_DIR)/core/matter_attribute_callbacks.cpp
+SRC_CPP += $(MATTER_DIR)/examples/chiptest/ameba_main_task.cpp
 
 # all-clusters-app ameba source files
 SRC_CPP += $(CHIPDIR)/examples/all-clusters-app/ameba/main/chipinterface.cpp
@@ -139,7 +140,6 @@ ifeq ($(CHIP_ENABLE_OTA_REQUESTOR), true)
 SRC_CPP += $(CHIPDIR)/examples/platform/ameba/ota/OTAInitializer.cpp
 endif
 SRC_CPP += $(CHIPDIR)/examples/platform/ameba/shell/launch_shell.cpp
-SRC_CPP += $(CHIPDIR)/examples/platform/ameba/test_event_trigger/AmebaTestEventTriggerDelegate.cpp
 
 # Matter Main Common Source file list
 # -------------------------------------------------------------------
@@ -181,7 +181,8 @@ CFLAGS += -DV8M_STKOVF
 include $(MATTER_INCLUDE)
 
 CFLAGS += -DCHIP_PROJECT=1
-CFLAGS += -DCHIP_AMEBA_APP_TASK=1
+CFLAGS += -DCONFIG_ENABLE_AMEBA_APP_TASK=1
+CFLAGS += -DCONFIG_ENABLE_AMEBA_ATTRIBUTE_CALLBACK=1
 
 # Matter Shell Flags
 ifeq ($(CHIP_ENABLE_SHELL), true)

--- a/project/amebaz2/make/matter_main_sources.mk
+++ b/project/amebaz2/make/matter_main_sources.mk
@@ -23,8 +23,6 @@ INCLUDES += -I$(CHIPDIR)/zzz_generated/app-common
 SRC_C += $(CHIPDIR)/examples/platform/ameba/route_hook/ameba_route_hook.c
 SRC_C += $(CHIPDIR)/examples/platform/ameba/route_hook/ameba_route_table.c
 
-SRC_CPP += $(CHIPDIR)/examples/providers/DeviceInfoProviderImpl.cpp
-
 # connectedhomeip - src - app
 SRC_CPP += $(CHIPDIR)/src/app/SafeAttributePersistenceProvider.cpp
 SRC_CPP += $(CHIPDIR)/src/app/StorageDelegateWrapper.cpp
@@ -46,8 +44,9 @@ SRC_CPP += $(CHIPDIR)/src/app/server/TermsAndConditionsManager.cpp
 endif
 
 # connectedhomeip - src - app - server-cluster
-SRC_CPP += $(CHIPDIR)/src/app/server-cluster/ServerClusterInterface.cpp
+SRC_CPP += $(CHIPDIR)/src/app/server-cluster/AttributeListBuilder.cpp
 SRC_CPP += $(CHIPDIR)/src/app/server-cluster/DefaultServerCluster.cpp
+SRC_CPP += $(CHIPDIR)/src/app/server-cluster/ServerClusterInterface.cpp
 
 # connectedhomeip - src - app - util
 SRC_CPP += $(CHIPDIR)/src/app/util/attribute-storage.cpp
@@ -90,6 +89,7 @@ SRC_CPP += $(MATTER_DIR)/api/matter_log_api.cpp
 
 # matter - core
 SRC_CPP += $(MATTER_DIR)/core/matter_device_utils.cpp
+SRC_CPP += $(MATTER_DIR)/core/matter_test_event_trigger.cpp # Not using AmebaTestEventTriggerDelegate.cpp
 
 # matter - drivers
 SRC_CPP += $(MATTER_DIR)/drivers/matter_drivers/diagnostic_logs/ameba_diagnosticlogs_provider_delegate_impl.cpp

--- a/project/amebaz2plus/Makefile.include.app.list
+++ b/project/amebaz2plus/Makefile.include.app.list
@@ -35,6 +35,7 @@ SRC_C += ../../../component/common/application/matter/common/atcmd/atcmd_matter.
 SRC_C += ../../../component/common/application/matter/common/bluetooth/matter_blemgr_common.c
 
 #matter - app - port
+SRC_C += ../../../component/common/application/matter/common/port/matter_data_providers.c
 SRC_C += ../../../component/common/application/matter/common/port/matter_dcts.c
 SRC_C += ../../../component/common/application/matter/common/port/matter_fs.c
 SRC_C += ../../../component/common/application/matter/common/port/matter_lwip.c

--- a/project/amebaz2plus/make/all_clusters/lib_chip_main.mk
+++ b/project/amebaz2plus/make/all_clusters/lib_chip_main.mk
@@ -77,7 +77,6 @@ SRC_C =
 SRC_CPP =
 
 # all-clusters-app clusters source files
-SRC_CPP += $(SDKROOTDIR)/component/common/application/matter/drivers/matter_consoles/matter_command.cpp
 SRC_CPP += $(MATTER_DRIVER)/action/ameba_bridged_actions_stubs.cpp
 SRC_CPP += $(MATTER_DRIVER)/air_quality/ameba_air_quality_instance.cpp
 SRC_CPP += $(MATTER_DRIVER)/device_energy_management/ameba_concentration_measurement_instances.cpp
@@ -124,7 +123,9 @@ SRC_CPP += $(MATTER_DRIVER)/water_heater_management/ameba_water_heater_managemen
 SRC_CPP += $(MATTER_DRIVER)/water_heater_management/ameba_water_heater_management_main.cpp
 SRC_CPP += $(MATTER_DRIVER)/water_heater_management/ameba_water_heater_management_manufacturer.cpp
 SRC_CPP += $(MATTER_DRIVER)/water_heater_mode/ameba_water_heater_mode.cpp
-SRC_CPP += $(SDKROOTDIR)/component/common/application/matter/examples/chiptest/ameba_main_task.cpp
+SRC_CPP += $(MATTER_DIR)/drivers/matter_consoles/matter_command.cpp
+SRC_CPP += $(MATTER_DIR)/core/matter_attribute_callbacks.cpp
+SRC_CPP += $(MATTER_DIR)/examples/chiptest/ameba_main_task.cpp
 
 # all-clusters-app ameba source files
 SRC_CPP += $(CHIPDIR)/examples/all-clusters-app/ameba/main/chipinterface.cpp
@@ -139,7 +140,6 @@ ifeq ($(CHIP_ENABLE_OTA_REQUESTOR), true)
 SRC_CPP += $(CHIPDIR)/examples/platform/ameba/ota/OTAInitializer.cpp
 endif
 SRC_CPP += $(CHIPDIR)/examples/platform/ameba/shell/launch_shell.cpp
-SRC_CPP += $(CHIPDIR)/examples/platform/ameba/test_event_trigger/AmebaTestEventTriggerDelegate.cpp
 
 # Matter Main Common Source file list
 # -------------------------------------------------------------------
@@ -181,7 +181,8 @@ CFLAGS += -DV8M_STKOVF
 include $(MATTER_INCLUDE)
 
 CFLAGS += -DCHIP_PROJECT=1
-CFLAGS += -DCHIP_AMEBA_APP_TASK=1
+CFLAGS += -DCONFIG_ENABLE_AMEBA_APP_TASK=1
+CFLAGS += -DCONFIG_ENABLE_AMEBA_ATTRIBUTE_CALLBACK=1
 
 # Matter Shell Flags
 ifeq ($(CHIP_ENABLE_SHELL), true)

--- a/project/amebaz2plus/make/matter_main_sources.mk
+++ b/project/amebaz2plus/make/matter_main_sources.mk
@@ -22,9 +22,6 @@ INCLUDES += -I$(CHIPDIR)/zzz_generated/app-common
 # connectedhomeip - examples
 SRC_C += $(CHIPDIR)/examples/platform/ameba/route_hook/ameba_route_hook.c
 SRC_C += $(CHIPDIR)/examples/platform/ameba/route_hook/ameba_route_table.c
-
-SRC_CPP += $(CHIPDIR)/examples/providers/DeviceInfoProviderImpl.cpp
-
 # connectedhomeip - src - app
 SRC_CPP += $(CHIPDIR)/src/app/SafeAttributePersistenceProvider.cpp
 SRC_CPP += $(CHIPDIR)/src/app/StorageDelegateWrapper.cpp
@@ -46,8 +43,9 @@ SRC_CPP += $(CHIPDIR)/src/app/server/TermsAndConditionsManager.cpp
 endif
 
 # connectedhomeip - src - app - server-cluster
-SRC_CPP += $(CHIPDIR)/src/app/server-cluster/ServerClusterInterface.cpp
+SRC_CPP += $(CHIPDIR)/src/app/server-cluster/AttributeListBuilder.cpp
 SRC_CPP += $(CHIPDIR)/src/app/server-cluster/DefaultServerCluster.cpp
+SRC_CPP += $(CHIPDIR)/src/app/server-cluster/ServerClusterInterface.cpp
 
 # connectedhomeip - src - app - util
 SRC_CPP += $(CHIPDIR)/src/app/util/attribute-storage.cpp
@@ -90,6 +88,7 @@ SRC_CPP += $(MATTER_DIR)/api/matter_log_api.cpp
 
 # matter - core
 SRC_CPP += $(MATTER_DIR)/core/matter_device_utils.cpp
+SRC_CPP += $(MATTER_DIR)/core/matter_test_event_trigger.cpp # Not using AmebaTestEventTriggerDelegate.cpp
 
 # matter - drivers
 SRC_CPP += $(MATTER_DIR)/drivers/matter_drivers/diagnostic_logs/ameba_diagnosticlogs_provider_delegate_impl.cpp

--- a/tools/docker/amebad/Dockerfile
+++ b/tools/docker/amebad/Dockerfile
@@ -3,7 +3,7 @@ FROM ameba-rtos-matter:common
 
 # Redefine following build arguments to respective repo and tag/branch
 ARG AMEBA_MATTER_REPO=https://github.com/xshuqun/ameba-rtos-matter.git
-ARG TAG_NAME=ameba/update_sdk_250704_main
+ARG TAG_NAME=ameba/update_sdk_250724
 
 # Define fixed build arguments
 ARG AMBD_REPO=https://github.com/Ameba-AIoT/ameba-rtos-d.git

--- a/tools/docker/amebaz2/Dockerfile
+++ b/tools/docker/amebaz2/Dockerfile
@@ -3,7 +3,7 @@ FROM ameba-rtos-matter:common
 
 # Redefine following build arguments to respective repo and tag/branch
 ARG AMEBA_MATTER_REPO=https://github.com/xshuqun/ameba-rtos-matter.git
-ARG TAG_NAME=ameba/update_sdk_250704_main
+ARG TAG_NAME=ameba/update_sdk_250724
 
 # Define fixed build arguments
 ARG AMBZ2_REPO=https://github.com/Ameba-AIoT/ameba-rtos-z2.git


### PR DESCRIPTION
This PR addresses:

* Added matter_data_providers.c/.h for handling device info provider.
* Added matter_attribute_callbacks.cpp/.h for handling attribute callbacks.
* Added matter_test_event_trigger.cpp/.h for test event trigger functionality.
* Added initializing of data providers when Matter starts.
* Added initializing of attribute callback only for all-clusters-app.
* Fixed checkExist() return value.

Verification:
* Data providers shall be was checked with fixed label, localization configuration and time format localization cluster command.
* Event trigger has been moved from connectedhomeip to ameba-rtos-matter only, CI verification needed.
* Attribute callback currently is empty function, will need to add in all the attributes to handle in the next PR.