### PR TITLE
[general][sdk] fix build error for v1.4.2

### DIFF
--- a/drivers/matter_drivers/energy_evse/ameba_energy_evse_delegate_impl.cpp
+++ b/drivers/matter_drivers/energy_evse/ameba_energy_evse_delegate_impl.cpp
@@ -79,13 +79,13 @@ Status EnergyEvseDelegate::EnableCharging(const DataModel::Nullable<uint32_t> & 
 {
     ChipLogProgress(AppServer, "EnergyEvseDelegate::EnableCharging()");
 
-    if (maximumChargeCurrent < kMinimumChargeCurrentLimit)
+    if (maximumChargeCurrent < mMinimumChargeCurrent)
     {
         ChipLogError(AppServer, "Maximum Current outside limits");
         return Status::ConstraintError;
     }
 
-    if (minimumChargeCurrent < kMinimumChargeCurrentLimit)
+    if (minimumChargeCurrent < mMinimumChargeCurrent)
     {
         ChipLogError(AppServer, "Minimum Current outside limits");
         return Status::ConstraintError;
@@ -342,7 +342,7 @@ Status EnergyEvseDelegate::HwRegisterEvseCallbackHandler(EVSECallbackFunc handle
  */
 Status EnergyEvseDelegate::HwSetMaxHardwareCurrentLimit(int64_t currentmA)
 {
-    if (currentmA < kMinimumChargeCurrentLimit)
+    if (currentmA < mMinimumChargeCurrent)
     {
         return Status::ConstraintError;
     }
@@ -364,7 +364,7 @@ Status EnergyEvseDelegate::HwSetMaxHardwareCurrentLimit(int64_t currentmA)
  */
 Status EnergyEvseDelegate::HwSetCircuitCapacity(int64_t currentmA)
 {
-    if (currentmA < kMinimumChargeCurrentLimit)
+    if (currentmA < mMinimumChargeCurrent)
     {
         return Status::ConstraintError;
     }
@@ -389,7 +389,7 @@ Status EnergyEvseDelegate::HwSetCircuitCapacity(int64_t currentmA)
  */
 Status EnergyEvseDelegate::HwSetCableAssemblyLimit(int64_t currentmA)
 {
-    if (currentmA < kMinimumChargeCurrentLimit)
+    if (currentmA < mMinimumChargeCurrent)
     {
         return Status::ConstraintError;
     }

--- a/project/amebad/make/chip_main/matter_main_sources.mk
+++ b/project/amebad/make/chip_main/matter_main_sources.mk
@@ -59,11 +59,8 @@ CPPSRC += $(CHIPDIR)/src/app/server/TermsAndConditionsManager.cpp
 endif
 
 # connectedhomeip - src - app - server-cluster
-CPPSRC += $(CHIPDIR)/src/app/server-cluster/AttributeListBuilder.cpp
 CPPSRC += $(CHIPDIR)/src/app/server-cluster/DefaultServerCluster.cpp
 CPPSRC += $(CHIPDIR)/src/app/server-cluster/ServerClusterInterface.cpp
-CPPSRC += $(CHIPDIR)/src/app/server-cluster/ServerClusterInterfaceRegistry.cpp
-CPPSRC += $(CHIPDIR)/src/app/server-cluster/SingleEndpointServerClusterRegistry.cpp
 
 # connectedhomeip - src - app - util
 CPPSRC += $(CHIPDIR)/src/app/util/attribute-storage.cpp
@@ -76,9 +73,9 @@ CPPSRC += $(CHIPDIR)/src/app/util/util.cpp
 CPPSRC += $(CHIPDIR)/src/app/util/privilege-storage.cpp
 
 # connectedhomeip - src - app - persistence
-CPPSRC += $(CHIPDIR)/src/app/persistence/AttributePersistenceProviderInstance.cpp
-CPPSRC += $(CHIPDIR)/src/app/persistence/DefaultAttributePersistenceProvider.cpp
-CPPSRC += $(CHIPDIR)/src/app/persistence/DeferredAttributePersistenceProvider.cpp
+CPPSRC += $(CHIPDIR)/src/app/util/persistence/AttributePersistenceProvider.cpp
+CPPSRC += $(CHIPDIR)/src/app/util/persistence/DefaultAttributePersistenceProvider.cpp
+CPPSRC += $(CHIPDIR)/src/app/util/persistence/DeferredAttributePersistenceProvider.cpp
 
 # connectedhomeip - src - data-model-providers
 CPPSRC += $(CHIPDIR)/src/data-model-providers/codegen/CodegenDataModelProvider.cpp
@@ -86,6 +83,8 @@ CPPSRC += $(CHIPDIR)/src/data-model-providers/codegen/CodegenDataModelProvider_R
 CPPSRC += $(CHIPDIR)/src/data-model-providers/codegen/CodegenDataModelProvider_Write.cpp
 CPPSRC += $(CHIPDIR)/src/data-model-providers/codegen/EmberAttributeDataBuffer.cpp
 CPPSRC += $(CHIPDIR)/src/data-model-providers/codegen/Instance.cpp
+CPPSRC += $(CHIPDIR)/src/data-model-providers/codegen/ServerClusterInterfaceRegistry.cpp
+CPPSRC += $(CHIPDIR)/src/data-model-providers/codegen/EmberMetadata.cpp
 
 # connectedhomeip - src - setup_payload
 CPPSRC += $(CHIPDIR)/src/setup_payload/OnboardingCodesUtil.cpp

--- a/project/amebaz2/make/matter_main_sources.mk
+++ b/project/amebaz2/make/matter_main_sources.mk
@@ -44,10 +44,8 @@ SRC_CPP += $(CHIPDIR)/src/app/server/TermsAndConditionsManager.cpp
 endif
 
 # connectedhomeip - src - app - server-cluster
-SRC_CPP += $(CHIPDIR)/src/app/server-cluster/AttributeListBuilder.cpp
 SRC_CPP += $(CHIPDIR)/src/app/server-cluster/DefaultServerCluster.cpp
 SRC_CPP += $(CHIPDIR)/src/app/server-cluster/ServerClusterInterface.cpp
-SRC_CPP += $(CHIPDIR)/src/app/server-cluster/ServerClusterInterfaceRegistry.cpp
 
 # connectedhomeip - src - app - util
 SRC_CPP += $(CHIPDIR)/src/app/util/attribute-storage.cpp
@@ -60,10 +58,9 @@ SRC_CPP += $(CHIPDIR)/src/app/util/util.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/privilege-storage.cpp
 
 # connectedhomeip - src - app - persistence
-SRC_CPP += $(CHIPDIR)/src/app/persistence/AttributePersistenceProviderInstance.cpp
-SRC_CPP += $(CHIPDIR)/src/app/persistence/DefaultAttributePersistenceProvider.cpp
-SRC_CPP += $(CHIPDIR)/src/app/persistence/DeferredAttributePersistenceProvider.cpp
-SRC_CPP += $(CHIPDIR)/src/app/server-cluster/SingleEndpointServerClusterRegistry.cpp
+SRC_CPP += $(CHIPDIR)/src/app/util/persistence/AttributePersistenceProvider.cpp
+SRC_CPP += $(CHIPDIR)/src/app/util/persistence/DefaultAttributePersistenceProvider.cpp
+SRC_CPP += $(CHIPDIR)/src/app/util/persistence/DeferredAttributePersistenceProvider.cpp
 
 # connectedhomeip - src - data-model-providers
 SRC_CPP += $(CHIPDIR)/src/data-model-providers/codegen/CodegenDataModelProvider.cpp
@@ -71,6 +68,9 @@ SRC_CPP += $(CHIPDIR)/src/data-model-providers/codegen/CodegenDataModelProvider_
 SRC_CPP += $(CHIPDIR)/src/data-model-providers/codegen/CodegenDataModelProvider_Write.cpp
 SRC_CPP += $(CHIPDIR)/src/data-model-providers/codegen/EmberAttributeDataBuffer.cpp
 SRC_CPP += $(CHIPDIR)/src/data-model-providers/codegen/Instance.cpp
+SRC_CPP += $(CHIPDIR)/src/data-model-providers/codegen/ServerClusterInterfaceRegistry.cpp
+SRC_CPP += $(CHIPDIR)/src/data-model-providers/codegen/EmberMetadata.cpp
+
 # connectedhomeip - src - setup_payload
 SRC_CPP += $(CHIPDIR)/src/setup_payload/OnboardingCodesUtil.cpp
 

--- a/project/amebaz2plus/make/matter_main_sources.mk
+++ b/project/amebaz2plus/make/matter_main_sources.mk
@@ -43,11 +43,8 @@ SRC_CPP += $(CHIPDIR)/src/app/server/TermsAndConditionsManager.cpp
 endif
 
 # connectedhomeip - src - app - server-cluster
-SRC_CPP += $(CHIPDIR)/src/app/server-cluster/AttributeListBuilder.cpp
 SRC_CPP += $(CHIPDIR)/src/app/server-cluster/DefaultServerCluster.cpp
 SRC_CPP += $(CHIPDIR)/src/app/server-cluster/ServerClusterInterface.cpp
-SRC_CPP += $(CHIPDIR)/src/app/server-cluster/ServerClusterInterfaceRegistry.cpp
-SRC_CPP += $(CHIPDIR)/src/app/server-cluster/SingleEndpointServerClusterRegistry.cpp
 
 # connectedhomeip - src - app - util
 SRC_CPP += $(CHIPDIR)/src/app/util/attribute-storage.cpp
@@ -60,9 +57,9 @@ SRC_CPP += $(CHIPDIR)/src/app/util/util.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/privilege-storage.cpp
 
 # connectedhomeip - src - app - persistence
-SRC_CPP += $(CHIPDIR)/src/app/persistence/AttributePersistenceProviderInstance.cpp
-SRC_CPP += $(CHIPDIR)/src/app/persistence/DefaultAttributePersistenceProvider.cpp
-SRC_CPP += $(CHIPDIR)/src/app/persistence/DeferredAttributePersistenceProvider.cpp
+SRC_CPP += $(CHIPDIR)/src/app/util/persistence/AttributePersistenceProvider.cpp
+SRC_CPP += $(CHIPDIR)/src/app/util/persistence/DefaultAttributePersistenceProvider.cpp
+SRC_CPP += $(CHIPDIR)/src/app/util/persistence/DeferredAttributePersistenceProvider.cpp
 
 # connectedhomeip - src - data-model-providers
 SRC_CPP += $(CHIPDIR)/src/data-model-providers/codegen/CodegenDataModelProvider.cpp
@@ -70,6 +67,8 @@ SRC_CPP += $(CHIPDIR)/src/data-model-providers/codegen/CodegenDataModelProvider_
 SRC_CPP += $(CHIPDIR)/src/data-model-providers/codegen/CodegenDataModelProvider_Write.cpp
 SRC_CPP += $(CHIPDIR)/src/data-model-providers/codegen/EmberAttributeDataBuffer.cpp
 SRC_CPP += $(CHIPDIR)/src/data-model-providers/codegen/Instance.cpp
+SRC_CPP += $(CHIPDIR)/src/data-model-providers/codegen/ServerClusterInterfaceRegistry.cpp
+SRC_CPP += $(CHIPDIR)/src/data-model-providers/codegen/EmberMetadata.cpp
 
 # connectedhomeip - src - setup_payload
 SRC_CPP += $(CHIPDIR)/src/setup_payload/OnboardingCodesUtil.cpp

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -23,7 +23,7 @@ RUN set -x \
 
 # Define build arguments for repositories
 ARG CHIP_REPO=https://github.com/project-chip/connectedhomeip.git
-ARG CHIP_REF=master
+ARG CHIP_REF=v1.4.2-branch
 ARG AMEBA_DIR=/opt/ameba
 
 # Create the necessary directory, clone the connectedhomeip repo

--- a/tools/docker/amebad/Dockerfile
+++ b/tools/docker/amebad/Dockerfile
@@ -3,7 +3,7 @@ FROM ameba-rtos-matter:common
 
 # Redefine following build arguments to respective repo and tag/branch
 ARG AMEBA_MATTER_REPO=https://github.com/xshuqun/ameba-rtos-matter.git
-ARG TAG_NAME=ameba/add_acl_extensions
+ARG TAG_NAME=ameba/v1.4.2/fix_build_error_250810
 
 # Define fixed build arguments
 ARG AMBD_REPO=https://github.com/Ameba-AIoT/ameba-rtos-d.git

--- a/tools/docker/amebaz2/Dockerfile
+++ b/tools/docker/amebaz2/Dockerfile
@@ -3,7 +3,7 @@ FROM ameba-rtos-matter:common
 
 # Redefine following build arguments to respective repo and tag/branch
 ARG AMEBA_MATTER_REPO=https://github.com/xshuqun/ameba-rtos-matter.git
-ARG TAG_NAME=ameba/add_acl_extensions
+ARG TAG_NAME=ameba/v1.4.2/fix_build_error_250810
 
 # Define fixed build arguments
 ARG AMBZ2_REPO=https://github.com/Ameba-AIoT/ameba-rtos-z2.git


### PR DESCRIPTION
This PR addresses:

* fix build error based on connectedhomeip v1.4.2-branch.
* update docker to matter v1.4.2.

Verification:
Test by CI.