### PR TITLE
[general][sdk] start matter_op_hours after matter_data_provider_init

### DIFF
--- a/tools/docker/amebad/Dockerfile
+++ b/tools/docker/amebad/Dockerfile
@@ -3,7 +3,7 @@ FROM ameba-rtos-matter:common
 
 # Redefine following build arguments to respective repo and tag/branch
 ARG AMEBA_MATTER_REPO=https://github.com/xshuqun/ameba-rtos-matter.git
-ARG TAG_NAME=ameba/update_mbedtls_v1.4.2_250828
+ARG TAG_NAME=ameba/v1.4.2/update_sdk_250905
 
 # Define fixed build arguments
 ARG AMBD_REPO=https://github.com/Ameba-AIoT/ameba-rtos-d.git

--- a/tools/docker/amebaz2/Dockerfile
+++ b/tools/docker/amebaz2/Dockerfile
@@ -3,7 +3,7 @@ FROM ameba-rtos-matter:common
 
 # Redefine following build arguments to respective repo and tag/branch
 ARG AMEBA_MATTER_REPO=https://github.com/xshuqun/ameba-rtos-matter.git
-ARG TAG_NAME=ameba/update_mbedtls_v1.4.2_250828
+ARG TAG_NAME=ameba/v1.4.2/update_sdk_250905
 
 # Define fixed build arguments
 ARG AMBZ2_REPO=https://github.com/Ameba-AIoT/ameba-rtos-z2.git


### PR DESCRIPTION
This PR addresses:
* To prevent DCT conflict, start matter_op_hours after matter_data_provider_init has been completed.
* Normalized file with linux standard.

Verification:
Tested on porting layer.