### PR TITLE
[general][sdk] Fixes for Matter 1.5 SVE

### DIFF
--- a/drivers/matter_drivers/device_energy_management/ameba_energy_management_common_main.cpp
+++ b/drivers/matter_drivers/device_energy_management/ameba_energy_management_common_main.cpp
@@ -29,6 +29,7 @@
 #include <water_heater_mode/ameba_water_heater_mode_delegate.h>
 #include <water_heater_mode/ameba_water_heater_mode_instance.h>
 
+#include <app/clusters/electrical-energy-measurement-server/ElectricalEnergyMeasurementCluster.h>
 #include <app/clusters/electrical-energy-measurement-server/electrical-energy-measurement-server.h>
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>

--- a/drivers/matter_drivers/energy_evse/ameba_charging_targets_mem_manager.cpp
+++ b/drivers/matter_drivers/energy_evse/ameba_charging_targets_mem_manager.cpp
@@ -93,6 +93,7 @@ CHIP_ERROR ChargingTargetsMemMgr::AllocAndCopy()
     // ChargingTargetsMemMgr.h before this method can be called.
 
     VerifyOrDie(mpListOfDays[mChargingTargetSchedulesIdx] == nullptr);
+    VerifyOrReturnError(mNumDailyChargingTargets <= kEvseTargetsMaxTargetsPerDay, CHIP_ERROR_NO_MEMORY);
 
     if (mNumDailyChargingTargets > 0)
     {
@@ -124,6 +125,7 @@ ChargingTargetsMemMgr::AllocAndCopy(const DataModel::List<const Structs::Chargin
     VerifyOrDie(mpListOfDays[mChargingTargetSchedulesIdx] == nullptr);
 
     mNumDailyChargingTargets = static_cast<uint16_t>(chargingTargets.size());
+    VerifyOrReturnError(mNumDailyChargingTargets <= kEvseTargetsMaxTargetsPerDay, CHIP_ERROR_NO_MEMORY);
 
     if (mNumDailyChargingTargets > 0)
     {
@@ -161,6 +163,7 @@ ChargingTargetsMemMgr::AllocAndCopy(const DataModel::DecodableList<Structs::Char
     ReturnErrorOnFailure(chargingTargets.ComputeSize(&numDailyChargingTargets));
 
     mNumDailyChargingTargets = static_cast<uint16_t>(numDailyChargingTargets);
+    VerifyOrReturnError(mNumDailyChargingTargets <= kEvseTargetsMaxTargetsPerDay, CHIP_ERROR_NO_MEMORY);
 
     if (mNumDailyChargingTargets > 0)
     {

--- a/drivers/matter_drivers/energy_evse/ameba_energy_evse_delegate_impl.cpp
+++ b/drivers/matter_drivers/energy_evse/ameba_energy_evse_delegate_impl.cpp
@@ -242,6 +242,10 @@ Status EnergyEvseDelegate::SetTargets(
     VerifyOrReturnError(targets != nullptr, Status::Failure);
 
     CHIP_ERROR err = targets->SetTargets(chargingTargetSchedules);
+    if (err == CHIP_ERROR_NO_MEMORY)
+    {
+        return Status::ResourceExhausted;
+    }
     VerifyOrReturnError(err == CHIP_NO_ERROR, StatusIB(err).mStatus);
 
     /* The Application needs to be told that the Targets have been updated

--- a/examples/chiptest/all-clusters-app.zap
+++ b/examples/chiptest/all-clusters-app.zap
@@ -54,7 +54,7 @@
         }
       ],
       "deviceVersions": [
-        3
+        4
       ],
       "deviceIdentifiers": [
         22
@@ -9044,7 +9044,7 @@
               "storageOption": "RAM",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "2",
+              "defaultValue": "1",
               "reportable": 1,
               "minInterval": 1,
               "maxInterval": 65534,
@@ -11096,7 +11096,7 @@
               "storageOption": "RAM",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "6",
+              "defaultValue": "7",
               "reportable": 1,
               "minInterval": 0,
               "maxInterval": 65344,
@@ -11330,7 +11330,7 @@
               "storageOption": "RAM",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "5",
+              "defaultValue": "4",
               "reportable": 1,
               "minInterval": 1,
               "maxInterval": 65534,
@@ -11932,7 +11932,7 @@
               "storageOption": "RAM",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "6",
+              "defaultValue": "5",
               "reportable": 1,
               "minInterval": 1,
               "maxInterval": 65534,

--- a/tools/docker/amebad/Dockerfile
+++ b/tools/docker/amebad/Dockerfile
@@ -2,8 +2,8 @@
 FROM ameba-rtos-matter:common
 
 # Redefine following build arguments to respective repo and tag/branch
-ARG AMEBA_MATTER_REPO=https://github.com/xshuqun/ameba-rtos-matter.git
-ARG TAG_NAME=mainPR/update_sdk_251022
+ARG AMEBA_MATTER_REPO=https://github.com/mikaelajiwidodo/ameba-rtos-matter.git
+ARG TAG_NAME=ameba/main/v1.5-sve-fixes
 
 # Define fixed build arguments
 ARG AMBD_REPO=https://github.com/Ameba-AIoT/ameba-rtos-d.git

--- a/tools/docker/amebaz2/Dockerfile
+++ b/tools/docker/amebaz2/Dockerfile
@@ -2,8 +2,8 @@
 FROM ameba-rtos-matter:common
 
 # Redefine following build arguments to respective repo and tag/branch
-ARG AMEBA_MATTER_REPO=https://github.com/xshuqun/ameba-rtos-matter.git
-ARG TAG_NAME=mainPR/update_sdk_251022
+ARG AMEBA_MATTER_REPO=https://github.com/mikaelajiwidodo/ameba-rtos-matter.git
+ARG TAG_NAME=ameba/main/v1.5-sve-fixes
 
 # Define fixed build arguments
 ARG AMBZ2_REPO=https://github.com/Ameba-AIoT/ameba-rtos-z2.git


### PR DESCRIPTION
This PR addresses:
* TC-IDM-10.3 fix : update clusterRevision and deviceVersions of all-clusters-app.zap
* TC-EEVSE-2.3 fix: update energy_evse source codes based on https://github.com/project-chip/connectedhomeip/pull/41687

Verification:
Tested on AmebaD and AmebaZ2 during Matter 1.5 SVE using Test Harness