### PR TITLE
[general][sdk] Link Matter BootReason with Ameba ResetReason

### DIFF
--- a/.github/workflows/check_pr_message.yml
+++ b/.github/workflows/check_pr_message.yml
@@ -15,5 +15,5 @@ jobs:
             const body = context.payload.pull_request.body || "";
 
             if (!body.includes("This PR addresses:") || !body.includes("Verification:")) {
-              core.setFailed(`❌ PR description must include both "This commit addresses:" and "Verification:" sections.`);
+              core.setFailed(`❌ PR description must include both "This PR addresses:" and "Verification:" sections.`);
             }

--- a/api/matter_api.cpp
+++ b/api/matter_api.cpp
@@ -1,3 +1,22 @@
+/*
+ *    This module is a confidential and proprietary property of RealTek and
+ *    possession or use of this module requires written permission of RealTek.
+ *
+ *    Copyright(c) 2025, Realtek Semiconductor Corporation. All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
 #include <platform_stdlib.h>
 #include <app/server/Server.h>
 #include <credentials/DeviceAttestationCredsProvider.h>
@@ -12,41 +31,6 @@
 
 using namespace ::chip::Credentials;
 using namespace ::chip::DeviceLayer;
-
-extern "C" uint8_t matter_get_total_operational_hour(uint32_t *totalOperationalHours)
-{
-    if (totalOperationalHours == nullptr)
-    {
-        printf("%s: nullptr\n", __FUNCTION__);
-        return -1;
-    }
-
-    CHIP_ERROR err;
-    DiagnosticDataProvider &diagProvider = chip::DeviceLayer::GetDiagnosticDataProviderImpl();
-
-    if (&diagProvider != NULL)
-    {
-        err = diagProvider.GetTotalOperationalHours(*totalOperationalHours);
-        if (err != CHIP_NO_ERROR)
-        {
-            printf("%s: GetTotalOperationalHours Failed err=%d\n", __FUNCTION__, err);
-            return -1;
-        }
-    }
-    else
-    {
-        printf("%s: DiagnosticDataProvider is invalid\n", __FUNCTION__);
-        return -1;
-    }
-    return 0;
-}
-
-extern "C" uint8_t matter_set_total_operational_hour(uint32_t time)
-{
-    CHIP_ERROR err = ConfigurationMgr().StoreTotalOperationalHours(time);
-
-    return (err == CHIP_NO_ERROR) ? 0 : -1;
-}
 
 bool matter_server_is_commissioned()
 {

--- a/api/matter_api.h
+++ b/api/matter_api.h
@@ -1,16 +1,22 @@
-/********************************************************************************
- * @file    matter_api.h
- * @author
- * @version
- * @brief   Useful API to support Matter protocol.
- ********************************************************************************
-  *
-  * This module is a confidential and proprietary property of RealTek and
-  * possession or use of this module requires written permission of RealTek.
-  *
-  * Copyright(c) 2016, Realtek Semiconductor Corporation. All rights reserved.
-  *
-********************************************************************************/
+/*
+ *    This module is a confidential and proprietary property of RealTek and
+ *    possession or use of this module requires written permission of RealTek.
+ *
+ *    Copyright(c) 2025, Realtek Semiconductor Corporation. All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
 #pragma once
 
 using namespace ::chip;

--- a/common/port/matter_ota.h
+++ b/common/port/matter_ota.h
@@ -1,17 +1,21 @@
-/********************************************************************************
- * @file    matter_ota.h
- * @author
- * @version
- * @brief   OTA API to support Matter OTA feature.
- ********************************************************************************
- * @attention
+/*
+ *    This module is a confidential and proprietary property of RealTek and
+ *    possession or use of this module requires written permission of RealTek.
  *
- * This module is a confidential and proprietary property of RealTek and
- * possession or use of this module requires written permission of RealTek.
+ *    Copyright(c) 2025, Realtek Semiconductor Corporation. All rights reserved.
  *
- * Copyright(c) 2016, Realtek Semiconductor Corporation. All rights reserved.
-********************************************************************************/
-
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
 #ifndef __RTK_MATTER_OTA_H__
 #define __RTK_MATTER_OTA_H__
 
@@ -22,8 +26,9 @@ extern "C" {
 /**
   * @brief  Matter OTA error number.
   */
-enum {
-    OTA_SUCCESS = 0,            /**< Matter OTA success */
+enum
+{
+    OTA_SUCCESS = 1,            /**< Matter OTA success */
     OTA_ERROR = -1,             /**< Matter OTA error */
 };
 
@@ -65,7 +70,7 @@ int8_t matter_ota_flash_burst_write(uint8_t *data, uint32_t size);
 
 /**
  * @brief  Write/Store the remaining data of Matter OTA firmware.
- *         After the last frame of Matter OTA, check for remaining data using matter_ota_buffer_size, 
+ *         After the last frame of Matter OTA, check for remaining data using matter_ota_buffer_size,
  *         if there is remaining data, write it into flash.
  * @return OTA_SUCCESS if write successful; OTA_ERROR otherwise
  */
@@ -78,6 +83,12 @@ int8_t matter_ota_flush_last(void);
  * @return OTA_SUCCESS if update successful; OTA_ERROR otherwise
  */
 int8_t matter_ota_update_signature(void);
+
+/**
+ * @brief  Check if OTA has been completed by reading the key value from KVS.
+ * @return value if get successfully; OTA_ERROR otherwise
+ */
+uint8_t matter_get_ota_completed_value(void);
 
 /**
  * @brief  Reset device after Matter OTA completes.

--- a/core/matter_core.cpp
+++ b/core/matter_core.cpp
@@ -1,3 +1,22 @@
+/*
+ *    This module is a confidential and proprietary property of RealTek and
+ *    possession or use of this module requires written permission of RealTek.
+ *
+ *    Copyright(c) 2025, Realtek Semiconductor Corporation. All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
 #include <stdlib.h>
 #include <stdint.h>
 

--- a/core/matter_device_utils.cpp
+++ b/core/matter_device_utils.cpp
@@ -1,4 +1,29 @@
+/*
+ *    This module is a confidential and proprietary property of RealTek and
+ *    possession or use of this module requires written permission of RealTek.
+ *
+ *    Copyright(c) 2025, Realtek Semiconductor Corporation. All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
 #include <platform_stdlib.h>
+#if defined(CONFIG_PLATFORM_8710C)
+#include <reset_reason_api.h>
+#else
+#include <rtl8721dlp_sysreg.h>
+#endif
+
 #include <app/server/Server.h>
 #include <credentials/DeviceAttestationCredsProvider.h>
 #include <platform/Ameba/DiagnosticDataProviderImpl.h>
@@ -9,31 +34,40 @@
 #include <setup_payload/QRCodeSetupPayloadGenerator.h>
 
 #include <matter_api.h>
+#include <matter_ota.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #if defined(CONFIG_ENABLE_AMEBA_OPHOURS) && (CONFIG_ENABLE_AMEBA_OPHOURS == 1)
 #define HOUR_PER_MILLISECOND       ( 3600 * 1000 )
 #endif
 
+using namespace ::chip;
 using namespace ::chip::Credentials;
 using namespace ::chip::DeviceLayer;
+using namespace ::chip::app::Clusters;
+
+using BootReasonType = GeneralDiagnostics::BootReasonEnum;
 
 uint8_t matter_get_total_operational_hour(uint32_t *totalOperationalHours)
 {
     if (totalOperationalHours == nullptr)
     {
-        printf("%s: nullptr\n", __FUNCTION__);
+        ChipLogError(DeviceLayer,"%s: nullptr\n", __FUNCTION__);
         return -1;
     }
 
     CHIP_ERROR err;
     DiagnosticDataProvider &diagProvider = chip::DeviceLayer::GetDiagnosticDataProviderImpl();
 
-    if (&diagProvider != NULL)
+    if (&diagProvider != nullptr)
     {
         err = diagProvider.GetTotalOperationalHours(*totalOperationalHours);
         if (err != CHIP_NO_ERROR)
         {
-            printf("%s: GetTotalOperationalHours Failed err=%d\n", __FUNCTION__, err);
+            ChipLogError(DeviceLayer,"%s: get failed err=%d\n", __FUNCTION__, err);
             return -1;
         }
     }
@@ -68,7 +102,7 @@ static void matter_op_hours_task(void *pvParameters)
             ret = matter_set_total_operational_hour(prev_hour);
             if (ret != 0)
             {
-                printf("matter_store_total_operational_hour failed, ret=%d\n", ret);
+                ChipLogError(DeviceLayer,"matter_store_total_operational_hour failed, ret=%d\n", ret);
                 goto loop;
             }
             // 3. Delete "temp_hour" from NVS
@@ -93,7 +127,7 @@ loop:
                 prev_hour = cur_hour;
                 if (setPref_new(key, key, (uint8_t *) &cur_hour, sizeof(cur_hour)) != DCT_SUCCESS)
                 {
-                    printf("setPref_new: temp_hour Failed\n");
+                    ChipLogError(DeviceLayer,"setPref_new: temp_hour failed\n");
                 }
             }
         }
@@ -110,9 +144,80 @@ void matter_op_hours(void)
         printf("\n\r%s xTaskCreate(matter_op_hours) failed", __FUNCTION__);
     }
 }
+#endif
 
-extern "C" void matter_op_hours_wrapper(void)
+/* BootReasonEnum Declaration
+ * 0: kUnspecified               > RESET_REASON_UNKNOWN
+ * 1: kPowerOnReboot             > RESET_REASON_POWER_ON
+ * 2: kBrownOutReset             > RESET_REASON_BROWN_OUT
+ * 3: kSoftwareWatchdogReset     > RESET_REASON_WATCHDOG
+ * 4: kHardwareWatchdogReset     > Not supported
+ * 5: kSoftwareUpdateCompleted   > RESET_REASON_SOFTWARE + is_ota(1)
+ * 6: kSoftwareReset             > RESET_REASON_SOFTWARE
+ * */
+
+#if defined(CONFIG_PLATFORM_8710C)
+BootReasonType rtl8710c_map_reset_reason(uint32_t reason, bool isOta)
 {
-    matter_op_hours();
+    switch (reason)
+    {
+    case RESET_REASON_POWER_ON:
+        return BootReasonType::kPowerOnReboot;
+    case RESET_REASON_BROWN_OUT:
+        return BootReasonType::kBrownOutReset;
+    case RESET_REASON_WATCHDOG:
+        return BootReasonType::kSoftwareWatchdogReset;
+    case RESET_REASON_SOFTWARE:
+        return isOta ? BootReasonType::kSoftwareUpdateCompleted : BootReasonType::kSoftwareReset;
+    case RESET_REASON_UNKNOWN:
+    default:
+        return BootReasonType::kUnspecified;
+    }
+}
+#elif defined(CONFIG_PLATFORM_8721D)
+BootReasonType rtl8721d_map_reset_reason(uint32_t reason, bool isOta)
+{
+    switch (reason)
+    {
+    case 0:
+        return BootReasonType::kPowerOnReboot;
+    case BIT_BOOT_BOD_RESET_HAPPEN:
+        return BootReasonType::kBrownOutReset;
+    case BIT_BOOT_WDG_RESET_HAPPEN:
+    case BIT_BOOT_KM4WDG_RESET_HAPPEN:
+        return BootReasonType::kSoftwareWatchdogReset;
+    case BIT_BOOT_SYS_RESET_HAPPEN:
+    case BIT_BOOT_KM4SYS_RESET_HAPPEN:
+        return isOta ? BootReasonType::kSoftwareUpdateCompleted : BootReasonType::kSoftwareReset;
+    default:
+        return BootReasonType::kPowerOnReboot;
+    }
+}
+#endif
+
+void matter_store_boot_reason(void)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    uint8_t is_ota = matter_get_ota_completed_value();
+    BootReasonType bootReason = BootReasonType::kUnspecified;
+
+#if defined(CONFIG_PLATFORM_8710C)
+    bootReason = rtl8710c_map_reset_reason(hal_reset_reason_get(), is_ota);
+#elif defined(CONFIG_PLATFORM_8721D)
+    bootReason = rtl8721d_map_reset_reason(BOOT_Reason(), is_ota);
+#endif
+
+    ChipLogDetail(DeviceLayer, "store boot reason 0x%x", to_underlying(bootReason));
+
+    err = ConfigurationManagerImpl().StoreBootReason(to_underlying(bootReason));
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(DeviceLayer, "store boot reason (0x%x) failed 0x%X", to_underlying(bootReason), err);
+    }
+    return;
+}
+
+#ifdef __cplusplus
 }
 #endif

--- a/core/matter_device_utils.h
+++ b/core/matter_device_utils.h
@@ -1,14 +1,38 @@
-/********************************************************************************
-  *
-  * This module is a confidential and proprietary property of RealTek and
-  * possession or use of this module requires written permission of RealTek.
-  *
-  * Copyright(c) 2016, Realtek Semiconductor Corporation. All rights reserved.
-  *
-********************************************************************************/
+/*
+ *    This module is a confidential and proprietary property of RealTek and
+ *    possession or use of this module requires written permission of RealTek.
+ *
+ *    Copyright(c) 2025, Realtek Semiconductor Corporation. All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
 #pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief  Store BootReason according to device's Reset Reason.
+ */
+void matter_store_boot_reason(void);
 
 /**
  * @brief  Start an hourly recurring task to track Total Operational Hours.
  */
 void matter_op_hours(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/examples/chiptest/example_matter.c
+++ b/examples/chiptest/example_matter.c
@@ -1,3 +1,22 @@
+/*
+ *    This module is a confidential and proprietary property of RealTek and
+ *    possession or use of this module requires written permission of RealTek.
+ *
+ *    Copyright(c) 2025, Realtek Semiconductor Corporation. All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
 #include <FreeRTOS.h>
 #include <task.h>
 #include <platform/platform_stdlib.h>
@@ -5,15 +24,12 @@
 #include <platform_opts.h>
 #include <wifi_constants.h>
 #include <wifi/wifi_conf.h>
+#include <matter_data_providers.h>
+#include <matter_device_utils.h>
 #if defined(CONFIG_ENABLE_AMEBA_DLOG) && (CONFIG_ENABLE_AMEBA_DLOG)
 #include <matter_fs.h>
 #include <diagnostic_logs/ameba_logging_faultlog.h>
 #include <diagnostic_logs/ameba_logging_redirect_wrapper.h>
-#endif
-#include <matter_data_providers.h>
-
-#if defined(CONFIG_ENABLE_AMEBA_OPHOURS) && (CONFIG_ENABLE_AMEBA_OPHOURS == 1)
-extern void matter_op_hours_wrapper(void);
 #endif
 
 #if defined(CONFIG_EXAMPLE_MATTER_CHIPTEST) && CONFIG_EXAMPLE_MATTER_CHIPTEST
@@ -47,8 +63,10 @@ static void example_matter_task_thread(void *pvParameters)
     matter_data_provider_init();
 
 #if defined(CONFIG_ENABLE_AMEBA_OPHOURS) && (CONFIG_ENABLE_AMEBA_OPHOURS == 1)
-    matter_op_hours_wrapper();
+    matter_op_hours();
 #endif
+
+    matter_store_boot_reason();
 
     vTaskDelete(NULL);
     return;

--- a/project/amebad/make/chip_main/matter_main_sources.mk
+++ b/project/amebad/make/chip_main/matter_main_sources.mk
@@ -62,6 +62,7 @@ endif
 CPPSRC += $(CHIPDIR)/src/app/server-cluster/AttributeListBuilder.cpp
 CPPSRC += $(CHIPDIR)/src/app/server-cluster/DefaultServerCluster.cpp
 CPPSRC += $(CHIPDIR)/src/app/server-cluster/ServerClusterInterface.cpp
+CPPSRC += $(CHIPDIR)/src/app/server-cluster/ServerClusterInterfaceRegistry.cpp
 
 # connectedhomeip - src - app - util
 CPPSRC += $(CHIPDIR)/src/app/util/attribute-storage.cpp
@@ -84,7 +85,6 @@ CPPSRC += $(CHIPDIR)/src/data-model-providers/codegen/CodegenDataModelProvider_R
 CPPSRC += $(CHIPDIR)/src/data-model-providers/codegen/CodegenDataModelProvider_Write.cpp
 CPPSRC += $(CHIPDIR)/src/data-model-providers/codegen/EmberAttributeDataBuffer.cpp
 CPPSRC += $(CHIPDIR)/src/data-model-providers/codegen/Instance.cpp
-CPPSRC += $(CHIPDIR)/src/data-model-providers/codegen/ServerClusterInterfaceRegistry.cpp
 
 # connectedhomeip - src - setup_payload
 CPPSRC += $(CHIPDIR)/src/setup_payload/OnboardingCodesUtil.cpp

--- a/project/amebaz2/make/matter_main_sources.mk
+++ b/project/amebaz2/make/matter_main_sources.mk
@@ -47,6 +47,7 @@ endif
 SRC_CPP += $(CHIPDIR)/src/app/server-cluster/AttributeListBuilder.cpp
 SRC_CPP += $(CHIPDIR)/src/app/server-cluster/DefaultServerCluster.cpp
 SRC_CPP += $(CHIPDIR)/src/app/server-cluster/ServerClusterInterface.cpp
+SRC_CPP += $(CHIPDIR)/src/app/server-cluster/ServerClusterInterfaceRegistry.cpp
 
 # connectedhomeip - src - app - util
 SRC_CPP += $(CHIPDIR)/src/app/util/attribute-storage.cpp
@@ -69,8 +70,6 @@ SRC_CPP += $(CHIPDIR)/src/data-model-providers/codegen/CodegenDataModelProvider_
 SRC_CPP += $(CHIPDIR)/src/data-model-providers/codegen/CodegenDataModelProvider_Write.cpp
 SRC_CPP += $(CHIPDIR)/src/data-model-providers/codegen/EmberAttributeDataBuffer.cpp
 SRC_CPP += $(CHIPDIR)/src/data-model-providers/codegen/Instance.cpp
-SRC_CPP += $(CHIPDIR)/src/data-model-providers/codegen/ServerClusterInterfaceRegistry.cpp
-
 # connectedhomeip - src - setup_payload
 SRC_CPP += $(CHIPDIR)/src/setup_payload/OnboardingCodesUtil.cpp
 

--- a/project/amebaz2plus/make/matter_main_sources.mk
+++ b/project/amebaz2plus/make/matter_main_sources.mk
@@ -46,6 +46,7 @@ endif
 SRC_CPP += $(CHIPDIR)/src/app/server-cluster/AttributeListBuilder.cpp
 SRC_CPP += $(CHIPDIR)/src/app/server-cluster/DefaultServerCluster.cpp
 SRC_CPP += $(CHIPDIR)/src/app/server-cluster/ServerClusterInterface.cpp
+SRC_CPP += $(CHIPDIR)/src/app/server-cluster/ServerClusterInterfaceRegistry.cpp
 
 # connectedhomeip - src - app - util
 SRC_CPP += $(CHIPDIR)/src/app/util/attribute-storage.cpp
@@ -68,7 +69,6 @@ SRC_CPP += $(CHIPDIR)/src/data-model-providers/codegen/CodegenDataModelProvider_
 SRC_CPP += $(CHIPDIR)/src/data-model-providers/codegen/CodegenDataModelProvider_Write.cpp
 SRC_CPP += $(CHIPDIR)/src/data-model-providers/codegen/EmberAttributeDataBuffer.cpp
 SRC_CPP += $(CHIPDIR)/src/data-model-providers/codegen/Instance.cpp
-SRC_CPP += $(CHIPDIR)/src/data-model-providers/codegen/ServerClusterInterfaceRegistry.cpp
 
 # connectedhomeip - src - setup_payload
 SRC_CPP += $(CHIPDIR)/src/setup_payload/OnboardingCodesUtil.cpp

--- a/tools/docker/amebad/Dockerfile
+++ b/tools/docker/amebad/Dockerfile
@@ -3,7 +3,7 @@ FROM ameba-rtos-matter:common
 
 # Redefine following build arguments to respective repo and tag/branch
 ARG AMEBA_MATTER_REPO=https://github.com/xshuqun/ameba-rtos-matter.git
-ARG TAG_NAME=ameba/ota_update_250724
+ARG TAG_NAME=ameba/update_bootreason_250801
 
 # Define fixed build arguments
 ARG AMBD_REPO=https://github.com/Ameba-AIoT/ameba-rtos-d.git

--- a/tools/docker/amebaz2/Dockerfile
+++ b/tools/docker/amebaz2/Dockerfile
@@ -3,7 +3,7 @@ FROM ameba-rtos-matter:common
 
 # Redefine following build arguments to respective repo and tag/branch
 ARG AMEBA_MATTER_REPO=https://github.com/xshuqun/ameba-rtos-matter.git
-ARG TAG_NAME=ameba/ota_update_250724
+ARG TAG_NAME=ameba/update_bootreason_250801
 
 # Define fixed build arguments
 ARG AMBZ2_REPO=https://github.com/Ameba-AIoT/ameba-rtos-z2.git


### PR DESCRIPTION
This PR addresses:

* Linking Matter BootReason with Ameba ResetReason.
* Add kOTACompleted key value to identify if it is ota or normal software reset.
* Fixed build error for ServerClusterInterfaceRegistry.cpp, file location changes.

Verification:
Tested with different device reset and obtain its corresponding resetreason and bootreason.