### PR TITLE
[amebaz2][amebaz2plus] mbedtls directory declaration part 1

### DIFF
--- a/project/amebaz2/Makefile.include.app.list
+++ b/project/amebaz2/Makefile.include.app.list
@@ -1,127 +1,123 @@
 include $(MATTER_INCLUDE)
 
-ifeq ($(MBEDTLS_DIR_SELECTION), matter)
-MBEDTLS_DIR = $(MATTER_MBEDTLS_DIR)
-else
-MBEDTLS_DIR = $(DEFAULT_MBEDTLS_DIR)
-endif
+
 
 # Matter Include file list
 # -------------------------------------------------------------------
 
-INCLUDES += -I../../../component/common/application/matter/api
-INCLUDES += -I../../../component/common/application/matter/common/bluetooth
-INCLUDES += -I../../../component/common/application/matter/common/include
-INCLUDES += -I../../../component/common/application/matter/common/lwip/include
-INCLUDES += -I../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/include
-INCLUDES += -I../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/include/lwip
-INCLUDES += -I../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/port/realtek
-INCLUDES += -I../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/port/realtek/include
-INCLUDES += -I../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/port/realtek/freertos
-INCLUDES += -I../../../component/common/application/matter/common/mbedtls
+INCLUDES += -I$(MATTER_DIR)/api
+INCLUDES += -I$(MATTER_DIR)/common/bluetooth
+INCLUDES += -I$(MATTER_DIR)/common/include
+INCLUDES += -I$(MATTER_DIR)/common/lwip/include
+INCLUDES += -I$(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/include
+INCLUDES += -I$(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/include/lwip
+INCLUDES += -I$(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/port/realtek
+INCLUDES += -I$(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/port/realtek/include
+INCLUDES += -I$(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/port/realtek/freertos
+INCLUDES += -I$(MATTER_DIR)/common/mbedtls
 INCLUDES += -I${MBEDTLS_DIR}/$(MBEDTLS_VERSION)/include
 INCLUDES += -I${MBEDTLS_DIR}/$(MBEDTLS_VERSION)/include/mbedtls
 INCLUDES += -I${MBEDTLS_DIR}/$(MBEDTLS_VERSION)/library
-INCLUDES += -I../../../component/common/application/matter/common/port
-INCLUDES += -I../../../component/common/application/matter/common/protobuf
-INCLUDES += -I../../../component/common/application/matter/common/protobuf/nanopb
-INCLUDES += -I../../../component/common/application/matter/core
-INCLUDES += -I../../../component/common/application/matter/drivers/device
-INCLUDES += -I../../../component/common/application/matter/drivers/matter_consoles
-INCLUDES += -I../../../component/common/application/matter/drivers/matter_drivers
-INCLUDES += -I../../../component/common/application/matter/examples
+INCLUDES += -I$(MATTER_DIR)/common/port
+INCLUDES += -I$(MATTER_DIR)/common/protobuf
+INCLUDES += -I$(MATTER_DIR)/common/protobuf/nanopb
+INCLUDES += -I$(MATTER_DIR)/core
+INCLUDES += -I$(MATTER_DIR)/drivers/device
+INCLUDES += -I$(MATTER_DIR)/drivers/matter_consoles
+INCLUDES += -I$(MATTER_DIR)/drivers/matter_drivers
+INCLUDES += -I$(MATTER_DIR)/examples
 
 # Source file list
 # -------------------------------------------------------------------
 
 #matter - app - atcmd
-SRC_C += ../../../component/common/application/matter/common/atcmd/atcmd_matter.c
+SRC_C += $(MATTER_DIR)/common/atcmd/atcmd_matter.c
 
 #matter - app - bluetooth
-SRC_C += ../../../component/common/application/matter/common/bluetooth/matter_blemgr_common.c
+SRC_C += $(MATTER_DIR)/common/bluetooth/matter_blemgr_common.c
 
 #matter - app - port
-SRC_C += ../../../component/common/application/matter/common/port/matter_dcts.c
-SRC_C += ../../../component/common/application/matter/common/port/matter_fs.c
-SRC_C += ../../../component/common/application/matter/common/port/matter_lwip.c
-SRC_C += ../../../component/common/application/matter/common/port/matter_ota.c
-SRC_C += ../../../component/common/application/matter/common/port/matter_timers.c
-SRC_C += ../../../component/common/application/matter/common/port/matter_utils.c
-SRC_C += ../../../component/common/application/matter/common/port/matter_wifis.c
+SRC_C += $(MATTER_DIR)/common/port/matter_dcts.c
+SRC_C += $(MATTER_DIR)/common/port/matter_fs.c
+SRC_C += $(MATTER_DIR)/common/port/matter_lwip.c
+SRC_C += $(MATTER_DIR)/common/port/matter_ota.c
+SRC_C += $(MATTER_DIR)/common/port/matter_timers.c
+SRC_C += $(MATTER_DIR)/common/port/matter_utils.c
+SRC_C += $(MATTER_DIR)/common/port/matter_wifis.c
 
 #matter - app - mbedtls
-SRC_C += ../../../component/common/application/matter/common/mbedtls/net_sockets.c
+SRC_C += $(MATTER_DIR)/common/mbedtls/net_sockets.c
 
 #matter - app - protobuf
-SRC_C += ../../../component/common/application/matter/common/protobuf/ameba_factory.pb.c
-SRC_C += ../../../component/common/application/matter/common/protobuf/nanopb/pb_encode.c  # The nanopb encoder
-SRC_C += ../../../component/common/application/matter/common/protobuf/nanopb/pb_decode.c  # The nanopb decoder
-SRC_C += ../../../component/common/application/matter/common/protobuf/nanopb/pb_common.c  # The nanopb common parts
+SRC_C += $(MATTER_DIR)/common/protobuf/ameba_factory.pb.c
+SRC_C += $(MATTER_DIR)/common/protobuf/nanopb/pb_encode.c  # The nanopb encoder
+SRC_C += $(MATTER_DIR)/common/protobuf/nanopb/pb_decode.c  # The nanopb decoder
+SRC_C += $(MATTER_DIR)/common/protobuf/nanopb/pb_common.c  # The nanopb common parts
 
 #matter - app - example
-SRC_C += ../../../component/common/application/matter/examples/matter_example_entry.c
-SRC_C += ../../../component/common/application/matter/examples/chiptest/example_matter.c
+SRC_C += $(MATTER_DIR)/examples/matter_example_entry.c
+SRC_C += $(MATTER_DIR)/examples/chiptest/example_matter.c
 
 #matter - common - lwip
 
 #network - lwip
 #network - lwip - api
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/api/api_lib.c
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/api/api_msg.c
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/api/err.c
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/api/netbuf.c
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/api/netdb.c
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/api/netifapi.c
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/api/sockets.c
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/api/tcpip.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/api/api_lib.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/api/api_msg.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/api/err.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/api/netbuf.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/api/netdb.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/api/netifapi.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/api/sockets.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/api/tcpip.c
 
 #network - lwip - core
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/core/def.c
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/core/dns.c
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/core/inet_chksum.c
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/core/init.c
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/core/ip.c
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/core/mem.c
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/core/memp.c
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/core/netif.c
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/core/pbuf.c
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/core/raw.c
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/core/stats.c
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/core/sys.c
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/core/tcp.c
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/core/tcp_in.c
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/core/tcp_out.c
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/core/timeouts.c
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/core/udp.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/core/def.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/core/dns.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/core/inet_chksum.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/core/init.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/core/ip.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/core/mem.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/core/memp.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/core/netif.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/core/pbuf.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/core/raw.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/core/stats.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/core/sys.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/core/tcp.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/core/tcp_in.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/core/tcp_out.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/core/timeouts.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/core/udp.c
 
 #network - lwip - core - ipv4
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/core/ipv4/autoip.c
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/core/ipv4/dhcp.c
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/core/ipv4/etharp.c
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/core/ipv4/icmp.c
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/core/ipv4/igmp.c
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/core/ipv4/ip4.c
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/core/ipv4/ip4_addr.c
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/core/ipv4/ip4_frag.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/core/ipv4/autoip.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/core/ipv4/dhcp.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/core/ipv4/etharp.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/core/ipv4/icmp.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/core/ipv4/igmp.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/core/ipv4/ip4.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/core/ipv4/ip4_addr.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/core/ipv4/ip4_frag.c
 
 #network - lwip - core - ipv6
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/core/ipv6/dhcp6.c
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/core/ipv6/ethip6.c
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/core/ipv6/icmp6.c
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/core/ipv6/inet6.c
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/core/ipv6/ip6.c
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/core/ipv6/ip6_addr.c
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/core/ipv6/ip6_frag.c
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/core/ipv6/mld6.c
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/core/ipv6/nd6.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/core/ipv6/dhcp6.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/core/ipv6/ethip6.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/core/ipv6/icmp6.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/core/ipv6/inet6.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/core/ipv6/ip6.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/core/ipv6/ip6_addr.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/core/ipv6/ip6_frag.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/core/ipv6/mld6.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/core/ipv6/nd6.c
 
 #network - lwip - netif
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/netif/ethernet.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/netif/ethernet.c
 
 #network - lwip - port
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/port/realtek/freertos/ethernetif.c
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/port/realtek/freertos/sys_arch.c
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/port/realtek/hooks/lwip_default_hooks.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/port/realtek/freertos/ethernetif.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/port/realtek/freertos/sys_arch.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/port/realtek/hooks/lwip_default_hooks.c
 
 #matter - common - mbedtls
 SRC_C += ${MBEDTLS_DIR}/$(MBEDTLS_VERSION)/library/aes.c
@@ -206,6 +202,7 @@ SRC_C += ${MBEDTLS_DIR}/$(MBEDTLS_VERSION)/library/rsa_internal.c
 SRC_C += ${MBEDTLS_DIR}/$(MBEDTLS_VERSION)/library/ssl_srv.c
 SRC_C += ${MBEDTLS_DIR}/$(MBEDTLS_VERSION)/library/xtea.c
 else ifeq ($(MBEDTLS_VERSION), mbedtls-3.6.1)
+SRC_C += $(MBEDTLS_DIR)/$(MBEDTLS_VERSION)/library/aes_alt.c
 SRC_C += ${MBEDTLS_DIR}/$(MBEDTLS_VERSION)/library/aesce.c
 SRC_C += ${MBEDTLS_DIR}/$(MBEDTLS_VERSION)/library/bignum_core.c
 SRC_C += ${MBEDTLS_DIR}/$(MBEDTLS_VERSION)/library/bignum_mod.c

--- a/project/amebaz2/Makefile.include.app.s.list
+++ b/project/amebaz2/Makefile.include.app.s.list
@@ -1,20 +1,11 @@
 include $(MATTER_INCLUDE)
 
-DEFAULT_MBEDTLS_DIR = ../../../component/common/network/ssl
-MATTER_MBEDTLS_DIR = ../../../component/common/application/matter/common/mbedtls
-
-ifeq ($(MBEDTLS_DIR_SELECTION), matter)
-MBEDTLS_DIR = $(MATTER_MBEDTLS_DIR)
-else
-MBEDTLS_DIR = $(DEFAULT_MBEDTLS_DIR)
-endif
-
 # Matter Include file list
 # -------------------------------------------------------------------
 
-INCLUDES += -I../../../component/common/application/matter/common/port
-INCLUDES += -I../../../component/common/application/matter/common/include
-INCLUDES += -I../../../component/common/application/matter/common/mbedtls
+INCLUDES += -I$(MATTER_DIR)/common/port
+INCLUDES += -I$(MATTER_DIR)/common/include
+INCLUDES += -I$(MATTER_DIR)/common/mbedtls
 INCLUDES += -I$(MBEDTLS_DIR)/$(MBEDTLS_VERSION)/include
 INCLUDES += -I$(MBEDTLS_DIR)/$(MBEDTLS_VERSION)/include/mbedtls
 INCLUDES += -I$(MBEDTLS_DIR)/$(MBEDTLS_VERSION)/library
@@ -102,6 +93,7 @@ SRC_C += $(MBEDTLS_DIR)/$(MBEDTLS_VERSION)/library/rsa_internal.c
 SRC_C += $(MBEDTLS_DIR)/$(MBEDTLS_VERSION)/library/ssl_srv.c
 SRC_C += $(MBEDTLS_DIR)/$(MBEDTLS_VERSION)/library/xtea.c
 else ifeq ($(MBEDTLS_VERSION), mbedtls-3.6.1)
+SRC_C += $(MBEDTLS_DIR)/$(MBEDTLS_VERSION)/library/aes_alt.c
 SRC_C += $(MBEDTLS_DIR)/$(MBEDTLS_VERSION)/library/aesce.c
 SRC_C += $(MBEDTLS_DIR)/$(MBEDTLS_VERSION)/library/bignum_core.c
 SRC_C += $(MBEDTLS_DIR)/$(MBEDTLS_VERSION)/library/bignum_mod.c

--- a/project/amebaz2/Makefile.include.hdr.list
+++ b/project/amebaz2/Makefile.include.hdr.list
@@ -3,24 +3,24 @@ include $(MATTER_INCLUDE)
 # Ameba Matter Common Include folder list
 # -------------------------------------------------------------------
 
-INCLUDES += -I$(SDKROOTDIR)/component/common/application/matter/api
-INCLUDES += -I$(SDKROOTDIR)/component/common/application/matter/common/bluetooth
-INCLUDES += -I$(SDKROOTDIR)/component/common/application/matter/common/bluetooth/bt_matter_adapter
-INCLUDES += -I$(SDKROOTDIR)/component/common/application/matter/common/include
-INCLUDES += -I$(SDKROOTDIR)/component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/include
-INCLUDES += -I$(SDKROOTDIR)/component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/include/lwip
-INCLUDES += -I$(SDKROOTDIR)/component/common/application/matter/common/lwip/$(LWIP_VERSION)/port/realtek
-INCLUDES += -I$(SDKROOTDIR)/component/common/application/matter/common/lwip/$(LWIP_VERSION)/port/realtek/include
-INCLUDES += -I$(SDKROOTDIR)/component/common/application/matter/common/lwip/$(LWIP_VERSION)/port/realtek/freertos
-INCLUDES += -I$(SDKROOTDIR)/component/common/application/matter/common/mbedtls
-INCLUDES += -I$(SDKROOTDIR)/component/common/application/matter/common/mbedtls/$(MBEDTLS_VERSION)/include
-INCLUDES += -I$(SDKROOTDIR)/component/common/application/matter/common/mbedtls/$(MBEDTLS_VERSION)/include/mbedtls
-INCLUDES += -I$(SDKROOTDIR)/component/common/application/matter/common/mbedtls/$(MBEDTLS_VERSION)/library
-INCLUDES += -I$(SDKROOTDIR)/component/common/application/matter/common/port
-INCLUDES += -I$(SDKROOTDIR)/component/common/application/matter/core
-INCLUDES += -I$(SDKROOTDIR)/component/common/application/matter/drivers/device
-INCLUDES += -I$(SDKROOTDIR)/component/common/application/matter/drivers/matter_consoles
-INCLUDES += -I$(SDKROOTDIR)/component/common/application/matter/drivers/matter_drivers
+INCLUDES += -I$(MATTER_DIR)/api
+INCLUDES += -I$(MATTER_DIR)/common/bluetooth
+INCLUDES += -I$(MATTER_DIR)/common/bluetooth/bt_matter_adapter
+INCLUDES += -I$(MATTER_DIR)/common/include
+INCLUDES += -I$(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/include
+INCLUDES += -I$(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/include/lwip
+INCLUDES += -I$(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/port/realtek
+INCLUDES += -I$(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/port/realtek/include
+INCLUDES += -I$(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/port/realtek/freertos
+INCLUDES += -I$(MATTER_DIR)/common/mbedtls
+INCLUDES += -I$(MATTER_DIR)/common/mbedtls/$(MBEDTLS_VERSION)/include
+INCLUDES += -I$(MATTER_DIR)/common/mbedtls/$(MBEDTLS_VERSION)/include/mbedtls
+INCLUDES += -I$(MATTER_DIR)/common/mbedtls/$(MBEDTLS_VERSION)/library
+INCLUDES += -I$(MATTER_DIR)/common/port
+INCLUDES += -I$(MATTER_DIR)/core
+INCLUDES += -I$(MATTER_DIR)/drivers/device
+INCLUDES += -I$(MATTER_DIR)/drivers/matter_consoles
+INCLUDES += -I$(MATTER_DIR)/drivers/matter_drivers
 
 # Include folder list
 # -------------------------------------------------------------------

--- a/project/amebaz2/Makefile.include.matter
+++ b/project/amebaz2/Makefile.include.matter
@@ -14,7 +14,13 @@ MATTER_TOOLCHAINDIR = $(MATTER_DIR)/tools/toolchain
 # MbedTLS Configuration
 MBEDTLS_DIR_SELECTION = matter
 DEFAULT_MBEDTLS_DIR = $(SDKROOTDIR)/component/common/network/ssl
-MATTER_MBEDTLS_DIR  = $(SDKROOTDIR)/component/common/application/matter/common/mbedtls
+MATTER_MBEDTLS_DIR  = $(MATTER_DIR)/common/mbedtls
+
+ifeq ($(MBEDTLS_DIR_SELECTION), matter)
+MBEDTLS_DIR = $(MATTER_MBEDTLS_DIR)
+else
+MBEDTLS_DIR = $(DEFAULT_MBEDTLS_DIR)
+endif
 
 # -------------------------------------------------------------------
 # Toolchain Definition

--- a/project/amebaz2plus/Makefile.include.app.list
+++ b/project/amebaz2plus/Makefile.include.app.list
@@ -1,127 +1,121 @@
 include $(MATTER_INCLUDE)
 
-ifeq ($(MBEDTLS_DIR_SELECTION), matter)
-MBEDTLS_DIR = $(MATTER_MBEDTLS_DIR)
-else
-MBEDTLS_DIR = $(DEFAULT_MBEDTLS_DIR)
-endif
-
 # Matter Include file list
 # -------------------------------------------------------------------
 
-INCLUDES += -I../../../component/common/application/matter/api
-INCLUDES += -I../../../component/common/application/matter/common/bluetooth
-INCLUDES += -I../../../component/common/application/matter/common/include
-INCLUDES += -I../../../component/common/application/matter/common/lwip/include
-INCLUDES += -I../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/include
-INCLUDES += -I../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/include/lwip
-INCLUDES += -I../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/port/realtek
-INCLUDES += -I../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/port/realtek/include
-INCLUDES += -I../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/port/realtek/freertos
-INCLUDES += -I../../../component/common/application/matter/common/mbedtls
+INCLUDES += -I$(MATTER_DIR)/api
+INCLUDES += -I$(MATTER_DIR)/common/bluetooth
+INCLUDES += -I$(MATTER_DIR)/common/include
+INCLUDES += -I$(MATTER_DIR)/common/lwip/include
+INCLUDES += -I$(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/include
+INCLUDES += -I$(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/include/lwip
+INCLUDES += -I$(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/port/realtek
+INCLUDES += -I$(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/port/realtek/include
+INCLUDES += -I$(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/port/realtek/freertos
+INCLUDES += -I$(MATTER_DIR)/common/mbedtls
 INCLUDES += -I${MBEDTLS_DIR}/$(MBEDTLS_VERSION)/include
 INCLUDES += -I${MBEDTLS_DIR}/$(MBEDTLS_VERSION)/include/mbedtls
 INCLUDES += -I${MBEDTLS_DIR}/$(MBEDTLS_VERSION)/library
-INCLUDES += -I../../../component/common/application/matter/common/port
-INCLUDES += -I../../../component/common/application/matter/common/protobuf
-INCLUDES += -I../../../component/common/application/matter/common/protobuf/nanopb
-INCLUDES += -I../../../component/common/application/matter/core
-INCLUDES += -I../../../component/common/application/matter/drivers/device
-INCLUDES += -I../../../component/common/application/matter/drivers/matter_consoles
-INCLUDES += -I../../../component/common/application/matter/drivers/matter_drivers
-INCLUDES += -I../../../component/common/application/matter/examples
+INCLUDES += -I$(MATTER_DIR)/common/port
+INCLUDES += -I$(MATTER_DIR)/common/protobuf
+INCLUDES += -I$(MATTER_DIR)/common/protobuf/nanopb
+INCLUDES += -I$(MATTER_DIR)/core
+INCLUDES += -I$(MATTER_DIR)/drivers/device
+INCLUDES += -I$(MATTER_DIR)/drivers/matter_consoles
+INCLUDES += -I$(MATTER_DIR)/drivers/matter_drivers
+INCLUDES += -I$(MATTER_DIR)/examples
 
 # Source file list
 # -------------------------------------------------------------------
 
 #matter - app - atcmd
-SRC_C += ../../../component/common/application/matter/common/atcmd/atcmd_matter.c
+SRC_C += $(MATTER_DIR)/common/atcmd/atcmd_matter.c
 
 #matter - app - bluetooth
-SRC_C += ../../../component/common/application/matter/common/bluetooth/matter_blemgr_common.c
+SRC_C += $(MATTER_DIR)/common/bluetooth/matter_blemgr_common.c
 
 #matter - app - port
-SRC_C += ../../../component/common/application/matter/common/port/matter_dcts.c
-SRC_C += ../../../component/common/application/matter/common/port/matter_fs.c
-SRC_C += ../../../component/common/application/matter/common/port/matter_lwip.c
-SRC_C += ../../../component/common/application/matter/common/port/matter_ota.c
-SRC_C += ../../../component/common/application/matter/common/port/matter_timers.c
-SRC_C += ../../../component/common/application/matter/common/port/matter_utils.c
-SRC_C += ../../../component/common/application/matter/common/port/matter_wifis.c
+SRC_C += $(MATTER_DIR)/common/port/matter_dcts.c
+SRC_C += $(MATTER_DIR)/common/port/matter_fs.c
+SRC_C += $(MATTER_DIR)/common/port/matter_lwip.c
+SRC_C += $(MATTER_DIR)/common/port/matter_ota.c
+SRC_C += $(MATTER_DIR)/common/port/matter_timers.c
+SRC_C += $(MATTER_DIR)/common/port/matter_utils.c
+SRC_C += $(MATTER_DIR)/common/port/matter_wifis.c
 
 #matter - app - mbedtls
-SRC_C += ../../../component/common/application/matter/common/mbedtls/net_sockets.c
+SRC_C += $(MATTER_DIR)/common/mbedtls/net_sockets.c
 
 #matter - app - protobuf
-SRC_C += ../../../component/common/application/matter/common/protobuf/ameba_factory.pb.c
-SRC_C += ../../../component/common/application/matter/common/protobuf/nanopb/pb_encode.c  # The nanopb encoder
-SRC_C += ../../../component/common/application/matter/common/protobuf/nanopb/pb_decode.c  # The nanopb decoder
-SRC_C += ../../../component/common/application/matter/common/protobuf/nanopb/pb_common.c  # The nanopb common parts
+SRC_C += $(MATTER_DIR)/common/protobuf/ameba_factory.pb.c
+SRC_C += $(MATTER_DIR)/common/protobuf/nanopb/pb_encode.c  # The nanopb encoder
+SRC_C += $(MATTER_DIR)/common/protobuf/nanopb/pb_decode.c  # The nanopb decoder
+SRC_C += $(MATTER_DIR)/common/protobuf/nanopb/pb_common.c  # The nanopb common parts
 
 #matter - app - example
-SRC_C += ../../../component/common/application/matter/examples/matter_example_entry.c
-SRC_C += ../../../component/common/application/matter/examples/chiptest/example_matter.c
+SRC_C += $(MATTER_DIR)/examples/matter_example_entry.c
+SRC_C += $(MATTER_DIR)/examples/chiptest/example_matter.c
 
 #matter - common - lwip
 
 #network - lwip
 #network - lwip - api
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/api/api_lib.c
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/api/api_msg.c
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/api/err.c
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/api/netbuf.c
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/api/netdb.c
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/api/netifapi.c
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/api/sockets.c
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/api/tcpip.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/api/api_lib.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/api/api_msg.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/api/err.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/api/netbuf.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/api/netdb.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/api/netifapi.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/api/sockets.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/api/tcpip.c
 
 #network - lwip - core
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/core/def.c
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/core/dns.c
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/core/inet_chksum.c
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/core/init.c
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/core/ip.c
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/core/mem.c
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/core/memp.c
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/core/netif.c
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/core/pbuf.c
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/core/raw.c
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/core/stats.c
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/core/sys.c
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/core/tcp.c
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/core/tcp_in.c
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/core/tcp_out.c
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/core/timeouts.c
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/core/udp.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/core/def.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/core/dns.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/core/inet_chksum.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/core/init.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/core/ip.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/core/mem.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/core/memp.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/core/netif.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/core/pbuf.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/core/raw.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/core/stats.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/core/sys.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/core/tcp.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/core/tcp_in.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/core/tcp_out.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/core/timeouts.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/core/udp.c
 
 #network - lwip - core - ipv4
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/core/ipv4/autoip.c
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/core/ipv4/dhcp.c
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/core/ipv4/etharp.c
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/core/ipv4/icmp.c
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/core/ipv4/igmp.c
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/core/ipv4/ip4.c
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/core/ipv4/ip4_addr.c
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/core/ipv4/ip4_frag.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/core/ipv4/autoip.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/core/ipv4/dhcp.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/core/ipv4/etharp.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/core/ipv4/icmp.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/core/ipv4/igmp.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/core/ipv4/ip4.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/core/ipv4/ip4_addr.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/core/ipv4/ip4_frag.c
 
 #network - lwip - core - ipv6
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/core/ipv6/dhcp6.c
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/core/ipv6/ethip6.c
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/core/ipv6/icmp6.c
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/core/ipv6/inet6.c
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/core/ipv6/ip6.c
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/core/ipv6/ip6_addr.c
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/core/ipv6/ip6_frag.c
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/core/ipv6/mld6.c
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/core/ipv6/nd6.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/core/ipv6/dhcp6.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/core/ipv6/ethip6.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/core/ipv6/icmp6.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/core/ipv6/inet6.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/core/ipv6/ip6.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/core/ipv6/ip6_addr.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/core/ipv6/ip6_frag.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/core/ipv6/mld6.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/core/ipv6/nd6.c
 
 #network - lwip - netif
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/netif/ethernet.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/netif/ethernet.c
 
 #network - lwip - port
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/port/realtek/freertos/ethernetif.c
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/port/realtek/freertos/sys_arch.c
-SRC_C += ../../../component/common/application/matter/common/lwip/$(LWIP_VERSION)/port/realtek/hooks/lwip_default_hooks.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/port/realtek/freertos/ethernetif.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/port/realtek/freertos/sys_arch.c
+SRC_C += $(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/port/realtek/hooks/lwip_default_hooks.c
 
 #matter - common - mbedtls
 SRC_C += ${MBEDTLS_DIR}/$(MBEDTLS_VERSION)/library/aes.c
@@ -206,6 +200,7 @@ SRC_C += ${MBEDTLS_DIR}/$(MBEDTLS_VERSION)/library/rsa_internal.c
 SRC_C += ${MBEDTLS_DIR}/$(MBEDTLS_VERSION)/library/ssl_srv.c
 SRC_C += ${MBEDTLS_DIR}/$(MBEDTLS_VERSION)/library/xtea.c
 else ifeq ($(MBEDTLS_VERSION), mbedtls-3.6.1)
+SRC_C += $(MBEDTLS_DIR)/$(MBEDTLS_VERSION)/library/aes_alt.c
 SRC_C += ${MBEDTLS_DIR}/$(MBEDTLS_VERSION)/library/aesce.c
 SRC_C += ${MBEDTLS_DIR}/$(MBEDTLS_VERSION)/library/bignum_core.c
 SRC_C += ${MBEDTLS_DIR}/$(MBEDTLS_VERSION)/library/bignum_mod.c

--- a/project/amebaz2plus/Makefile.include.app.s.list
+++ b/project/amebaz2plus/Makefile.include.app.s.list
@@ -1,20 +1,11 @@
 include $(MATTER_INCLUDE)
 
-DEFAULT_MBEDTLS_DIR = ../../../component/common/network/ssl
-MATTER_MBEDTLS_DIR = ../../../component/common/application/matter/common/mbedtls
-
-ifeq ($(MBEDTLS_DIR_SELECTION), matter)
-MBEDTLS_DIR = $(MATTER_MBEDTLS_DIR)
-else
-MBEDTLS_DIR = $(DEFAULT_MBEDTLS_DIR)
-endif
-
 # Matter Include file list
 # -------------------------------------------------------------------
 
-INCLUDES += -I../../../component/common/application/matter/common/port
-INCLUDES += -I../../../component/common/application/matter/common/include
-INCLUDES += -I../../../component/common/application/matter/common/mbedtls
+INCLUDES += -I$(MATTER_DIR)/common/port
+INCLUDES += -I$(MATTER_DIR)/common/include
+INCLUDES += -I$(MATTER_DIR)/common/mbedtls
 INCLUDES += -I$(MBEDTLS_DIR)/$(MBEDTLS_VERSION)/include
 INCLUDES += -I$(MBEDTLS_DIR)/$(MBEDTLS_VERSION)/include/mbedtls
 INCLUDES += -I$(MBEDTLS_DIR)/$(MBEDTLS_VERSION)/library
@@ -102,6 +93,7 @@ SRC_C += $(MBEDTLS_DIR)/$(MBEDTLS_VERSION)/library/rsa_internal.c
 SRC_C += $(MBEDTLS_DIR)/$(MBEDTLS_VERSION)/library/ssl_srv.c
 SRC_C += $(MBEDTLS_DIR)/$(MBEDTLS_VERSION)/library/xtea.c
 else ifeq ($(MBEDTLS_VERSION), mbedtls-3.6.1)
+SRC_C += $(MBEDTLS_DIR)/$(MBEDTLS_VERSION)/library/aes_alt.c
 SRC_C += $(MBEDTLS_DIR)/$(MBEDTLS_VERSION)/library/aesce.c
 SRC_C += $(MBEDTLS_DIR)/$(MBEDTLS_VERSION)/library/bignum_core.c
 SRC_C += $(MBEDTLS_DIR)/$(MBEDTLS_VERSION)/library/bignum_mod.c

--- a/project/amebaz2plus/Makefile.include.hdr.list
+++ b/project/amebaz2plus/Makefile.include.hdr.list
@@ -3,24 +3,24 @@ include $(MATTER_INCLUDE)
 # Ameba Matter Common Include folder list
 # -------------------------------------------------------------------
 
-INCLUDES += -I$(SDKROOTDIR)/component/common/application/matter/api
-INCLUDES += -I$(SDKROOTDIR)/component/common/application/matter/common/bluetooth
-INCLUDES += -I$(SDKROOTDIR)/component/common/application/matter/common/bluetooth/bt_matter_adapter
-INCLUDES += -I$(SDKROOTDIR)/component/common/application/matter/common/include
-INCLUDES += -I$(SDKROOTDIR)/component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/include
-INCLUDES += -I$(SDKROOTDIR)/component/common/application/matter/common/lwip/$(LWIP_VERSION)/src/include/lwip
-INCLUDES += -I$(SDKROOTDIR)/component/common/application/matter/common/lwip/$(LWIP_VERSION)/port/realtek
-INCLUDES += -I$(SDKROOTDIR)/component/common/application/matter/common/lwip/$(LWIP_VERSION)/port/realtek/include
-INCLUDES += -I$(SDKROOTDIR)/component/common/application/matter/common/lwip/$(LWIP_VERSION)/port/realtek/freertos
-INCLUDES += -I$(SDKROOTDIR)/component/common/application/matter/common/mbedtls
-INCLUDES += -I$(SDKROOTDIR)/component/common/application/matter/common/mbedtls/$(MBEDTLS_VERSION)/include
-INCLUDES += -I$(SDKROOTDIR)/component/common/application/matter/common/mbedtls/$(MBEDTLS_VERSION)/include/mbedtls
-INCLUDES += -I$(SDKROOTDIR)/component/common/application/matter/common/mbedtls/$(MBEDTLS_VERSION)/library
-INCLUDES += -I$(SDKROOTDIR)/component/common/application/matter/common/port
-INCLUDES += -I$(SDKROOTDIR)/component/common/application/matter/core
-INCLUDES += -I$(SDKROOTDIR)/component/common/application/matter/drivers/device
-INCLUDES += -I$(SDKROOTDIR)/component/common/application/matter/drivers/matter_consoles
-INCLUDES += -I$(SDKROOTDIR)/component/common/application/matter/drivers/matter_drivers
+INCLUDES += -I$(MATTER_DIR)/api
+INCLUDES += -I$(MATTER_DIR)/common/bluetooth
+INCLUDES += -I$(MATTER_DIR)/common/bluetooth/bt_matter_adapter
+INCLUDES += -I$(MATTER_DIR)/common/include
+INCLUDES += -I$(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/include
+INCLUDES += -I$(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/src/include/lwip
+INCLUDES += -I$(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/port/realtek
+INCLUDES += -I$(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/port/realtek/include
+INCLUDES += -I$(MATTER_DIR)/common/lwip/$(LWIP_VERSION)/port/realtek/freertos
+INCLUDES += -I$(MATTER_DIR)/common/mbedtls
+INCLUDES += -I$(MATTER_DIR)/common/mbedtls/$(MBEDTLS_VERSION)/include
+INCLUDES += -I$(MATTER_DIR)/common/mbedtls/$(MBEDTLS_VERSION)/include/mbedtls
+INCLUDES += -I$(MATTER_DIR)/common/mbedtls/$(MBEDTLS_VERSION)/library
+INCLUDES += -I$(MATTER_DIR)/common/port
+INCLUDES += -I$(MATTER_DIR)/core
+INCLUDES += -I$(MATTER_DIR)/drivers/device
+INCLUDES += -I$(MATTER_DIR)/drivers/matter_consoles
+INCLUDES += -I$(MATTER_DIR)/drivers/matter_drivers
 
 # Include folder list
 # -------------------------------------------------------------------

--- a/project/amebaz2plus/Makefile.include.matter
+++ b/project/amebaz2plus/Makefile.include.matter
@@ -14,7 +14,13 @@ MATTER_TOOLCHAINDIR = $(MATTER_DIR)/tools/toolchain
 # MbedTLS Configuration
 MBEDTLS_DIR_SELECTION = matter
 DEFAULT_MBEDTLS_DIR = $(SDKROOTDIR)/component/common/network/ssl
-MATTER_MBEDTLS_DIR  = $(SDKROOTDIR)/component/common/application/matter/common/mbedtls
+MATTER_MBEDTLS_DIR  = $(MATTER_DIR)/common/mbedtls
+
+ifeq ($(MBEDTLS_DIR_SELECTION), matter)
+MBEDTLS_DIR = $(MATTER_MBEDTLS_DIR)
+else
+MBEDTLS_DIR = $(DEFAULT_MBEDTLS_DIR)
+endif
 
 # -------------------------------------------------------------------
 # Toolchain Definition

--- a/tools/docker/amebad/Dockerfile
+++ b/tools/docker/amebad/Dockerfile
@@ -3,7 +3,7 @@ FROM ameba-rtos-matter:common
 
 # Redefine following build arguments to respective repo and tag/branch
 ARG AMEBA_MATTER_REPO=https://github.com/xshuqun/ameba-rtos-matter.git
-ARG TAG_NAME=ameba/v1.4_update_mbedtls_250728
+ARG TAG_NAME=ameba/update_mbedtls_250729
 
 # Define fixed build arguments
 ARG AMBD_REPO=https://github.com/Ameba-AIoT/ameba-rtos-d.git

--- a/tools/docker/amebaz2/Dockerfile
+++ b/tools/docker/amebaz2/Dockerfile
@@ -3,7 +3,7 @@ FROM ameba-rtos-matter:common
 
 # Redefine following build arguments to respective repo and tag/branch
 ARG AMEBA_MATTER_REPO=https://github.com/xshuqun/ameba-rtos-matter.git
-ARG TAG_NAME=ameba/v1.4_update_mbedtls_250728
+ARG TAG_NAME=ameba/update_mbedtls_250729
 
 # Define fixed build arguments
 ARG AMBZ2_REPO=https://github.com/Ameba-AIoT/ameba-rtos-z2.git


### PR DESCRIPTION
This PR addresses:
* tidy up path delcaration and move mbedtls directory to Makefile.include.matter.
* include aes_alt.c which could be built when MBEDTLS_AES_ALT is enabled.

Verification:
CI build.