### PR TITLE
[ameba-rtos][sdk] Fix Secure MbedTLS

### DIFF
--- a/common/mbedtls/matter_mbedtls_config.h
+++ b/common/mbedtls/matter_mbedtls_config.h
@@ -42,7 +42,7 @@
 int strstr(const char *s1, const char *s2);
 #define __weak __attribute__((weak))
 #define u32 uint32_t
-#define MATTER_MBEDTLS_SECURE_HEAP_SIZE		U(4 * 1024)
+#define MATTER_MBEDTLS_SECURE_HEAP_SIZE		U(8 * 1024)
 
 #endif
 

--- a/common/mbedtls/matter_mbedtls_nsc.c
+++ b/common/mbedtls/matter_mbedtls_nsc.c
@@ -17,6 +17,7 @@
  *    limitations under the License.
  */
 
+#include "platform_autoconf.h"
 #if defined(CONFIG_AMEBADPLUS) || defined(CONFIG_AMEBALITE)
 #include "cmsis.h"
 #include "platform_stdlib.h"
@@ -108,16 +109,6 @@ static int _random(void *p_rng, unsigned char *output, size_t output_len)
 }
 
 #endif //defined(CONFIG_XXX)
-
-#if defined(CONFIG_AMEBADPLUS) || defined(CONFIG_AMEBALITE)
-IMAGE3_ENTRY_SECTION
-int NS_ENTRY secure_mbedtls_platform_set_calloc_free(void)
-#elif defined(CONFIG_AMEBASMART)
-int secure_mbedtls_platform_set_calloc_free(void)
-#endif
-{
-	return 	mbedtls_platform_set_calloc_free(_calloc, _free);
-}
 
 /**
  * @brief Clears the Key Pair associated with the specified Matter Key Type.

--- a/common/mbedtls/mbedtls-2.28.1/library_s/mbedtls_nsc.c
+++ b/common/mbedtls/mbedtls-2.28.1/library_s/mbedtls_nsc.c
@@ -1,3 +1,22 @@
+/*
+ *    This module is a confidential and proprietary property of RealTek and
+ *    possession or use of this module requires written permission of RealTek.
+ *
+ *    Copyright(c) 2025, Realtek Semiconductor Corporation. All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#include "platform_autoconf.h"
 #if defined(CONFIG_AMEBADPLUS) || defined(CONFIG_AMEBALITE)
 #include "cmsis.h"
 #include "platform_stdlib.h"

--- a/common/mbedtls/mbedtls-3.6.1/library_s/mbedtls_nsc.c
+++ b/common/mbedtls/mbedtls-3.6.1/library_s/mbedtls_nsc.c
@@ -1,3 +1,22 @@
+/*
+ *    This module is a confidential and proprietary property of RealTek and
+ *    possession or use of this module requires written permission of RealTek.
+ *
+ *    Copyright(c) 2025, Realtek Semiconductor Corporation. All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#include "platform_autoconf.h"
 #if defined(CONFIG_AMEBADPLUS) || defined(CONFIG_AMEBALITE)
 #include "cmsis.h"
 #include "platform_stdlib.h"

--- a/common/port/matter_utils.c
+++ b/common/port/matter_utils.c
@@ -18,6 +18,7 @@
  */
 
 #include <platform_stdlib.h>
+#include <platform_autoconf.h>
 // These addresses are located right after VFS1
 #if defined(CONFIG_AMEBADPLUS) || defined(CONFIG_AMEBALITE)
 #define MATTER_FACTORY_DATA (0x08400000 - SPI_FLASH_BASE)

--- a/project/amebadplus/make/mbedtls_secure/library_s/Makefile
+++ b/project/amebadplus/make/mbedtls_secure/library_s/Makefile
@@ -16,6 +16,7 @@ vpath %.c $(DIR) $(shell find $(DIR) -type d) $(shell find $(MATTER_MBEDTLSDIR) 
 #                               Source FILE LIST                              #
 #*****************************************************************************#
 CSRC = $(MATTER_MBEDTLSDIR)/matter_mbedtls_nsc.c \
+       $(MBEDTLSDIR)/library_s/mbedtls_nsc.c \
        $(MATTER_DIR)/common/os/freertos_secure_additions.c
 
 #*****************************************************************************#

--- a/project/amebalite/make/mbedtls_secure/library_s/Makefile
+++ b/project/amebalite/make/mbedtls_secure/library_s/Makefile
@@ -16,6 +16,7 @@ vpath %.c $(DIR) $(shell find $(DIR) -type d) $(shell find $(MATTER_MBEDTLSDIR) 
 #                               Source FILE LIST                              #
 #*****************************************************************************#
 CSRC = $(MATTER_MBEDTLSDIR)/matter_mbedtls_nsc.c \
+       $(MBEDTLSDIR)/library_s/mbedtls_nsc.c \
        $(MATTER_DIR)/common/os/freertos_secure_additions.c
 
 #*****************************************************************************#

--- a/project/amebasmart/make/atf/mbedtls_secure/Makefile
+++ b/project/amebasmart/make/atf/mbedtls_secure/Makefile
@@ -84,7 +84,8 @@ LIBMBEDTLS_SRCS+= $(addprefix ${MBEDTLS_DIR}/library/, \
                     )
 endif
 
-LIBMBEDTLS_SRCS += ${MATTER_MBEDTLSDIR}/matter_mbedtls_nsc.c
+LIBMBEDTLS_SRCS += ${MATTER_MBEDTLSDIR}/matter_mbedtls_nsc.c \
+                   ${MBEDTLS_DIR}/library_s/mbedtls_nsc.c
 
 $(eval $(call MAKE_LIB,mbedtls))
 


### PR DESCRIPTION
This PR addresses:
* Increased the size of MATTER_MBEDTLS_SECURE_HEAP_SIZE to 8 * 1024 to accomodate secure mbedtls-2.28.1 on AmebaSmart
* Removed secure_mbedtls_platform_set_calloc_free() from matter_mbedtls_nsc.c
* Included platform_autoconf.h to some source codes
* Included library_s/mbedtls_nsc.c to Makefile to link the secure_mbedtls_platform_set_calloc_free()

Verification:
Test with chip-tool.