### PR TITLE
[general][sdk] fix security vulnerability and update sdk

### DIFF
--- a/common/include/lwipopts_matter.h
+++ b/common/include/lwipopts_matter.h
@@ -63,6 +63,12 @@ extern "C" {
 #undef PBUF_POOL_BUFSIZE
 #define PBUF_POOL_BUFSIZE               1500
 
+#undef MEM_LIBC_MALLOC
+#define MEM_LIBC_MALLOC                 1
+
+#undef MEMP_MEM_MALLOC
+#define MEMP_MEM_MALLOC                 1
+
 /* UDP and Timeout Options */
 #undef MEMP_NUM_UDP_PCB
 #define MEMP_NUM_UDP_PCB                10

--- a/common/lwip/lwip_v2.1.2/port/realtek/hooks/lwip_default_hooks.c
+++ b/common/lwip/lwip_v2.1.2/port/realtek/hooks/lwip_default_hooks.c
@@ -1,5 +1,7 @@
 #include "lwip_default_hooks.h"
 
+#if LWIP_IPV6  /* don't build if not configured for use in lwipopts.h */
+
 #define __weak __attribute__((weak))
 
 struct netif *__weak
@@ -18,3 +20,5 @@ const ip6_addr_t *__weak lwip_hook_nd6_get_gw(struct netif *netif, const ip6_add
 
     return 0;
 }
+
+#endif /* LWIP_IPV6 */

--- a/common/lwip/lwip_v2.1.2/port/realtek/include/lwip_default_hooks.h
+++ b/common/lwip/lwip_v2.1.2/port/realtek/include/lwip_default_hooks.h
@@ -4,6 +4,8 @@
 #include "lwip/arch.h"
 #include "lwip/err.h"
 
+#if LWIP_IPV6  /* don't build if not configured for use in lwipopts.h */
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -18,4 +20,5 @@ const ip6_addr_t *lwip_hook_nd6_get_gw(struct netif *netif, const ip6_addr_t *de
 }
 #endif
 
+#endif /* LWIP_IPV6 */
 #endif /* _LWIP_DEFAULT_HOOKS_H_ */

--- a/common/lwip/lwip_v2.1.2/src/include/lwip/opt.h
+++ b/common/lwip/lwip_v2.1.2/src/include/lwip/opt.h
@@ -255,7 +255,7 @@
  * already use it.
  */
 #if !defined MEM_LIBC_MALLOC || defined __DOXYGEN__
-#define MEM_LIBC_MALLOC                 1
+#define MEM_LIBC_MALLOC                 0
 #endif
 
 /**
@@ -268,7 +268,7 @@
  * not only for internal pools defined in memp_std.h)!
  */
 #if !defined MEMP_MEM_MALLOC || defined __DOXYGEN__
-#define MEMP_MEM_MALLOC                 1
+#define MEMP_MEM_MALLOC                 0
 #endif
 
 /**

--- a/common/mbedtls/mbedtls-3.6.1/include/mbedtls/x509.h
+++ b/common/mbedtls/mbedtls-3.6.1/include/mbedtls/x509.h
@@ -332,7 +332,7 @@ int mbedtls_x509_dn_gets(char *buf, size_t size, const mbedtls_x509_name *dn);
  *                   call to mbedtls_asn1_free_named_data_list().
  *
  * \param[out] head  Address in which to store the pointer to the head of the
- *                   allocated list of mbedtls_x509_name
+ *                   allocated list of mbedtls_x509_name. Must point to NULL on entry.
  * \param[in] name   The string representation of a DN to convert
  *
  * \return           0 on success, or a negative error code.

--- a/common/mbedtls/mbedtls-3.6.1/library/aes_alt.c
+++ b/common/mbedtls/mbedtls-3.6.1/library/aes_alt.c
@@ -1,0 +1,392 @@
+/*
+ *  FIPS-197 compliant AES implementation
+ *
+ *  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+ */
+/*
+ *  The AES block cipher was designed by Vincent Rijmen and Joan Daemen.
+ *
+ *  https://csrc.nist.gov/csrc/media/projects/cryptographic-standards-and-guidelines/documents/aes-development/rijndael-ammended.pdf
+ *  http://csrc.nist.gov/publications/fips/fips197/fips-197.pdf
+ */
+
+#include "common.h"
+
+#if defined(MBEDTLS_AES_ALT)
+
+#include <string.h>
+
+#include "mbedtls/aes.h"
+#include "mbedtls/platform.h"
+#include "mbedtls/platform_util.h"
+#include "mbedtls/error.h"
+
+#include "ctr.h"
+
+#include <hal_crypto.h>
+#include "device_lock.h"
+
+void mbedtls_aes_init(mbedtls_aes_context *ctx)
+{
+    memset(ctx, 0, sizeof(mbedtls_aes_context));
+}
+
+void mbedtls_aes_free(mbedtls_aes_context *ctx)
+{
+    if (ctx == NULL) {
+        return;
+    }
+
+    mbedtls_platform_zeroize(ctx, sizeof(mbedtls_aes_context));
+}
+
+/*
+ * AES key schedule (encryption)
+ */
+#if !defined(MBEDTLS_AES_SETKEY_ENC_ALT)
+int mbedtls_aes_setkey_enc(mbedtls_aes_context *ctx, const unsigned char *key,
+                           unsigned int keybits)
+{
+    switch (keybits) {
+        case 128: ctx->nr = 10; break;
+#if !defined(MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH)
+        case 192: ctx->nr = 12; break;
+        case 256: ctx->nr = 14; break;
+#endif /* !MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH */
+        default: return MBEDTLS_ERR_AES_INVALID_KEY_LENGTH;
+    }
+
+    ctx->rk = (uint8_t *) (((uint32_t) ctx->buf + 31) / 32 * 32);
+    memcpy(ctx->rk, key, keybits / 8);
+
+    return 0;
+}
+#endif /* !MBEDTLS_AES_SETKEY_ENC_ALT */
+
+/*
+ * AES key schedule (decryption)
+ */
+#if !defined(MBEDTLS_AES_SETKEY_DEC_ALT) && !defined(MBEDTLS_BLOCK_CIPHER_NO_DECRYPT)
+int mbedtls_aes_setkey_dec(mbedtls_aes_context *ctx, const unsigned char *key,
+                           unsigned int keybits)
+{
+    int ret;
+
+    /* Also checks keybits */
+    if ((ret = mbedtls_aes_setkey_enc(ctx, key, keybits)) != 0) {
+        goto exit;
+    }
+
+exit:
+
+    return ret;
+}
+#endif /* !MBEDTLS_AES_SETKEY_DEC_ALT && !MBEDTLS_BLOCK_CIPHER_NO_DECRYPT */
+
+/*
+ * AES-ECB block encryption/decryption
+ */
+int mbedtls_aes_crypt_ecb(mbedtls_aes_context *ctx,
+                          int mode,
+                          const unsigned char input[16],
+                          unsigned char output[16])
+{
+    unsigned char key_buf[32 + 32 + 32], *key_buf_aligned;
+
+    if (mode != MBEDTLS_AES_ENCRYPT && mode != MBEDTLS_AES_DECRYPT) {
+        return MBEDTLS_ERR_AES_BAD_INPUT_DATA;
+    }
+
+    device_mutex_lock(RT_DEV_LOCK_CRYPTO);
+    key_buf_aligned = (unsigned char *) (((unsigned int) key_buf + 32) / 32 * 32);
+    if(mode == MBEDTLS_AES_DECRYPT)
+    {
+        memcpy(key_buf_aligned, ctx->rk, ((ctx->nr - 6) * 4));
+        rom_ssl_ram_map.hw_crypto_aes_ecb_init(key_buf_aligned, ((ctx->nr - 6) * 4));
+        rom_ssl_ram_map.hw_crypto_aes_ecb_decrypt(input, 16, NULL, 0, output);
+    }
+    else
+    {
+        memcpy(key_buf_aligned, ctx->rk, ((ctx->nr - 6) * 4));
+        rom_ssl_ram_map.hw_crypto_aes_ecb_init(key_buf_aligned,((ctx->nr - 6) * 4));
+        rom_ssl_ram_map.hw_crypto_aes_ecb_encrypt(input, 16, NULL, 0, output);
+    }
+	device_mutex_unlock(RT_DEV_LOCK_CRYPTO);
+
+	return 0;
+}
+
+#if defined(MBEDTLS_CIPHER_MODE_CBC)
+
+/*
+ * AES-CBC buffer encryption/decryption
+ */
+int mbedtls_aes_crypt_cbc(mbedtls_aes_context *ctx,
+                          int mode,
+                          size_t length,
+                          unsigned char iv[16],
+                          const unsigned char *input,
+                          unsigned char *output)
+{
+	unsigned char key_buf[32 + 32 + 32], *key_buf_aligned;
+    unsigned char iv_buf[32 + 16 + 32], *iv_buf_aligned, iv_tmp[16];
+    size_t length_done = 0;
+
+    if (mode != MBEDTLS_AES_ENCRYPT && mode != MBEDTLS_AES_DECRYPT) {
+        return MBEDTLS_ERR_AES_BAD_INPUT_DATA;
+    }
+
+    /* Nothing to do if length is zero. */
+    if (length == 0) {
+        return 0;
+    }
+
+    if (length % 16) {
+        return MBEDTLS_ERR_AES_INVALID_INPUT_LENGTH;
+    }
+
+    device_mutex_lock(RT_DEV_LOCK_CRYPTO);
+
+    if(length > 0)
+    {
+        key_buf_aligned = (unsigned char *) (((unsigned int) key_buf + 32) / 32 * 32);
+        iv_buf_aligned = (unsigned char *) (((unsigned int) iv_buf + 32) / 32 * 32);
+
+        memcpy(iv_buf_aligned, iv, 16);
+
+        if(mode == MBEDTLS_AES_DECRYPT)
+        {
+            memcpy(key_buf_aligned, ctx->rk, ((ctx->nr - 6) * 4));
+            rom_ssl_ram_map.hw_crypto_aes_cbc_init(key_buf_aligned, ((ctx->nr - 6) * 4));
+
+            while((length - length_done) > RTL_CRYPTO_FRAGMENT)
+            {
+                memcpy(iv_tmp, (input + length_done + RTL_CRYPTO_FRAGMENT - 16), 16);
+                rom_ssl_ram_map.hw_crypto_aes_cbc_decrypt(input + length_done, RTL_CRYPTO_FRAGMENT, iv_buf_aligned, 16, output + length_done);
+                memcpy(iv_buf_aligned, iv_tmp, 16);
+                length_done += RTL_CRYPTO_FRAGMENT;
+            }
+
+            memcpy(iv_tmp, (input + length - 16), 16);
+            rom_ssl_ram_map.hw_crypto_aes_cbc_decrypt(input + length_done, length - length_done, iv_buf_aligned, 16, output + length_done);
+            memcpy(iv, iv_tmp, 16);
+        }
+        else
+        {
+            memcpy(key_buf_aligned, ctx->rk, ((ctx->nr - 6) * 4));
+            rom_ssl_ram_map.hw_crypto_aes_cbc_init(key_buf_aligned,((ctx->nr - 6) * 4));
+
+            while((length - length_done) > RTL_CRYPTO_FRAGMENT)
+            {
+                rom_ssl_ram_map.hw_crypto_aes_cbc_encrypt(input + length_done, RTL_CRYPTO_FRAGMENT, iv_buf_aligned, 16, output + length_done);
+                memcpy(iv_buf_aligned, (output + length_done + RTL_CRYPTO_FRAGMENT - 16), 16);
+                length_done += RTL_CRYPTO_FRAGMENT;
+            }
+            rom_ssl_ram_map.hw_crypto_aes_cbc_encrypt(input + length_done, length - length_done, iv_buf_aligned, 16, output + length_done);
+            memcpy(iv, (output + length - 16), 16);
+        }
+    }	
+    device_mutex_unlock(RT_DEV_LOCK_CRYPTO);
+
+	return 0;
+}
+#endif /* MBEDTLS_CIPHER_MODE_CBC */
+
+#if defined(MBEDTLS_CIPHER_MODE_CFB)
+/*
+ * AES-CFB128 buffer encryption/decryption
+ */
+int mbedtls_aes_crypt_cfb128(mbedtls_aes_context *ctx,
+                             int mode,
+                             size_t length,
+                             size_t *iv_off,
+                             unsigned char iv[16],
+                             const unsigned char *input,
+                             unsigned char *output)
+{
+    int c;
+    int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
+    size_t n;
+
+    if (mode != MBEDTLS_AES_ENCRYPT && mode != MBEDTLS_AES_DECRYPT) {
+        return MBEDTLS_ERR_AES_BAD_INPUT_DATA;
+    }
+
+    n = *iv_off;
+
+    if (n > 15) {
+        return MBEDTLS_ERR_AES_BAD_INPUT_DATA;
+    }
+
+    if (mode == MBEDTLS_AES_DECRYPT) {
+        while (length--) {
+            if (n == 0) {
+                ret = mbedtls_aes_crypt_ecb(ctx, MBEDTLS_AES_ENCRYPT, iv, iv);
+                if (ret != 0) {
+                    goto exit;
+                }
+            }
+
+            c = *input++;
+            *output++ = (unsigned char) (c ^ iv[n]);
+            iv[n] = (unsigned char) c;
+
+            n = (n + 1) & 0x0F;
+        }
+    } else {
+        while (length--) {
+            if (n == 0) {
+                ret = mbedtls_aes_crypt_ecb(ctx, MBEDTLS_AES_ENCRYPT, iv, iv);
+                if (ret != 0) {
+                    goto exit;
+                }
+            }
+
+            iv[n] = *output++ = (unsigned char) (iv[n] ^ *input++);
+
+            n = (n + 1) & 0x0F;
+        }
+    }
+
+    *iv_off = n;
+    ret = 0;
+
+exit:
+    return ret;
+}
+
+/*
+ * AES-CFB8 buffer encryption/decryption
+ */
+int mbedtls_aes_crypt_cfb8(mbedtls_aes_context *ctx,
+                           int mode,
+                           size_t length,
+                           unsigned char iv[16],
+                           const unsigned char *input,
+                           unsigned char *output)
+{
+    int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
+    unsigned char c;
+    unsigned char ov[17];
+
+    if (mode != MBEDTLS_AES_ENCRYPT && mode != MBEDTLS_AES_DECRYPT) {
+        return MBEDTLS_ERR_AES_BAD_INPUT_DATA;
+    }
+    while (length--) {
+        memcpy(ov, iv, 16);
+        ret = mbedtls_aes_crypt_ecb(ctx, MBEDTLS_AES_ENCRYPT, iv, iv);
+        if (ret != 0) {
+            goto exit;
+        }
+
+        if (mode == MBEDTLS_AES_DECRYPT) {
+            ov[16] = *input;
+        }
+
+        c = *output++ = (unsigned char) (iv[0] ^ *input++);
+
+        if (mode == MBEDTLS_AES_ENCRYPT) {
+            ov[16] = c;
+        }
+
+        memcpy(iv, ov + 1, 16);
+    }
+    ret = 0;
+
+exit:
+    return ret;
+}
+#endif /* MBEDTLS_CIPHER_MODE_CFB */
+
+#if defined(MBEDTLS_CIPHER_MODE_OFB)
+/*
+ * AES-OFB (Output Feedback Mode) buffer encryption/decryption
+ */
+int mbedtls_aes_crypt_ofb(mbedtls_aes_context *ctx,
+                          size_t length,
+                          size_t *iv_off,
+                          unsigned char iv[16],
+                          const unsigned char *input,
+                          unsigned char *output)
+{
+    int ret = 0;
+    size_t n;
+
+    n = *iv_off;
+
+    if (n > 15) {
+        return MBEDTLS_ERR_AES_BAD_INPUT_DATA;
+    }
+
+    while (length--) {
+        if (n == 0) {
+            ret = mbedtls_aes_crypt_ecb(ctx, MBEDTLS_AES_ENCRYPT, iv, iv);
+            if (ret != 0) {
+                goto exit;
+            }
+        }
+        *output++ =  *input++ ^ iv[n];
+
+        n = (n + 1) & 0x0F;
+    }
+
+    *iv_off = n;
+
+exit:
+    return ret;
+}
+#endif /* MBEDTLS_CIPHER_MODE_OFB */
+
+#if defined(MBEDTLS_CIPHER_MODE_CTR)
+/*
+ * AES-CTR buffer encryption/decryption
+ */
+int mbedtls_aes_crypt_ctr(mbedtls_aes_context *ctx,
+                          size_t length,
+                          size_t *nc_off,
+                          unsigned char nonce_counter[16],
+                          unsigned char stream_block[16],
+                          const unsigned char *input,
+                          unsigned char *output)
+{
+    int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
+
+    size_t offset = *nc_off;
+
+    if (offset > 0x0F) {
+        return MBEDTLS_ERR_AES_BAD_INPUT_DATA;
+    }
+
+    for (size_t i = 0; i < length;) {
+        size_t n = 16;
+        if (offset == 0) {
+            ret = mbedtls_aes_crypt_ecb(ctx, MBEDTLS_AES_ENCRYPT, nonce_counter, stream_block);
+            if (ret != 0) {
+                goto exit;
+            }
+            mbedtls_ctr_increment_counter(nonce_counter);
+        } else {
+            n -= offset;
+        }
+
+        if (n > (length - i)) {
+            n = (length - i);
+        }
+        mbedtls_xor(&output[i], &input[i], &stream_block[offset], n);
+        // offset might be non-zero for the last block, but in that case, we don't use it again
+        offset = 0;
+        i += n;
+    }
+
+    // capture offset for future resumption
+    *nc_off = (*nc_off + length) % 16;
+
+    ret = 0;
+
+exit:
+    return ret;
+}
+#endif /* MBEDTLS_CIPHER_MODE_CTR */
+
+#endif /* MBEDTLS_AES_ALT */

--- a/common/mbedtls/mbedtls-3.6.1/library/aesni.c
+++ b/common/mbedtls/mbedtls-3.6.1/library/aesni.c
@@ -46,8 +46,12 @@
  */
 int mbedtls_aesni_has_support(unsigned int what)
 {
-    static int done = 0;
-    static unsigned int c = 0;
+    /* To avoid a race condition, tell the compiler that the assignment
+     * `done = 1` and the assignment to `c` may not be reordered.
+     * https://github.com/Mbed-TLS/mbedtls/issues/9840
+     */
+    static volatile int done = 0;
+    static volatile unsigned int c = 0;
 
     if (!done) {
 #if MBEDTLS_AESNI_HAVE_CODE == 2

--- a/common/mbedtls/mbedtls-3.6.1/library/asn1write.c
+++ b/common/mbedtls/mbedtls-3.6.1/library/asn1write.c
@@ -412,6 +412,7 @@ mbedtls_asn1_named_data *mbedtls_asn1_store_named_data(
     } else if (val_len == 0) {
         mbedtls_free(cur->val.p);
         cur->val.p = NULL;
+        cur->val.len = 0;
     } else if (cur->val.len != val_len) {
         /*
          * Enlarge existing value buffer if needed

--- a/common/mbedtls/mbedtls-3.6.1/library/cipher.c
+++ b/common/mbedtls/mbedtls-3.6.1/library/cipher.c
@@ -849,10 +849,6 @@ static int get_pkcs_padding(unsigned char *input, size_t input_len,
     }
 
     padding_len = input[input_len - 1];
-    if (padding_len == 0 || padding_len > input_len) {
-        return MBEDTLS_ERR_CIPHER_INVALID_PADDING;
-    }
-    *data_len = input_len - padding_len;
 
     mbedtls_ct_condition_t bad = mbedtls_ct_uint_gt(padding_len, input_len);
     bad = mbedtls_ct_bool_or(bad, mbedtls_ct_uint_eq(padding_len, 0));
@@ -865,6 +861,8 @@ static int get_pkcs_padding(unsigned char *input, size_t input_len,
         mbedtls_ct_condition_t different  = mbedtls_ct_uint_ne(input[i], padding_len);
         bad = mbedtls_ct_bool_or(bad, mbedtls_ct_bool_and(in_padding, different));
     }
+    /* If the padding is invalid, set the output length to 0 */
+    *data_len = mbedtls_ct_if(bad, 0, input_len - padding_len);
 
     return mbedtls_ct_error_if_else_0(bad, MBEDTLS_ERR_CIPHER_INVALID_PADDING);
 }

--- a/common/mbedtls/mbedtls-3.6.1/library/lms.c
+++ b/common/mbedtls/mbedtls-3.6.1/library/lms.c
@@ -242,6 +242,10 @@ int mbedtls_lms_import_public_key(mbedtls_lms_public_t *ctx,
     mbedtls_lms_algorithm_type_t type;
     mbedtls_lmots_algorithm_type_t otstype;
 
+    if (key_size < 4) {
+        return MBEDTLS_ERR_LMS_BAD_INPUT_DATA;
+    }
+
     type = (mbedtls_lms_algorithm_type_t) MBEDTLS_GET_UINT32_BE(key, PUBLIC_KEY_TYPE_OFFSET);
     if (type != MBEDTLS_LMS_SHA256_M32_H10) {
         return MBEDTLS_ERR_LMS_BAD_INPUT_DATA;
@@ -374,11 +378,17 @@ int mbedtls_lms_verify(const mbedtls_lms_public_t *ctx,
         return MBEDTLS_ERR_LMS_VERIFY_FAILED;
     }
 
-    create_merkle_leaf_value(
+    ret = create_merkle_leaf_value(
         &ctx->params,
         Kc_candidate_ots_pub_key,
         MERKLE_TREE_INTERNAL_NODE_AM(ctx->params.type) + q_leaf_identifier,
         Tc_candidate_root_node);
+
+        
+    if (ret != 0) {
+        return MBEDTLS_ERR_LMS_VERIFY_FAILED;
+    }
+    
 
     curr_node_id = MERKLE_TREE_INTERNAL_NODE_AM(ctx->params.type) +
                    q_leaf_identifier;
@@ -398,9 +408,11 @@ int mbedtls_lms_verify(const mbedtls_lms_public_t *ctx,
                          height * MBEDTLS_LMS_M_NODE_BYTES(ctx->params.type);
         }
 
-        create_merkle_internal_value(&ctx->params, left_node, right_node,
+        ret = create_merkle_internal_value(&ctx->params, left_node, right_node,
                                      parent_node_id, Tc_candidate_root_node);
-
+        if (ret != 0) {
+            return MBEDTLS_ERR_LMS_VERIFY_FAILED;
+        }
         curr_node_id /= 2;
     }
 

--- a/common/mbedtls/mbedtls-3.6.1/library/pem.c
+++ b/common/mbedtls/mbedtls-3.6.1/library/pem.c
@@ -243,7 +243,10 @@ exit:
 #if defined(MBEDTLS_DES_C) || defined(MBEDTLS_AES_C)
 static int pem_check_pkcs_padding(unsigned char *input, size_t input_len, size_t *data_len)
 {
-    /* input_len > 0 is guaranteed by mbedtls_pem_read_buffer(). */
+    /* input_len > 0 is not guaranteed by mbedtls_pem_read_buffer(). */
+    if (input_len < 1) {
+        return MBEDTLS_ERR_PEM_INVALID_DATA;
+    }
     size_t pad_len = input[input_len - 1];
     size_t i;
 

--- a/common/mbedtls/mbedtls-3.6.1/library/pkwrite.c
+++ b/common/mbedtls/mbedtls-3.6.1/library/pkwrite.c
@@ -65,17 +65,21 @@ static int pk_write_rsa_der(unsigned char **p, unsigned char *buf,
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
     if (mbedtls_pk_get_type(pk) == MBEDTLS_PK_OPAQUE) {
         uint8_t tmp[PSA_EXPORT_KEY_PAIR_MAX_SIZE];
-        size_t len = 0, tmp_len = 0;
+        size_t tmp_len = 0;
 
         if (psa_export_key(pk->priv_id, tmp, sizeof(tmp), &tmp_len) != PSA_SUCCESS) {
             return MBEDTLS_ERR_PK_BAD_INPUT_DATA;
         }
+        /* Ensure there's enough space in the provided buffer before copying data into it. */
+        if (tmp_len > (size_t) (*p - buf)) {
+            mbedtls_platform_zeroize(tmp, sizeof(tmp));
+            return MBEDTLS_ERR_ASN1_BUF_TOO_SMALL;
+        }
         *p -= tmp_len;
         memcpy(*p, tmp, tmp_len);
-        len += tmp_len;
         mbedtls_platform_zeroize(tmp, sizeof(tmp));
 
-        return (int) len;
+        return (int) tmp_len;
     }
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
     return mbedtls_rsa_write_key(mbedtls_pk_rsa(*pk), buf, p);
@@ -124,6 +128,10 @@ static int pk_write_ec_pubkey(unsigned char **p, unsigned char *start,
     if (mbedtls_pk_get_type(pk) == MBEDTLS_PK_OPAQUE) {
         if (psa_export_public_key(pk->priv_id, buf, sizeof(buf), &len) != PSA_SUCCESS) {
             return MBEDTLS_ERR_PK_BAD_INPUT_DATA;
+        }
+        /* Ensure there's enough space in the provided buffer before copying data into it. */
+            if (len > (size_t) (*p - start)) {
+            return MBEDTLS_ERR_ASN1_BUF_TOO_SMALL;
         }
         *p -= len;
         memcpy(*p, buf, len);

--- a/common/mbedtls/mbedtls-3.6.1/library/ssl_tls.c
+++ b/common/mbedtls/mbedtls-3.6.1/library/ssl_tls.c
@@ -8339,6 +8339,7 @@ int mbedtls_ssl_write_finished(mbedtls_ssl_context *ssl)
     ret = ssl->handshake->calc_finished(ssl, ssl->out_msg + 4, ssl->conf->endpoint);
     if (ret != 0) {
         MBEDTLS_SSL_DEBUG_RET(1, "calc_finished", ret);
+        return ret;
     }
 
     /*
@@ -8452,6 +8453,7 @@ int mbedtls_ssl_parse_finished(mbedtls_ssl_context *ssl)
     ret = ssl->handshake->calc_finished(ssl, buf, ssl->conf->endpoint ^ 1);
     if (ret != 0) {
         MBEDTLS_SSL_DEBUG_RET(1, "calc_finished", ret);
+        return ret;
     }
 
     if ((ret = mbedtls_ssl_read_record(ssl, 1)) != 0) {

--- a/common/mbedtls/mbedtls-3.6.1/library/x509_create.c
+++ b/common/mbedtls/mbedtls-3.6.1/library/x509_create.c
@@ -292,8 +292,12 @@ int mbedtls_x509_string_to_names(mbedtls_asn1_named_data **head, const char *nam
     unsigned char data[MBEDTLS_X509_MAX_DN_NAME_SIZE];
     size_t data_len = 0;
 
-    /* Clear existing chain if present */
-    mbedtls_asn1_free_named_data_list(head);
+    /* Ensure the output parameter is not already populated.
+     * (If it were, overwriting it would likely cause a memory leak.)
+     */
+    if (*head != NULL) {
+        return MBEDTLS_ERR_X509_BAD_INPUT_DATA;
+    }
 
     while (c <= end) {
         if (in_attr_type && *c == '=') {

--- a/tools/docker/amebad/Dockerfile
+++ b/tools/docker/amebad/Dockerfile
@@ -3,7 +3,7 @@ FROM ameba-rtos-matter:common
 
 # Redefine following build arguments to respective repo and tag/branch
 ARG AMEBA_MATTER_REPO=https://github.com/xshuqun/ameba-rtos-matter.git
-ARG TAG_NAME=ameba/v1.4/update_sdk_250903
+ARG TAG_NAME=ameba/v1.4/bug_fix_251008
 
 # Define fixed build arguments
 ARG AMBD_REPO=https://github.com/Ameba-AIoT/ameba-rtos-d.git

--- a/tools/docker/amebaz2/Dockerfile
+++ b/tools/docker/amebaz2/Dockerfile
@@ -3,7 +3,7 @@ FROM ameba-rtos-matter:common
 
 # Redefine following build arguments to respective repo and tag/branch
 ARG AMEBA_MATTER_REPO=https://github.com/xshuqun/ameba-rtos-matter.git
-ARG TAG_NAME=ameba/v1.4/update_sdk_250903
+ARG TAG_NAME=ameba/v1.4/bug_fix_251008
 
 # Define fixed build arguments
 ARG AMBZ2_REPO=https://github.com/Ameba-AIoT/ameba-rtos-z2.git


### PR DESCRIPTION
This PR addresses:
* Update Blackduck scanned security high-risk items of mbedtls 3.6.1

1. CVE-2025-48965 (asn1write.c) The function mbedtls_asn1_store_named_data() frees the buffer but not to reset the cur->val.len. Updating the code to set cur->val.len=0.
2. CVE-2025-47917 (x509_create.c and x509.h) For x509_create.c, to prevent a pointer *head from being double-free in function mbedtls_x509_string_to_names(), and ensure the pointer points to NULL on entry.
3. No CVE record, only BDSA record (pkwrite.c) The function pk_write_ec_pubkey() and pk_write_rsa_der() fail to ensure there is enough space allocated for user to copy data. Add the check of buffer size.
4. CVE-2025-52496 (aesni.c) To avoid a race condition of some compiler.
5. CVE-2025-49600 (lms.c) Add a check of return value of Merkle node creation.
6. CVE-2025-52497 (pem.c) Fix Integer Underflow when Decoding PEM Keys
7. CVE-2025-27810 (ssl_tls.c) Check for failures in Finished calculation and return, not just ignore it.
8. CVE-2025-49601 (lms.c) Add a check of input key_size.
9. CVE-2025-49087 (cipher.c) Change a better way of input check (input_len, padding_len)

* Tidy up LwIP configuration and wrapping IPv6 related codes.

Verification:
Verified with Commissioning