### PR TITLE
[common][sdk] support user intent commissioning flow

### DIFF
--- a/api/matter_api.cpp
+++ b/api/matter_api.cpp
@@ -1,3 +1,22 @@
+/*
+ *    This module is a confidential and proprietary property of RealTek and
+ *    possession or use of this module requires written permission of RealTek.
+ *
+ *    Copyright(c) 2025, Realtek Semiconductor Corporation. All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
 #include <platform_stdlib.h>
 #include <app/server/Server.h>
 #include <app/server/OnboardingCodesUtil.h>
@@ -15,8 +34,7 @@ using namespace ::chip::DeviceLayer;
 
 extern "C" uint8_t matter_get_total_operational_hour(uint32_t *totalOperationalHours)
 {
-    if (totalOperationalHours == nullptr)
-    {
+    if (totalOperationalHours == nullptr) {
         printf("%s: nullptr\n", __FUNCTION__);
         return -1;
     }
@@ -24,17 +42,13 @@ extern "C" uint8_t matter_get_total_operational_hour(uint32_t *totalOperationalH
     CHIP_ERROR err;
     DiagnosticDataProvider &diagProvider = chip::DeviceLayer::GetDiagnosticDataProviderImpl();
 
-    if (&diagProvider != NULL)
-    {
+    if (&diagProvider != NULL) {
         err = diagProvider.GetTotalOperationalHours(*totalOperationalHours);
-        if (err != CHIP_NO_ERROR)
-        {
+        if (err != CHIP_NO_ERROR) {
             printf("%s: GetTotalOperationalHours Failed err=%d\n", __FUNCTION__, err);
             return -1;
         }
-    }
-    else
-    {
+    } else {
         printf("%s: DiagnosticDataProvider is invalid\n", __FUNCTION__);
         return -1;
     }
@@ -48,7 +62,7 @@ extern "C" uint8_t matter_set_total_operational_hour(uint32_t time)
     return (err == CHIP_NO_ERROR) ? 0 : -1;
 }
 
-bool matter_server_is_commissioned()
+bool matter_server_is_commissioned(void)
 {
     return (chip::Server::GetInstance().GetFabricTable().FabricCount() != 0);
 }
@@ -57,10 +71,8 @@ void matter_get_fabric_indexes(uint16_t *pFabricIndexes, size_t bufSize)
 {
     size_t i = 0;
     for (auto it = chip::Server::GetInstance().GetFabricTable().begin();
-            it != chip::Server::GetInstance().GetFabricTable().end(); ++it)
-    {
-        if (bufSize < i)
-        {
+        it != chip::Server::GetInstance().GetFabricTable().end(); ++it) {
+        if (bufSize < i) {
             // out of buffer space
             ChipLogError(DeviceLayer, "Returning... buffer too small");
             return;
@@ -71,10 +83,28 @@ void matter_get_fabric_indexes(uint16_t *pFabricIndexes, size_t bufSize)
     }
 }
 
+void matter_print_onboarding_codes(void)
+{
+#if CONFIG_NETWORK_LAYER_BLE
+    auto flags = chip::RendezvousInformationFlags(chip::RendezvousInformationFlag::kBLE);
+#else
+    auto flags = chip::RendezvousInformationFlags(chip::RendezvousInformationFlag::kOnNetwork);
+#endif /* CONFIG_NETWORK_LAYER_BLE */
+
+    chip::PayloadContents payload;
+    CHIP_ERROR err = GetPayloadContents(payload, flags);
+    if (err != CHIP_NO_ERROR) {
+        ChipLogError(AppServer, "GetPayloadContents() failed: %" CHIP_ERROR_FORMAT, err.Format());
+    }
+#if CONFIG_USER_ACTION_REQUIRED
+    payload.commissioningFlow = chip::CommissioningFlow::kUserActionRequired;
+#endif
+    PrintOnboardingCodes(payload);
+}
+
 CHIP_ERROR matter_get_manual_pairing_code(char *buf, size_t bufSize)
 {
-    if (bufSize < chip::QRCodeBasicSetupPayloadGenerator::kMaxQRCodeBase38RepresentationLength + 1)
-    {
+    if (bufSize < chip::QRCodeBasicSetupPayloadGenerator::kMaxQRCodeBase38RepresentationLength + 1) {
         ChipLogError(DeviceLayer, "Buffer too small for onboarding code!");
         return CHIP_ERROR_INTERNAL;
     }
@@ -84,14 +114,12 @@ CHIP_ERROR matter_get_manual_pairing_code(char *buf, size_t bufSize)
     RendezvousInformationFlags rendezvousFlag = chip::RendezvousInformationFlags(chip::RendezvousInformationFlag::kBLE);
     PayloadContents payload;
 
-    if (GetPayloadContents(payload, rendezvousFlag) != CHIP_NO_ERROR)
-    {
+    if (GetPayloadContents(payload, rendezvousFlag) != CHIP_NO_ERROR) {
         ChipLogError(DeviceLayer, "Failed to get onboarding payload contents");
         return CHIP_ERROR_INTERNAL;
     }
 
-    if (GetManualPairingCode(manualPairingCode, payload) != CHIP_NO_ERROR)
-    {
+    if (GetManualPairingCode(manualPairingCode, payload) != CHIP_NO_ERROR) {
         ChipLogError(DeviceLayer, "Failed to generate manual pairing code!");
         return CHIP_ERROR_INTERNAL;
     }
@@ -103,8 +131,7 @@ CHIP_ERROR matter_get_manual_pairing_code(char *buf, size_t bufSize)
 
 CHIP_ERROR matter_get_qr_code(char *buf, size_t bufSize)
 {
-    if (bufSize < chip::QRCodeBasicSetupPayloadGenerator::kMaxQRCodeBase38RepresentationLength + 1)
-    {
+    if (bufSize < chip::QRCodeBasicSetupPayloadGenerator::kMaxQRCodeBase38RepresentationLength + 1) {
         ChipLogError(DeviceLayer, "Buffer too small for onboarding code!");
         return CHIP_ERROR_INTERNAL;
     }
@@ -114,14 +141,12 @@ CHIP_ERROR matter_get_qr_code(char *buf, size_t bufSize)
     RendezvousInformationFlags rendezvousFlag = chip::RendezvousInformationFlags(chip::RendezvousInformationFlag::kBLE);
     PayloadContents payload;
 
-    if (GetPayloadContents(payload, rendezvousFlag) != CHIP_NO_ERROR)
-    {
+    if (GetPayloadContents(payload, rendezvousFlag) != CHIP_NO_ERROR) {
         ChipLogError(DeviceLayer, "Failed to get onboarding payload contents");
         return CHIP_ERROR_INTERNAL;
     }
 
-    if (GetQRCode(qrCode, payload) != CHIP_NO_ERROR)
-    {
+    if (GetQRCode(qrCode, payload) != CHIP_NO_ERROR) {
         ChipLogError(DeviceLayer, "Failed to generate qr code!");
         return CHIP_ERROR_INTERNAL;
     }
@@ -136,8 +161,7 @@ CHIP_ERROR matter_open_basic_commissioning_window()
     CHIP_ERROR err = CHIP_ERROR_INTERNAL;
     CommissioningWindowManager *mgr = &(chip::Server::GetInstance().GetCommissioningWindowManager());
 
-    if (mgr != NULL)
-    {
+    if (mgr != NULL) {
         chip::DeviceLayer::PlatformMgr().LockChipStack();
         err = mgr->OpenBasicCommissioningWindow();
         chip::DeviceLayer::PlatformMgr().UnlockChipStack();
@@ -151,8 +175,7 @@ CHIP_ERROR matter_get_certificate_declaration(MutableByteSpan &outBuffer)
     CHIP_ERROR err = CHIP_ERROR_INTERNAL;
     DeviceAttestationCredentialsProvider *dacProvider = chip::Credentials::GetDeviceAttestationCredentialsProvider();
 
-    if (dacProvider != NULL)
-    {
+    if (dacProvider != NULL) {
         err = dacProvider->GetCertificationDeclaration(outBuffer);
     }
 
@@ -164,8 +187,7 @@ CHIP_ERROR matter_get_dac_cert(MutableByteSpan &outBuffer)
     CHIP_ERROR err = CHIP_ERROR_INTERNAL;
     DeviceAttestationCredentialsProvider *dacProvider = chip::Credentials::GetDeviceAttestationCredentialsProvider();
 
-    if (dacProvider != NULL)
-    {
+    if (dacProvider != NULL) {
         err = dacProvider->GetDeviceAttestationCert(outBuffer);
     }
 
@@ -177,8 +199,7 @@ CHIP_ERROR matter_get_pai_cert(MutableByteSpan &outBuffer)
     CHIP_ERROR err = CHIP_ERROR_INTERNAL;
     DeviceAttestationCredentialsProvider *dacProvider = chip::Credentials::GetDeviceAttestationCredentialsProvider();
 
-    if (dacProvider != NULL)
-    {
+    if (dacProvider != NULL) {
         err = dacProvider->GetProductAttestationIntermediateCert(outBuffer);
     }
 
@@ -190,8 +211,7 @@ CHIP_ERROR matter_get_firmware_information(MutableByteSpan &outBuffer)
     CHIP_ERROR err = CHIP_ERROR_INTERNAL;
     DeviceAttestationCredentialsProvider *dacProvider = chip::Credentials::GetDeviceAttestationCredentialsProvider();
 
-    if (dacProvider != NULL)
-    {
+    if (dacProvider != NULL) {
         err = dacProvider->GetFirmwareInformation(outBuffer);
     }
 
@@ -203,8 +223,7 @@ CHIP_ERROR matter_get_setup_discriminator(uint16_t &discriminator)
     CHIP_ERROR err = CHIP_ERROR_INTERNAL;
     CommissionableDataProvider *cdProvider = chip::DeviceLayer::GetCommissionableDataProvider();
 
-    if (cdProvider != NULL)
-    {
+    if (cdProvider != NULL) {
         err = cdProvider->GetSetupDiscriminator(discriminator);
     }
 
@@ -216,8 +235,7 @@ CHIP_ERROR matter_get_spake2p_iteration_count(uint32_t &iterationCount)
     CHIP_ERROR err = CHIP_ERROR_INTERNAL;
     CommissionableDataProvider *cdProvider = chip::DeviceLayer::GetCommissionableDataProvider();
 
-    if (cdProvider != NULL)
-    {
+    if (cdProvider != NULL) {
         err = cdProvider->GetSpake2pIterationCount(iterationCount);
     }
 
@@ -229,8 +247,7 @@ CHIP_ERROR matter_get_spake2p_salt(MutableByteSpan &saltBuf)
     CHIP_ERROR err = CHIP_ERROR_INTERNAL;
     CommissionableDataProvider *cdProvider = chip::DeviceLayer::GetCommissionableDataProvider();
 
-    if (cdProvider != NULL)
-    {
+    if (cdProvider != NULL) {
         err = cdProvider->GetSpake2pSalt(saltBuf);
     }
 
@@ -242,8 +259,7 @@ CHIP_ERROR matter_get_spake2p_verifier(MutableByteSpan &verifierBuf, size_t &ver
     CHIP_ERROR err = CHIP_ERROR_INTERNAL;
     CommissionableDataProvider *cdProvider = chip::DeviceLayer::GetCommissionableDataProvider();
 
-    if (cdProvider != NULL)
-    {
+    if (cdProvider != NULL) {
         err = cdProvider->GetSpake2pVerifier(verifierBuf, verifierLen);
     }
 
@@ -255,8 +271,7 @@ CHIP_ERROR matter_get_setup_passcode(uint32_t &passcode)
     CHIP_ERROR err = CHIP_ERROR_INTERNAL;
     CommissionableDataProvider *cdProvider = chip::DeviceLayer::GetCommissionableDataProvider();
 
-    if (cdProvider != NULL)
-    {
+    if (cdProvider != NULL) {
         err = cdProvider->GetSetupPasscode(passcode);
     }
 
@@ -268,8 +283,7 @@ CHIP_ERROR matter_get_vendor_name(char *buf, size_t bufSize)
     CHIP_ERROR err = CHIP_ERROR_INTERNAL;
     DeviceInstanceInfoProvider *diiProvider = chip::DeviceLayer::GetDeviceInstanceInfoProvider();
 
-    if (diiProvider != NULL)
-    {
+    if (diiProvider != NULL) {
         err = diiProvider->GetVendorName(buf, bufSize);
     }
 
@@ -281,8 +295,7 @@ CHIP_ERROR matter_get_vendor_id(uint16_t &vendorId)
     CHIP_ERROR err = CHIP_ERROR_INTERNAL;
     DeviceInstanceInfoProvider *diiProvider = chip::DeviceLayer::GetDeviceInstanceInfoProvider();
 
-    if (diiProvider != NULL)
-    {
+    if (diiProvider != NULL) {
         err = diiProvider->GetVendorId(vendorId);
     }
 
@@ -294,8 +307,7 @@ CHIP_ERROR matter_get_product_name(char *buf, size_t bufSize)
     CHIP_ERROR err = CHIP_ERROR_INTERNAL;
     DeviceInstanceInfoProvider *diiProvider = chip::DeviceLayer::GetDeviceInstanceInfoProvider();
 
-    if (diiProvider != NULL)
-    {
+    if (diiProvider != NULL) {
         err = diiProvider->GetProductName(buf, bufSize);
     }
 
@@ -307,8 +319,7 @@ CHIP_ERROR matter_get_product_id(uint16_t &productId)
     CHIP_ERROR err = CHIP_ERROR_INTERNAL;
     DeviceInstanceInfoProvider *diiProvider = chip::DeviceLayer::GetDeviceInstanceInfoProvider();
 
-    if (diiProvider != NULL)
-    {
+    if (diiProvider != NULL) {
         err = diiProvider->GetProductId(productId);
     }
 
@@ -320,8 +331,7 @@ CHIP_ERROR matter_get_part_number(char *buf, size_t bufSize)
     CHIP_ERROR err = CHIP_ERROR_INTERNAL;
     DeviceInstanceInfoProvider *diiProvider = chip::DeviceLayer::GetDeviceInstanceInfoProvider();
 
-    if (diiProvider != NULL)
-    {
+    if (diiProvider != NULL) {
         err = diiProvider->GetPartNumber(buf, bufSize);
     }
 
@@ -333,8 +343,7 @@ CHIP_ERROR matter_get_product_url(char *buf, size_t bufSize)
     CHIP_ERROR err = CHIP_ERROR_INTERNAL;
     DeviceInstanceInfoProvider *diiProvider = chip::DeviceLayer::GetDeviceInstanceInfoProvider();
 
-    if (diiProvider != NULL)
-    {
+    if (diiProvider != NULL) {
         err = diiProvider->GetProductURL(buf, bufSize);
     }
 
@@ -346,8 +355,7 @@ CHIP_ERROR matter_get_product_label(char *buf, size_t bufSize)
     CHIP_ERROR err = CHIP_ERROR_INTERNAL;
     DeviceInstanceInfoProvider *diiProvider = chip::DeviceLayer::GetDeviceInstanceInfoProvider();
 
-    if (diiProvider != NULL)
-    {
+    if (diiProvider != NULL) {
         err = diiProvider->GetProductLabel(buf, bufSize);
     }
 
@@ -359,8 +367,7 @@ CHIP_ERROR matter_get_serial_number(char *buf, size_t bufSize)
     CHIP_ERROR err = CHIP_ERROR_INTERNAL;
     DeviceInstanceInfoProvider *diiProvider = chip::DeviceLayer::GetDeviceInstanceInfoProvider();
 
-    if (diiProvider != NULL)
-    {
+    if (diiProvider != NULL) {
         err = diiProvider->GetSerialNumber(buf, bufSize);
     }
 
@@ -372,8 +379,7 @@ CHIP_ERROR matter_get_manufacturing_date(uint16_t &year, uint8_t &month, uint8_t
     CHIP_ERROR err = CHIP_ERROR_INTERNAL;
     DeviceInstanceInfoProvider *diiProvider = chip::DeviceLayer::GetDeviceInstanceInfoProvider();
 
-    if (diiProvider != NULL)
-    {
+    if (diiProvider != NULL) {
         err = diiProvider->GetManufacturingDate(year, month, day);
     }
 
@@ -385,8 +391,7 @@ CHIP_ERROR matter_get_hardware_version(uint16_t &hardwareVersion)
     CHIP_ERROR err = CHIP_ERROR_INTERNAL;
     DeviceInstanceInfoProvider *diiProvider = chip::DeviceLayer::GetDeviceInstanceInfoProvider();
 
-    if (diiProvider != NULL)
-    {
+    if (diiProvider != NULL) {
         err = diiProvider->GetHardwareVersion(hardwareVersion);
     }
 
@@ -398,8 +403,7 @@ CHIP_ERROR matter_get_hardware_version_string(char *buf, size_t bufSize)
     CHIP_ERROR err = CHIP_ERROR_INTERNAL;
     DeviceInstanceInfoProvider *diiProvider = chip::DeviceLayer::GetDeviceInstanceInfoProvider();
 
-    if (diiProvider != NULL)
-    {
+    if (diiProvider != NULL) {
         err = diiProvider->GetHardwareVersionString(buf, bufSize);
     }
 

--- a/api/matter_api.h
+++ b/api/matter_api.h
@@ -1,19 +1,31 @@
-/********************************************************************************
- * @file    matter_api.h
- * @author
- * @version
- * @brief   Useful API to support Matter protocol.
- ********************************************************************************
-  *
-  * This module is a confidential and proprietary property of RealTek and
-  * possession or use of this module requires written permission of RealTek.
-  *
-  * Copyright(c) 2016, Realtek Semiconductor Corporation. All rights reserved.
-  *
-********************************************************************************/
+/*
+ *    This module is a confidential and proprietary property of RealTek and
+ *    possession or use of this module requires written permission of RealTek.
+ *
+ *    Copyright(c) 2025, Realtek Semiconductor Corporation. All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
 #pragma once
 
-using namespace ::chip;
+#include <cstddef>
+#include <cstdint>
+
+#include <lib/core/CHIPError.h>
+#include <lib/support/Span.h>
+
+using namespace chip;
 
 /******************************************************
  *               Utilities and Information
@@ -31,6 +43,11 @@ bool matter_server_is_commissioned(void);
  * @param[in]  bufSize: Size of the buffer.
  */
 void matter_get_fabric_indexes(uint16_t *pFabricIndexes, size_t bufSize);
+
+/**
+ * @brief  Print onboarding codes.
+ */
+void matter_print_onboarding_codes(void);
 
 /**
  * @brief  Get the manual pairing code.

--- a/common/include/lwipopts_matter.h
+++ b/common/include/lwipopts_matter.h
@@ -1,11 +1,21 @@
-/******************************************************************************
-  *
-  * This module is a confidential and proprietary property of RealTek and
-  * possession or use of this module requires written permission of RealTek.
-  *
-  * Copyright(c) 2016, Realtek Semiconductor Corporation. All rights reserved.
-  *
-******************************************************************************/
+/*
+ *    This module is a confidential and proprietary property of RealTek and
+ *    possession or use of this module requires written permission of RealTek.
+ *
+ *    Copyright(c) 2025, Realtek Semiconductor Corporation. All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
 
 #ifndef LWIP_HDR_LWIPOPTS_MATTER_H
 #define LWIP_HDR_LWIPOPTS_MATTER_H

--- a/common/include/platform_opts_bt_matter.h
+++ b/common/include/platform_opts_bt_matter.h
@@ -1,14 +1,24 @@
-/******************************************************************************
-  *
-  * This module is a confidential and proprietary property of RealTek and
-  * possession or use of this module requires written permission of RealTek.
-  *
-  * Copyright(c) 2016, Realtek Semiconductor Corporation. All rights reserved.
-  *
-******************************************************************************/
+/*
+ *    This module is a confidential and proprietary property of RealTek and
+ *    possession or use of this module requires written permission of RealTek.
+ *
+ *    Copyright(c) 2025, Realtek Semiconductor Corporation. All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
 
-#ifndef __PLATFORM_OPTS_BT_MATTER_H__
-#define __PLATFORM_OPTS_BT_MATTER_H__
+#ifndef PLATFORM_OPTS_BT_MATTER_H
+#define PLATFORM_OPTS_BT_MATTER_H
 
 #if CONFIG_BT
 
@@ -23,18 +33,18 @@
 
 /* Matter Mesh Configuration */
 #if defined(CONFIG_BT_MESH_DEVICE_MATTER) && CONFIG_BT_MESH_DEVICE_MATTER
-    #undef CONFIG_BT_MESH_DEVICE_MULTIPLE_PROFILE
-    #define CONFIG_BT_MESH_DEVICE_MULTIPLE_PROFILE   1
+#undef CONFIG_BT_MESH_DEVICE_MULTIPLE_PROFILE
+#define CONFIG_BT_MESH_DEVICE_MULTIPLE_PROFILE   1
 #endif
 
 #if (CONFIG_BT_MESH_DEVICE_MATTER && !CONFIG_BT_MESH_DEVICE_MULTIPLE_PROFILE) || \
     (!CONFIG_BT_MESH_DEVICE_MATTER && CONFIG_BT_MESH_DEVICE_MULTIPLE_PROFILE)
-    #error "Please enable both CONFIG_BT_MESH_DEVICE_MATTER & CONFIG_BT_MESH_DEVICE_MULTIPLE_PROFILE"
+#error "Please enable both CONFIG_BT_MESH_DEVICE_MATTER & CONFIG_BT_MESH_DEVICE_MULTIPLE_PROFILE"
 #endif
 
 #endif /* CONFIG_PLATFORM_8710C */
 
 #endif /* CONFIG_BT */
 
-#endif /* __PLATFORM_OPTS_BT_MATTER_H__ */
+#endif /* PLATFORM_OPTS_BT_MATTER_H */
 

--- a/common/include/platform_opts_matter.h
+++ b/common/include/platform_opts_matter.h
@@ -1,14 +1,24 @@
-/******************************************************************************
-  *
-  * This module is a confidential and proprietary property of RealTek and
-  * possession or use of this module requires written permission of RealTek.
-  *
-  * Copyright(c) 2016, Realtek Semiconductor Corporation. All rights reserved.
-  *
-******************************************************************************/
+/*
+ *    This module is a confidential and proprietary property of RealTek and
+ *    possession or use of this module requires written permission of RealTek.
+ *
+ *    Copyright(c) 2025, Realtek Semiconductor Corporation. All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
 
-#ifndef __PLATFORM_OPTS_MATTER_H__
-#define __PLATFORM_OPTS_MATTER_H__
+#ifndef PLATFORM_OPTS_MATTER_H
+#define PLATFORM_OPTS_MATTER_H
 
 // Ameba Matter Device Type Example
 #define CONFIG_EXAMPLE_MATTER                           1
@@ -74,7 +84,7 @@
 #define MATTER_KVS_MODULE_NUM                   13                      // max number of module
 #define MATTER_KVS_VARIABLE_NAME_SIZE           32                      // max size of the variable name
 #define MATTER_KVS_VARIABLE_VALUE_SIZE          64+4                    // max size of the variable value, +4 so it can store 64 bytes variable
-                                                                        // max value number in moudle = floor(4024 / (32 + 64 + 4)) = 40
+// max value number in moudle = floor(4024 / (32 + 64 + 4)) = 40
 
 /****************************************************************
  * MATTER KVS2, for key length large than 64 (Fabric1 ~ FabricF)
@@ -83,7 +93,7 @@
 #define MATTER_KVS_MODULE_NUM2                  10                      // max number of module
 #define MATTER_KVS_VARIABLE_NAME_SIZE2          32                      // max size of the variable name
 #define MATTER_KVS_VARIABLE_VALUE_SIZE2         400+4                   // max size of the variable value, +4 so it can store 400 bytes variable
-                                                                        // max value number in moudle = floor(4024 / (32 + 400 + 4)) = 9
+// max value number in moudle = floor(4024 / (32 + 400 + 4)) = 9
 
 /*****************************************************************
  * Matter Factory Data: last 4KB of external flash
@@ -182,4 +192,4 @@
 #define LFS_NUM_BLOCKS                          (LFS_DEVICE_SIZE / SECTOR_SIZE_FLASH)
 #endif /* CONFIG_ENABLE_AMEBA_LFS */
 
-#endif /* __PLATFORM_OPTS_MATTER_H__ */
+#endif /* PLATFORM_OPTS_MATTER_H */

--- a/common/include/platform_stdlib_matter.h
+++ b/common/include/platform_stdlib_matter.h
@@ -1,11 +1,21 @@
-/******************************************************************************
-  *
-  * This module is a confidential and proprietary property of RealTek and
-  * possession or use of this module requires written permission of RealTek.
-  *
-  * Copyright(c) 2016, Realtek Semiconductor Corporation. All rights reserved.
-  *
-******************************************************************************/
+/*
+ *    This module is a confidential and proprietary property of RealTek and
+ *    possession or use of this module requires written permission of RealTek.
+ *
+ *    Copyright(c) 2025, Realtek Semiconductor Corporation. All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
 
 #ifndef PLATFORM_STDLIB_MATTER_H
 #define PLATFORM_STDLIB_MATTER_H
@@ -14,19 +24,19 @@
 #include <assert.h>
 
 extern size_t strnlen(const char *s, size_t count);
-extern void *pvPortMalloc( size_t xWantedSize );
+extern void *pvPortMalloc(size_t xWantedSize);
 
 //def
 #ifndef false
-    #define false   0
+#define false   0
 #endif
 
 #ifndef true
-    #define true    1
+#define true    1
 #endif
 
 #ifndef in_addr_t
-    typedef __uint32_t in_addr_t;
+typedef __uint32_t in_addr_t;
 #endif
 
 #elif defined(CONFIG_PLATFORM_8721D)
@@ -34,61 +44,61 @@ extern void *pvPortMalloc( size_t xWantedSize );
 #include <sys/time.h>
 #include <assert.h>
 
-extern char * _strtok_r( char *s , const char *delim , char **lasts);
-extern int _nanosleep( const struct timespec * rqtp, struct timespec * rmtp );
-extern int _vTaskDelay( const TickType_t xTicksToDelay );
-extern time_t _time( time_t * tloc );
+extern char *_strtok_r(char *s, const char *delim, char **lasts);
+extern int _nanosleep(const struct timespec *rqtp, struct timespec *rmtp);
+extern int _vTaskDelay(const TickType_t xTicksToDelay);
+extern time_t _time(time_t *tloc);
 extern void *pvPortCalloc(size_t xWantedCnt, size_t xWantedSize);
 
 #undef calloc
 #define calloc            pvPortCalloc
 
 #ifndef false
-    #define false   0
+#define false   0
 #endif
 
 #ifndef true
-    #define true    1
+#define true    1
 #endif
 
 #ifndef strtok_r
-    #define strtok_r(s, delim, lasts)	  _strtok_r (s, delim, lasts)
+#define strtok_r(s, delim, lasts)	  _strtok_r (s, delim, lasts)
 #endif
 
 #ifndef usleep
-    #define usleep(x)    _vTaskDelay(x)
+#define usleep(x)    _vTaskDelay(x)
 #endif
 
 #ifndef nanosleep
-    #define nanosleep    _nanosleep
+#define nanosleep    _nanosleep
 #endif
 
 #ifndef in_addr_t
-    typedef __uint32_t in_addr_t;
+typedef __uint32_t in_addr_t;
 #endif
 
 #ifdef strtok
-    #undef strtok
+#undef strtok
 #endif
 
 #ifdef strtol
-    #undef strtol
+#undef strtol
 #endif
 
 #ifdef rand
-    #undef rand
+#undef rand
 #endif
 
 #ifdef srand
-    #undef srand
+#undef srand
 #endif
 
 #ifdef IN
-    #undef IN
+#undef IN
 #endif
 
 #ifdef vsnprintf
-	#undef vsnprintf
+#undef vsnprintf
 #endif
 
 #endif /* CONFIG_PLATFORM_XXXX */

--- a/common/include/version_matter.h
+++ b/common/include/version_matter.h
@@ -1,0 +1,29 @@
+/*
+ *    This module is a confidential and proprietary property of RealTek and
+ *    possession or use of this module requires written permission of RealTek.
+ *
+ *    Copyright(c) 2025, Realtek Semiconductor Corporation. All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#ifndef AMEBA_MATTER_VERSION_H
+#define AMEBA_MATTER_VERSION_H
+
+#define AMEBA_MATTER_SDK_VERSION_MAJOR    1
+#define AMEBA_MATTER_SDK_VERSION_MINOR    4
+#define AMEBA_MATTER_SDK_VERSION_PATCH    0
+
+#define AMEBA_MATTER_SDK_GIT_REVISION     "v1.4"
+
+#endif /* AMEBA_MATTER_VERSION_H */

--- a/core/matter_core.cpp
+++ b/core/matter_core.cpp
@@ -1,6 +1,26 @@
+/*
+ *    This module is a confidential and proprietary property of RealTek and
+ *    possession or use of this module requires written permission of RealTek.
+ *
+ *    Copyright(c) 2025, Realtek Semiconductor Corporation. All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
 #include <stdlib.h>
 #include <stdint.h>
 
+#include <matter_api.h>
 #include <matter_core.h>
 #include <matter_events.h>
 #include <matter_interaction.h>
@@ -74,8 +94,7 @@ using namespace ::chip::DeviceLayer;
 // DeferredAttribute object describes a deferred attribute, but also holds a buffer with a value to
 // be written, so it must live so long as the DeferredAttributePersistenceProvider object.
 
-DeferredAttribute gDeferredAttributeArray[] =
-{
+DeferredAttribute gDeferredAttributeArray[] = {
     DeferredAttribute(ConcreteAttributePath(1 /* kLightEndpointId */, Clusters::LevelControl::Id, Clusters::LevelControl::Attributes::CurrentLevel::Id)),
     DeferredAttribute(ConcreteAttributePath(1 /* kLightEndpointId */, Clusters::ColorControl::Id, Clusters::ColorControl::Attributes::CurrentHue::Id)),
     DeferredAttribute(ConcreteAttributePath(1 /* kLightEndpointId */, Clusters::ColorControl::Id, Clusters::ColorControl::Attributes::CurrentSaturation::Id)),
@@ -83,10 +102,11 @@ DeferredAttribute gDeferredAttributeArray[] =
     DeferredAttribute(ConcreteAttributePath(1 /* kLightEndpointId */, Clusters::ColorControl::Id, Clusters::ColorControl::Attributes::CurrentX::Id)),
     DeferredAttribute(ConcreteAttributePath(1 /* kLightEndpointId */, Clusters::ColorControl::Id, Clusters::ColorControl::Attributes::CurrentY::Id)),
 };
-DeferredAttributePersistenceProvider gDeferredAttributePersister(Server::GetInstance().GetDefaultAttributePersister(), Span<DeferredAttribute>(gDeferredAttributeArray, 6), System::Clock::Milliseconds32(5000));
+DeferredAttributePersistenceProvider gDeferredAttributePersister(Server::GetInstance().GetDefaultAttributePersister(),
+        Span<DeferredAttribute>(gDeferredAttributeArray, 6), System::Clock::Milliseconds32(5000));
 
 app::Clusters::NetworkCommissioning::Instance
-    sWiFiNetworkCommissioningInstance(0 /* Endpoint Id */, &(NetworkCommissioning::AmebaWiFiDriver::GetInstance()));
+sWiFiNetworkCommissioningInstance(0 /* Endpoint Id */, &(NetworkCommissioning::AmebaWiFiDriver::GetInstance()));
 
 chip::DeviceLayer::DeviceInfoProviderImpl gExampleDeviceInfoProvider;
 chip::DeviceLayer::FactoryDataProvider mFactoryDataProvider;
@@ -98,52 +118,42 @@ chip::Inet::DropIfTooManyQueuedPacketsFilter sMdnsPacketFilter(kMaxPendingMdnsPa
 
 void matter_core_device_callback_internal(const ChipDeviceEvent *event, intptr_t arg)
 {
-    switch (event->Type)
-    {
+    switch (event->Type) {
     case DeviceEventType::kInternetConnectivityChange:
 #if CHIP_DEVICE_CONFIG_ENABLE_OTA_REQUESTOR
         static bool isOTAInitialized = false; // use this static variable to replace CheckInit()
 #endif
-        if (event->InternetConnectivityChange.IPv4 == kConnectivity_Established)
-        {
+        if (event->InternetConnectivityChange.IPv4 == kConnectivity_Established) {
             ChipLogProgress(DeviceLayer, "IPv4 Server ready...");
             chip::app::DnssdServer::Instance().StartServer();
-        }
-        else if (event->InternetConnectivityChange.IPv4 == kConnectivity_Lost)
-        {
+        } else if (event->InternetConnectivityChange.IPv4 == kConnectivity_Lost) {
             ChipLogProgress(DeviceLayer, "Lost IPv4 connectivity...");
         }
-        if (event->InternetConnectivityChange.IPv6 == kConnectivity_Established)
-        {
+        if (event->InternetConnectivityChange.IPv6 == kConnectivity_Established) {
             ChipLogProgress(DeviceLayer, "IPv6 Server ready...");
             chip::app::DnssdServer::Instance().StartServer();
 
 #if CHIP_DEVICE_CONFIG_ENABLE_OTA_REQUESTOR
             // Init OTA requestor only when we have gotten IPv6 address
-            if (!isOTAInitialized)
-            {
+            if (!isOTAInitialized) {
                 matter_ota_initializer();
                 isOTAInitialized = true;
             }
 #endif
-        }
-        else if (event->InternetConnectivityChange.IPv6 == kConnectivity_Lost)
-        {
+        } else if (event->InternetConnectivityChange.IPv6 == kConnectivity_Lost) {
             ChipLogProgress(DeviceLayer, "Lost IPv6 connectivity...");
         }
         break;
     case DeviceEventType::kInterfaceIpAddressChanged:
         if ((event->InterfaceIpAddressChanged.Type == InterfaceIpChangeType::kIpV4_Assigned) ||
-            (event->InterfaceIpAddressChanged.Type == InterfaceIpChangeType::kIpV6_Assigned))
-        {
+            (event->InterfaceIpAddressChanged.Type == InterfaceIpChangeType::kIpV6_Assigned)) {
             // MDNS server restart on any ip assignment: if link local ipv6 is configured, that
             // will not trigger a 'internet connectivity change' as there is no internet
             // connectivity. MDNS still wants to refresh its listening interfaces to include the
             // newly selected address.
             chip::app::DnssdServer::Instance().StartServer();
         }
-        if (event->InterfaceIpAddressChanged.Type == InterfaceIpChangeType::kIpV6_Assigned)
-        {
+        if (event->InterfaceIpAddressChanged.Type == InterfaceIpChangeType::kIpV6_Assigned) {
             ChipLogProgress(DeviceLayer, "Initializing route hook...");
             ameba_route_hook_init();
         }
@@ -219,8 +229,8 @@ void matter_core_init_server(intptr_t context)
 
 #if defined(CHIP_ENABLE_AMEBA_TERMS_AND_CONDITION) && (CHIP_ENABLE_AMEBA_TERMS_AND_CONDITION == 1)
     const Optional<app::TermsAndConditions> termsAndConditions = Optional<app::TermsAndConditions>(
-        app::TermsAndConditions(CHIP_AMEBA_TC_REQUIRED_ACKNOWLEDGEMENTS, CHIP_AMEBA_TC_MIN_REQUIRED_VERSION));
-    PersistentStorageDelegate & persistentStorageDelegate = Server::GetInstance().GetPersistentStorage();
+                            app::TermsAndConditions(CHIP_AMEBA_TC_REQUIRED_ACKNOWLEDGEMENTS, CHIP_AMEBA_TC_MIN_REQUIRED_VERSION));
+    PersistentStorageDelegate &persistentStorageDelegate = Server::GetInstance().GetPersistentStorage();
     chip::app::TermsAndConditionsManager::GetInstance()->Init(&persistentStorageDelegate, termsAndConditions);
 #endif
 
@@ -230,10 +240,8 @@ void matter_core_init_server(intptr_t context)
     // TODO: configure the endpoint
     emberAfEndpointEnableDisable(0xFFFE, false);
 
-    if (RTW_SUCCESS != wifi_is_connected_to_ap())
-    {
-        // QR code will be used with CHIP Tool
-        PrintOnboardingCodes(chip::RendezvousInformationFlags(chip::RendezvousInformationFlag::kBLE));
+    if (RTW_SUCCESS != wifi_is_connected_to_ap()) {
+        matter_print_onboarding_codes();
     }
 
 #if CONFIG_ENABLE_CHIP_SHELL
@@ -258,15 +266,13 @@ CHIP_ERROR matter_core_init(void)
     SuccessOrExit(err);
 
 #if defined(CONFIG_ENABLE_AMEBA_DLOG) && (CONFIG_ENABLE_AMEBA_DLOG == 1)
-    if (instance.GetAmebaLogSubsystemInited())
-    {
+    if (instance.GetAmebaLogSubsystemInited()) {
         instance.RegisterAmebaErrorFormatter(); // only register the custom error formatter if the log subsystem was inited.
     }
 #endif
 
     err = mFactoryDataProvider.Init();
-    if (err != CHIP_NO_ERROR)
-    {
+    if (err != CHIP_NO_ERROR) {
         ChipLogError(DeviceLayer, "Error initializing FactoryData!");
         ChipLogError(DeviceLayer, "Check if you have flashed it correctly!");
     }
@@ -275,8 +281,7 @@ CHIP_ERROR matter_core_init(void)
     SetDeviceAttestationCredentialsProvider(&mFactoryDataProvider);
     SetDeviceInstanceInfoProvider(&mFactoryDataProvider);
 
-    if (CONFIG_NETWORK_LAYER_BLE)
-    {
+    if (CONFIG_NETWORK_LAYER_BLE) {
         ConnectivityMgr().SetBLEAdvertisingEnabled(true);
     }
 
@@ -307,8 +312,7 @@ CHIP_ERROR matter_core_start(void)
     int res = matter_fs_init();
 
     /* init flash fs and read existing fault log into fs */
-    if (res == 0)
-    {
+    if (res == 0) {
         ChipLogProgress(DeviceLayer, "Matter FlashFS Initialized");
     }
 

--- a/examples/matter_example_entry.c
+++ b/examples/matter_example_entry.c
@@ -1,9 +1,30 @@
+/*
+ *    This module is a confidential and proprietary property of RealTek and
+ *    possession or use of this module requires written permission of RealTek.
+ *
+ *    Copyright(c) 2025, Realtek Semiconductor Corporation. All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
 #include <platform_opts.h>
+
+#if defined(CONFIG_EXAMPLE_MATTER) && (CONFIG_EXAMPLE_MATTER == 1)
+
 #if defined(CONFIG_PLATFORM_8721D)
 #include <atcmd_matter.h>
 #endif
 
-#if defined(CONFIG_EXAMPLE_MATTER) && (CONFIG_EXAMPLE_MATTER == 1)
 #if defined(CONFIG_EXAMPLE_MATTER_CHIPTEST) && (CONFIG_EXAMPLE_MATTER_CHIPTEST == 1)
 #include <chiptest/example_matter.h>
 #elif defined(CONFIG_EXAMPLE_MATTER_ROOM_AIR_CONDITIONER) && (CONFIG_EXAMPLE_MATTER_ROOM_AIR_CONDITIONER == 1)
@@ -30,6 +51,24 @@
 #include <thermostat/example_matter_thermostat.h>
 #endif
 
+#if defined(CONFIG_PLATFORM_8710C)
+#include "FreeRTOS.h"
+static void *matter_mbedtls_calloc_func(size_t nelements, size_t elementSize)
+{
+    size_t size;
+    void *ptr = NULL;
+
+    size = nelements * elementSize;
+    ptr = pvPortMalloc(size);
+
+    if (ptr) {
+        memset(ptr, 0, size);
+    }
+
+    return ptr;
+}
+#endif /* CONFIG_PLATFORM_8710C */
+
 /*
  * All of the examples (except CONFIG_EXAMPLE_MATTER_CHIPTEST) are disabled by default for code size consideration
  * The configuration is enabled in platform_opts_matter.h
@@ -38,7 +77,11 @@ void matter_example_entry(void)
 {
 #if defined(CONFIG_PLATFORM_8721D)
     matter_shell_init();
-#endif
+#endif /* CONFIG_PLATFORM_8721D */
+
+#if defined(CONFIG_PLATFORM_8710C)
+    mbedtls_platform_set_calloc_free(matter_mbedtls_calloc_func, vPortFree);
+#endif /* CONFIG_PLATFORM_8710C */
 
 #if defined(CONFIG_EXAMPLE_MATTER_CHIPTEST) && (CONFIG_EXAMPLE_MATTER_CHIPTEST == 1)
     example_matter_task();

--- a/project/amebad/Makefile.include.matter
+++ b/project/amebad/Makefile.include.matter
@@ -135,6 +135,11 @@ CFLAGS += -DCONFIG_ENABLE_AMEBA_SNTP=1
 CFLAGS += -DCONFIG_ENABLE_AMEBA_TEST_EVENT_TRIGGER=0
 
 # -------------------------------------------------------------------
+# Matter Commissioning Flow (default: standard)
+# -------------------------------------------------------------------
+CFLAGS += -DCONFIG_USER_ACTION_REQUIRED=0
+
+# -------------------------------------------------------------------
 # Matter Cluster Flags
 # -------------------------------------------------------------------
 

--- a/project/amebaz2/Makefile.include.matter
+++ b/project/amebaz2/Makefile.include.matter
@@ -109,6 +109,11 @@ CFLAGS += -DCONFIG_ENABLE_AMEBA_SNTP=1
 CFLAGS += -DCONFIG_ENABLE_AMEBA_TEST_EVENT_TRIGGER=0
 
 # -------------------------------------------------------------------
+# Matter Commissioning Flow (default: standard)
+# -------------------------------------------------------------------
+CFLAGS += -DCONFIG_USER_ACTION_REQUIRED=0
+
+# -------------------------------------------------------------------
 # Matter Cluster Flags
 # -------------------------------------------------------------------
 

--- a/project/amebaz2plus/Makefile.include.matter
+++ b/project/amebaz2plus/Makefile.include.matter
@@ -109,6 +109,11 @@ CFLAGS += -DCONFIG_ENABLE_AMEBA_SNTP=1
 CFLAGS += -DCONFIG_ENABLE_AMEBA_TEST_EVENT_TRIGGER=0
 
 # -------------------------------------------------------------------
+# Matter Commissioning Flow (default: standard)
+# -------------------------------------------------------------------
+CFLAGS += -DCONFIG_USER_ACTION_REQUIRED=0
+
+# -------------------------------------------------------------------
 # Matter Cluster Flags
 # -------------------------------------------------------------------
 

--- a/tools/docker/amebad/Dockerfile
+++ b/tools/docker/amebad/Dockerfile
@@ -3,7 +3,7 @@ FROM ameba-rtos-matter:common
 
 # Redefine following build arguments to respective repo and tag/branch
 ARG AMEBA_MATTER_REPO=https://github.com/xshuqun/ameba-rtos-matter.git
-ARG TAG_NAME=v1.4-PR/update_readme
+ARG TAG_NAME=v1.4-PR/support_user_intent
 
 # Define fixed build arguments
 ARG AMBD_REPO=https://github.com/Ameba-AIoT/ameba-rtos-d.git

--- a/tools/docker/amebaz2/Dockerfile
+++ b/tools/docker/amebaz2/Dockerfile
@@ -3,7 +3,7 @@ FROM ameba-rtos-matter:common
 
 # Redefine following build arguments to respective repo and tag/branch
 ARG AMEBA_MATTER_REPO=https://github.com/xshuqun/ameba-rtos-matter.git
-ARG TAG_NAME=v1.4-PR/update_readme
+ARG TAG_NAME=v1.4-PR/support_user_intent
 
 # Define fixed build arguments
 ARG AMBZ2_REPO=https://github.com/Ameba-AIoT/ameba-rtos-z2.git


### PR DESCRIPTION
## This PR addresses:

* support user intent commissioning flow.

Notes:
* There are 3 commissioning flow, and on default ameba is using standard flow.
  - Standard flow: device enters commissioning mode upon reboot
  - User Intent flow: user must perform an action e.g., pressing button
  - Custom flow: device enters commissioning mode using other ways e.g., via URL
* To support User Intent flow, it requires the following
  - payload.commissioningFlow = chip::CommissioningFlow::kUserActionRequired
  - set CHIP_DEVICE_CONFIG_PAIRING_INITIAL_HINT
  - set CHIP_DEVICE_CONFIG_PAIRING_INITIAL_INSTRUCTION

## Verification:

Tested with commissioning, and qr code parsing.