### PR TITLE
[common][sdk] support user intent commissioning flow

### DIFF
--- a/api/matter_api.cpp
+++ b/api/matter_api.cpp
@@ -32,7 +32,7 @@
 using namespace ::chip::Credentials;
 using namespace ::chip::DeviceLayer;
 
-bool matter_server_is_commissioned()
+bool matter_server_is_commissioned(void)
 {
     return (chip::Server::GetInstance().GetFabricTable().FabricCount() != 0);
 }
@@ -41,10 +41,8 @@ void matter_get_fabric_indexes(uint16_t *pFabricIndexes, size_t bufSize)
 {
     size_t i = 0;
     for (auto it = chip::Server::GetInstance().GetFabricTable().begin();
-            it != chip::Server::GetInstance().GetFabricTable().end(); ++it)
-    {
-        if (bufSize < i)
-        {
+        it != chip::Server::GetInstance().GetFabricTable().end(); ++it) {
+        if (bufSize < i) {
             // out of buffer space
             ChipLogError(DeviceLayer, "Returning... buffer too small");
             return;
@@ -55,10 +53,28 @@ void matter_get_fabric_indexes(uint16_t *pFabricIndexes, size_t bufSize)
     }
 }
 
+void matter_print_onboarding_codes(void)
+{
+#if CONFIG_NETWORK_LAYER_BLE
+    auto flags = chip::RendezvousInformationFlags(chip::RendezvousInformationFlag::kBLE);
+#else
+    auto flags = chip::RendezvousInformationFlags(chip::RendezvousInformationFlag::kOnNetwork);
+#endif /* CONFIG_NETWORK_LAYER_BLE */
+
+    chip::PayloadContents payload;
+    CHIP_ERROR err = GetPayloadContents(payload, flags);
+    if (err != CHIP_NO_ERROR) {
+        ChipLogError(AppServer, "GetPayloadContents() failed: %" CHIP_ERROR_FORMAT, err.Format());
+    }
+#if CONFIG_USER_ACTION_REQUIRED
+    payload.commissioningFlow = chip::CommissioningFlow::kUserActionRequired;
+#endif
+    PrintOnboardingCodes(payload);
+}
+
 CHIP_ERROR matter_get_manual_pairing_code(char *buf, size_t bufSize)
 {
-    if (bufSize < chip::QRCodeBasicSetupPayloadGenerator::kMaxQRCodeBase38RepresentationLength + 1)
-    {
+    if (bufSize < chip::QRCodeBasicSetupPayloadGenerator::kMaxQRCodeBase38RepresentationLength + 1) {
         ChipLogError(DeviceLayer, "Buffer too small for onboarding code!");
         return CHIP_ERROR_INTERNAL;
     }
@@ -68,14 +84,12 @@ CHIP_ERROR matter_get_manual_pairing_code(char *buf, size_t bufSize)
     RendezvousInformationFlags rendezvousFlag = chip::RendezvousInformationFlags(chip::RendezvousInformationFlag::kBLE);
     PayloadContents payload;
 
-    if (GetPayloadContents(payload, rendezvousFlag) != CHIP_NO_ERROR)
-    {
+    if (GetPayloadContents(payload, rendezvousFlag) != CHIP_NO_ERROR) {
         ChipLogError(DeviceLayer, "Failed to get onboarding payload contents");
         return CHIP_ERROR_INTERNAL;
     }
 
-    if (GetManualPairingCode(manualPairingCode, payload) != CHIP_NO_ERROR)
-    {
+    if (GetManualPairingCode(manualPairingCode, payload) != CHIP_NO_ERROR) {
         ChipLogError(DeviceLayer, "Failed to generate manual pairing code!");
         return CHIP_ERROR_INTERNAL;
     }
@@ -87,8 +101,7 @@ CHIP_ERROR matter_get_manual_pairing_code(char *buf, size_t bufSize)
 
 CHIP_ERROR matter_get_qr_code(char *buf, size_t bufSize)
 {
-    if (bufSize < chip::QRCodeBasicSetupPayloadGenerator::kMaxQRCodeBase38RepresentationLength + 1)
-    {
+    if (bufSize < chip::QRCodeBasicSetupPayloadGenerator::kMaxQRCodeBase38RepresentationLength + 1) {
         ChipLogError(DeviceLayer, "Buffer too small for onboarding code!");
         return CHIP_ERROR_INTERNAL;
     }
@@ -98,14 +111,12 @@ CHIP_ERROR matter_get_qr_code(char *buf, size_t bufSize)
     RendezvousInformationFlags rendezvousFlag = chip::RendezvousInformationFlags(chip::RendezvousInformationFlag::kBLE);
     PayloadContents payload;
 
-    if (GetPayloadContents(payload, rendezvousFlag) != CHIP_NO_ERROR)
-    {
+    if (GetPayloadContents(payload, rendezvousFlag) != CHIP_NO_ERROR) {
         ChipLogError(DeviceLayer, "Failed to get onboarding payload contents");
         return CHIP_ERROR_INTERNAL;
     }
 
-    if (GetQRCode(qrCode, payload) != CHIP_NO_ERROR)
-    {
+    if (GetQRCode(qrCode, payload) != CHIP_NO_ERROR) {
         ChipLogError(DeviceLayer, "Failed to generate qr code!");
         return CHIP_ERROR_INTERNAL;
     }
@@ -120,8 +131,7 @@ CHIP_ERROR matter_open_basic_commissioning_window()
     CHIP_ERROR err = CHIP_ERROR_INTERNAL;
     CommissioningWindowManager *mgr = &(chip::Server::GetInstance().GetCommissioningWindowManager());
 
-    if (mgr != NULL)
-    {
+    if (mgr != NULL) {
         chip::DeviceLayer::PlatformMgr().LockChipStack();
         err = mgr->OpenBasicCommissioningWindow();
         chip::DeviceLayer::PlatformMgr().UnlockChipStack();
@@ -135,8 +145,7 @@ CHIP_ERROR matter_get_certificate_declaration(MutableByteSpan &outBuffer)
     CHIP_ERROR err = CHIP_ERROR_INTERNAL;
     DeviceAttestationCredentialsProvider *dacProvider = chip::Credentials::GetDeviceAttestationCredentialsProvider();
 
-    if (dacProvider != NULL)
-    {
+    if (dacProvider != NULL) {
         err = dacProvider->GetCertificationDeclaration(outBuffer);
     }
 
@@ -148,8 +157,7 @@ CHIP_ERROR matter_get_dac_cert(MutableByteSpan &outBuffer)
     CHIP_ERROR err = CHIP_ERROR_INTERNAL;
     DeviceAttestationCredentialsProvider *dacProvider = chip::Credentials::GetDeviceAttestationCredentialsProvider();
 
-    if (dacProvider != NULL)
-    {
+    if (dacProvider != NULL) {
         err = dacProvider->GetDeviceAttestationCert(outBuffer);
     }
 
@@ -161,8 +169,7 @@ CHIP_ERROR matter_get_pai_cert(MutableByteSpan &outBuffer)
     CHIP_ERROR err = CHIP_ERROR_INTERNAL;
     DeviceAttestationCredentialsProvider *dacProvider = chip::Credentials::GetDeviceAttestationCredentialsProvider();
 
-    if (dacProvider != NULL)
-    {
+    if (dacProvider != NULL) {
         err = dacProvider->GetProductAttestationIntermediateCert(outBuffer);
     }
 
@@ -174,8 +181,7 @@ CHIP_ERROR matter_get_firmware_information(MutableByteSpan &outBuffer)
     CHIP_ERROR err = CHIP_ERROR_INTERNAL;
     DeviceAttestationCredentialsProvider *dacProvider = chip::Credentials::GetDeviceAttestationCredentialsProvider();
 
-    if (dacProvider != NULL)
-    {
+    if (dacProvider != NULL) {
         err = dacProvider->GetFirmwareInformation(outBuffer);
     }
 
@@ -187,8 +193,7 @@ CHIP_ERROR matter_get_setup_discriminator(uint16_t &discriminator)
     CHIP_ERROR err = CHIP_ERROR_INTERNAL;
     CommissionableDataProvider *cdProvider = chip::DeviceLayer::GetCommissionableDataProvider();
 
-    if (cdProvider != NULL)
-    {
+    if (cdProvider != NULL) {
         err = cdProvider->GetSetupDiscriminator(discriminator);
     }
 
@@ -200,8 +205,7 @@ CHIP_ERROR matter_get_spake2p_iteration_count(uint32_t &iterationCount)
     CHIP_ERROR err = CHIP_ERROR_INTERNAL;
     CommissionableDataProvider *cdProvider = chip::DeviceLayer::GetCommissionableDataProvider();
 
-    if (cdProvider != NULL)
-    {
+    if (cdProvider != NULL) {
         err = cdProvider->GetSpake2pIterationCount(iterationCount);
     }
 
@@ -213,8 +217,7 @@ CHIP_ERROR matter_get_spake2p_salt(MutableByteSpan &saltBuf)
     CHIP_ERROR err = CHIP_ERROR_INTERNAL;
     CommissionableDataProvider *cdProvider = chip::DeviceLayer::GetCommissionableDataProvider();
 
-    if (cdProvider != NULL)
-    {
+    if (cdProvider != NULL) {
         err = cdProvider->GetSpake2pSalt(saltBuf);
     }
 
@@ -226,8 +229,7 @@ CHIP_ERROR matter_get_spake2p_verifier(MutableByteSpan &verifierBuf, size_t &ver
     CHIP_ERROR err = CHIP_ERROR_INTERNAL;
     CommissionableDataProvider *cdProvider = chip::DeviceLayer::GetCommissionableDataProvider();
 
-    if (cdProvider != NULL)
-    {
+    if (cdProvider != NULL) {
         err = cdProvider->GetSpake2pVerifier(verifierBuf, verifierLen);
     }
 
@@ -239,8 +241,7 @@ CHIP_ERROR matter_get_setup_passcode(uint32_t &passcode)
     CHIP_ERROR err = CHIP_ERROR_INTERNAL;
     CommissionableDataProvider *cdProvider = chip::DeviceLayer::GetCommissionableDataProvider();
 
-    if (cdProvider != NULL)
-    {
+    if (cdProvider != NULL) {
         err = cdProvider->GetSetupPasscode(passcode);
     }
 
@@ -252,8 +253,7 @@ CHIP_ERROR matter_get_vendor_name(char *buf, size_t bufSize)
     CHIP_ERROR err = CHIP_ERROR_INTERNAL;
     DeviceInstanceInfoProvider *diiProvider = chip::DeviceLayer::GetDeviceInstanceInfoProvider();
 
-    if (diiProvider != NULL)
-    {
+    if (diiProvider != NULL) {
         err = diiProvider->GetVendorName(buf, bufSize);
     }
 
@@ -265,8 +265,7 @@ CHIP_ERROR matter_get_vendor_id(uint16_t &vendorId)
     CHIP_ERROR err = CHIP_ERROR_INTERNAL;
     DeviceInstanceInfoProvider *diiProvider = chip::DeviceLayer::GetDeviceInstanceInfoProvider();
 
-    if (diiProvider != NULL)
-    {
+    if (diiProvider != NULL) {
         err = diiProvider->GetVendorId(vendorId);
     }
 
@@ -278,8 +277,7 @@ CHIP_ERROR matter_get_product_name(char *buf, size_t bufSize)
     CHIP_ERROR err = CHIP_ERROR_INTERNAL;
     DeviceInstanceInfoProvider *diiProvider = chip::DeviceLayer::GetDeviceInstanceInfoProvider();
 
-    if (diiProvider != NULL)
-    {
+    if (diiProvider != NULL) {
         err = diiProvider->GetProductName(buf, bufSize);
     }
 
@@ -291,8 +289,7 @@ CHIP_ERROR matter_get_product_id(uint16_t &productId)
     CHIP_ERROR err = CHIP_ERROR_INTERNAL;
     DeviceInstanceInfoProvider *diiProvider = chip::DeviceLayer::GetDeviceInstanceInfoProvider();
 
-    if (diiProvider != NULL)
-    {
+    if (diiProvider != NULL) {
         err = diiProvider->GetProductId(productId);
     }
 
@@ -304,8 +301,7 @@ CHIP_ERROR matter_get_part_number(char *buf, size_t bufSize)
     CHIP_ERROR err = CHIP_ERROR_INTERNAL;
     DeviceInstanceInfoProvider *diiProvider = chip::DeviceLayer::GetDeviceInstanceInfoProvider();
 
-    if (diiProvider != NULL)
-    {
+    if (diiProvider != NULL) {
         err = diiProvider->GetPartNumber(buf, bufSize);
     }
 
@@ -317,8 +313,7 @@ CHIP_ERROR matter_get_product_url(char *buf, size_t bufSize)
     CHIP_ERROR err = CHIP_ERROR_INTERNAL;
     DeviceInstanceInfoProvider *diiProvider = chip::DeviceLayer::GetDeviceInstanceInfoProvider();
 
-    if (diiProvider != NULL)
-    {
+    if (diiProvider != NULL) {
         err = diiProvider->GetProductURL(buf, bufSize);
     }
 
@@ -330,8 +325,7 @@ CHIP_ERROR matter_get_product_label(char *buf, size_t bufSize)
     CHIP_ERROR err = CHIP_ERROR_INTERNAL;
     DeviceInstanceInfoProvider *diiProvider = chip::DeviceLayer::GetDeviceInstanceInfoProvider();
 
-    if (diiProvider != NULL)
-    {
+    if (diiProvider != NULL) {
         err = diiProvider->GetProductLabel(buf, bufSize);
     }
 
@@ -343,8 +337,7 @@ CHIP_ERROR matter_get_serial_number(char *buf, size_t bufSize)
     CHIP_ERROR err = CHIP_ERROR_INTERNAL;
     DeviceInstanceInfoProvider *diiProvider = chip::DeviceLayer::GetDeviceInstanceInfoProvider();
 
-    if (diiProvider != NULL)
-    {
+    if (diiProvider != NULL) {
         err = diiProvider->GetSerialNumber(buf, bufSize);
     }
 
@@ -356,8 +349,7 @@ CHIP_ERROR matter_get_manufacturing_date(uint16_t &year, uint8_t &month, uint8_t
     CHIP_ERROR err = CHIP_ERROR_INTERNAL;
     DeviceInstanceInfoProvider *diiProvider = chip::DeviceLayer::GetDeviceInstanceInfoProvider();
 
-    if (diiProvider != NULL)
-    {
+    if (diiProvider != NULL) {
         err = diiProvider->GetManufacturingDate(year, month, day);
     }
 
@@ -369,8 +361,7 @@ CHIP_ERROR matter_get_hardware_version(uint16_t &hardwareVersion)
     CHIP_ERROR err = CHIP_ERROR_INTERNAL;
     DeviceInstanceInfoProvider *diiProvider = chip::DeviceLayer::GetDeviceInstanceInfoProvider();
 
-    if (diiProvider != NULL)
-    {
+    if (diiProvider != NULL) {
         err = diiProvider->GetHardwareVersion(hardwareVersion);
     }
 
@@ -382,8 +373,7 @@ CHIP_ERROR matter_get_hardware_version_string(char *buf, size_t bufSize)
     CHIP_ERROR err = CHIP_ERROR_INTERNAL;
     DeviceInstanceInfoProvider *diiProvider = chip::DeviceLayer::GetDeviceInstanceInfoProvider();
 
-    if (diiProvider != NULL)
-    {
+    if (diiProvider != NULL) {
         err = diiProvider->GetHardwareVersionString(buf, bufSize);
     }
 

--- a/api/matter_api.h
+++ b/api/matter_api.h
@@ -19,7 +19,13 @@
 
 #pragma once
 
-using namespace ::chip;
+#include <cstddef>
+#include <cstdint>
+
+#include <lib/core/CHIPError.h>
+#include <lib/support/Span.h>
+
+using namespace chip;
 
 /******************************************************
  *               Utilities and Information
@@ -37,6 +43,11 @@ bool matter_server_is_commissioned(void);
  * @param[in]  bufSize: Size of the buffer.
  */
 void matter_get_fabric_indexes(uint16_t *pFabricIndexes, size_t bufSize);
+
+/**
+ * @brief  Print onboarding codes.
+ */
+void matter_print_onboarding_codes(void);
 
 /**
  * @brief  Get the manual pairing code.

--- a/common/include/lwipopts_matter.h
+++ b/common/include/lwipopts_matter.h
@@ -1,11 +1,21 @@
-/******************************************************************************
-  *
-  * This module is a confidential and proprietary property of RealTek and
-  * possession or use of this module requires written permission of RealTek.
-  *
-  * Copyright(c) 2016, Realtek Semiconductor Corporation. All rights reserved.
-  *
-******************************************************************************/
+/*
+ *    This module is a confidential and proprietary property of RealTek and
+ *    possession or use of this module requires written permission of RealTek.
+ *
+ *    Copyright(c) 2025, Realtek Semiconductor Corporation. All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
 
 #ifndef LWIP_HDR_LWIPOPTS_MATTER_H
 #define LWIP_HDR_LWIPOPTS_MATTER_H

--- a/common/include/platform_opts_bt_matter.h
+++ b/common/include/platform_opts_bt_matter.h
@@ -1,11 +1,21 @@
-/******************************************************************************
-  *
-  * This module is a confidential and proprietary property of RealTek and
-  * possession or use of this module requires written permission of RealTek.
-  *
-  * Copyright(c) 2016, Realtek Semiconductor Corporation. All rights reserved.
-  *
-******************************************************************************/
+/*
+ *    This module is a confidential and proprietary property of RealTek and
+ *    possession or use of this module requires written permission of RealTek.
+ *
+ *    Copyright(c) 2025, Realtek Semiconductor Corporation. All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
 
 #ifndef __PLATFORM_OPTS_BT_MATTER_H__
 #define __PLATFORM_OPTS_BT_MATTER_H__
@@ -23,13 +33,13 @@
 
 /* Matter Mesh Configuration */
 #if defined(CONFIG_BT_MESH_DEVICE_MATTER) && CONFIG_BT_MESH_DEVICE_MATTER
-    #undef CONFIG_BT_MESH_DEVICE_MULTIPLE_PROFILE
-    #define CONFIG_BT_MESH_DEVICE_MULTIPLE_PROFILE   1
+#undef CONFIG_BT_MESH_DEVICE_MULTIPLE_PROFILE
+#define CONFIG_BT_MESH_DEVICE_MULTIPLE_PROFILE   1
 #endif
 
 #if (CONFIG_BT_MESH_DEVICE_MATTER && !CONFIG_BT_MESH_DEVICE_MULTIPLE_PROFILE) || \
     (!CONFIG_BT_MESH_DEVICE_MATTER && CONFIG_BT_MESH_DEVICE_MULTIPLE_PROFILE)
-    #error "Please enable both CONFIG_BT_MESH_DEVICE_MATTER & CONFIG_BT_MESH_DEVICE_MULTIPLE_PROFILE"
+#error "Please enable both CONFIG_BT_MESH_DEVICE_MATTER & CONFIG_BT_MESH_DEVICE_MULTIPLE_PROFILE"
 #endif
 
 #endif /* CONFIG_PLATFORM_8710C */

--- a/common/include/platform_opts_matter.h
+++ b/common/include/platform_opts_matter.h
@@ -1,11 +1,21 @@
-/******************************************************************************
-  *
-  * This module is a confidential and proprietary property of RealTek and
-  * possession or use of this module requires written permission of RealTek.
-  *
-  * Copyright(c) 2016, Realtek Semiconductor Corporation. All rights reserved.
-  *
-******************************************************************************/
+/*
+ *    This module is a confidential and proprietary property of RealTek and
+ *    possession or use of this module requires written permission of RealTek.
+ *
+ *    Copyright(c) 2025, Realtek Semiconductor Corporation. All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
 
 #ifndef __PLATFORM_OPTS_MATTER_H__
 #define __PLATFORM_OPTS_MATTER_H__
@@ -74,7 +84,7 @@
 #define MATTER_KVS_MODULE_NUM                   13                      // max number of module
 #define MATTER_KVS_VARIABLE_NAME_SIZE           32                      // max size of the variable name
 #define MATTER_KVS_VARIABLE_VALUE_SIZE          64+4                    // max size of the variable value, +4 so it can store 64 bytes variable
-                                                                        // max value number in moudle = floor(4024 / (32 + 64 + 4)) = 40
+// max value number in moudle = floor(4024 / (32 + 64 + 4)) = 40
 
 /****************************************************************
  * MATTER KVS2, for key length large than 64 (Fabric1 ~ FabricF)
@@ -83,7 +93,7 @@
 #define MATTER_KVS_MODULE_NUM2                  10                      // max number of module
 #define MATTER_KVS_VARIABLE_NAME_SIZE2          32                      // max size of the variable name
 #define MATTER_KVS_VARIABLE_VALUE_SIZE2         400+4                   // max size of the variable value, +4 so it can store 400 bytes variable
-                                                                        // max value number in moudle = floor(4024 / (32 + 400 + 4)) = 9
+// max value number in moudle = floor(4024 / (32 + 400 + 4)) = 9
 
 /*****************************************************************
  * Matter Factory Data: last 4KB of external flash

--- a/common/include/platform_stdlib_matter.h
+++ b/common/include/platform_stdlib_matter.h
@@ -1,11 +1,21 @@
-/******************************************************************************
-  *
-  * This module is a confidential and proprietary property of RealTek and
-  * possession or use of this module requires written permission of RealTek.
-  *
-  * Copyright(c) 2016, Realtek Semiconductor Corporation. All rights reserved.
-  *
-******************************************************************************/
+/*
+ *    This module is a confidential and proprietary property of RealTek and
+ *    possession or use of this module requires written permission of RealTek.
+ *
+ *    Copyright(c) 2025, Realtek Semiconductor Corporation. All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
 
 #ifndef PLATFORM_STDLIB_MATTER_H
 #define PLATFORM_STDLIB_MATTER_H
@@ -14,19 +24,19 @@
 #include <assert.h>
 
 extern size_t strnlen(const char *s, size_t count);
-extern void *pvPortMalloc( size_t xWantedSize );
+extern void *pvPortMalloc(size_t xWantedSize);
 
 //def
 #ifndef false
-    #define false   0
+#define false   0
 #endif
 
 #ifndef true
-    #define true    1
+#define true    1
 #endif
 
 #ifndef in_addr_t
-    typedef __uint32_t in_addr_t;
+typedef __uint32_t in_addr_t;
 #endif
 
 #elif defined(CONFIG_PLATFORM_8721D)
@@ -34,61 +44,61 @@ extern void *pvPortMalloc( size_t xWantedSize );
 #include <sys/time.h>
 #include <assert.h>
 
-extern char * _strtok_r( char *s , const char *delim , char **lasts);
-extern int _nanosleep( const struct timespec * rqtp, struct timespec * rmtp );
-extern int _vTaskDelay( const TickType_t xTicksToDelay );
-extern time_t _time( time_t * tloc );
+extern char *_strtok_r(char *s, const char *delim, char **lasts);
+extern int _nanosleep(const struct timespec *rqtp, struct timespec *rmtp);
+extern int _vTaskDelay(const TickType_t xTicksToDelay);
+extern time_t _time(time_t *tloc);
 extern void *pvPortCalloc(size_t xWantedCnt, size_t xWantedSize);
 
 #undef calloc
 #define calloc            pvPortCalloc
 
 #ifndef false
-    #define false   0
+#define false   0
 #endif
 
 #ifndef true
-    #define true    1
+#define true    1
 #endif
 
 #ifndef strtok_r
-    #define strtok_r(s, delim, lasts)	  _strtok_r (s, delim, lasts)
+#define strtok_r(s, delim, lasts)	  _strtok_r (s, delim, lasts)
 #endif
 
 #ifndef usleep
-    #define usleep(x)    _vTaskDelay(x)
+#define usleep(x)    _vTaskDelay(x)
 #endif
 
 #ifndef nanosleep
-    #define nanosleep    _nanosleep
+#define nanosleep    _nanosleep
 #endif
 
 #ifndef in_addr_t
-    typedef __uint32_t in_addr_t;
+typedef __uint32_t in_addr_t;
 #endif
 
 #ifdef strtok
-    #undef strtok
+#undef strtok
 #endif
 
 #ifdef strtol
-    #undef strtol
+#undef strtol
 #endif
 
 #ifdef rand
-    #undef rand
+#undef rand
 #endif
 
 #ifdef srand
-    #undef srand
+#undef srand
 #endif
 
 #ifdef IN
-    #undef IN
+#undef IN
 #endif
 
 #ifdef vsnprintf
-	#undef vsnprintf
+#undef vsnprintf
 #endif
 
 #endif /* CONFIG_PLATFORM_XXXX */

--- a/common/include/version_matter.h
+++ b/common/include/version_matter.h
@@ -1,0 +1,29 @@
+/*
+ *    This module is a confidential and proprietary property of RealTek and
+ *    possession or use of this module requires written permission of RealTek.
+ *
+ *    Copyright(c) 2025, Realtek Semiconductor Corporation. All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#ifndef AMEBA_MATTER_VERSION_H
+#define AMEBA_MATTER_VERSION_H
+
+#define AMEBA_MATTER_SDK_VERSION_MAJOR    1
+#define AMEBA_MATTER_SDK_VERSION_MINOR    4
+#define AMEBA_MATTER_SDK_VERSION_PATCH    2
+
+#define AMEBA_MATTER_SDK_GIT_REVISION     "v1.4.2"
+
+#endif /* AMEBA_MATTER_VERSION_H */

--- a/core/matter_core.cpp
+++ b/core/matter_core.cpp
@@ -20,6 +20,7 @@
 #include <stdlib.h>
 #include <stdint.h>
 
+#include <matter_api.h>
 #include <matter_core.h>
 #include <matter_dcts.h>
 #include <matter_data_providers.h>
@@ -249,7 +250,7 @@ void matter_core_init_server(intptr_t context)
 
 #if CHIP_ENABLE_AMEBA_TERMS_AND_CONDITION
     const Optional<app::TermsAndConditions> termsAndConditions = Optional<app::TermsAndConditions>(
-                app::TermsAndConditions(CHIP_AMEBA_TC_REQUIRED_ACKNOWLEDGEMENTS, CHIP_AMEBA_TC_MIN_REQUIRED_VERSION));
+                            app::TermsAndConditions(CHIP_AMEBA_TC_REQUIRED_ACKNOWLEDGEMENTS, CHIP_AMEBA_TC_MIN_REQUIRED_VERSION));
     PersistentStorageDelegate &persistentStorageDelegate = Server::GetInstance().GetPersistentStorage();
     chip::app::TermsAndConditionsManager::GetInstance()->Init(&persistentStorageDelegate, termsAndConditions);
 #endif // CHIP_ENABLE_AMEBA_TERMS_AND_CONDITION
@@ -261,8 +262,7 @@ void matter_core_init_server(intptr_t context)
     emberAfEndpointEnableDisable(0xFFFE, false);
 
     if (RTW_SUCCESS != wifi_is_connected_to_ap()) {
-        // QR code will be used with CHIP Tool
-        PrintOnboardingCodes(chip::RendezvousInformationFlags(chip::RendezvousInformationFlag::kBLE));
+        matter_print_onboarding_codes();
     }
 
 #if CONFIG_ENABLE_CHIP_SHELL

--- a/examples/matter_example_entry.c
+++ b/examples/matter_example_entry.c
@@ -1,9 +1,30 @@
+/*
+ *    This module is a confidential and proprietary property of RealTek and
+ *    possession or use of this module requires written permission of RealTek.
+ *
+ *    Copyright(c) 2025, Realtek Semiconductor Corporation. All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
 #include <platform_opts.h>
+
+#if defined(CONFIG_EXAMPLE_MATTER) && (CONFIG_EXAMPLE_MATTER == 1)
+
 #if defined(CONFIG_PLATFORM_8721D)
 #include <atcmd_matter.h>
 #endif
 
-#if defined(CONFIG_EXAMPLE_MATTER) && (CONFIG_EXAMPLE_MATTER == 1)
 #if defined(CONFIG_EXAMPLE_MATTER_CHIPTEST) && (CONFIG_EXAMPLE_MATTER_CHIPTEST == 1)
 #include <chiptest/example_matter.h>
 #elif defined(CONFIG_EXAMPLE_MATTER_ROOM_AIR_CONDITIONER) && (CONFIG_EXAMPLE_MATTER_ROOM_AIR_CONDITIONER == 1)
@@ -30,6 +51,24 @@
 #include <thermostat/example_matter_thermostat.h>
 #endif
 
+#if defined(CONFIG_PLATFORM_8710C)
+#include "FreeRTOS.h"
+static void *matter_mbedtls_calloc_func(size_t nelements, size_t elementSize)
+{
+    size_t size;
+    void *ptr = NULL;
+
+    size = nelements * elementSize;
+    ptr = pvPortMalloc(size);
+
+    if (ptr) {
+        memset(ptr, 0, size);
+    }
+
+    return ptr;
+}
+#endif /* CONFIG_PLATFORM_8710C */
+
 /*
  * All of the examples (except CONFIG_EXAMPLE_MATTER_CHIPTEST) are disabled by default for code size consideration
  * The configuration is enabled in platform_opts_matter.h
@@ -38,7 +77,11 @@ void matter_example_entry(void)
 {
 #if defined(CONFIG_PLATFORM_8721D)
     matter_shell_init();
-#endif
+#endif /* CONFIG_PLATFORM_8721D */
+
+#if defined(CONFIG_PLATFORM_8710C)
+    mbedtls_platform_set_calloc_free(matter_mbedtls_calloc_func, vPortFree);
+#endif /* CONFIG_PLATFORM_8710C */
 
 #if defined(CONFIG_EXAMPLE_MATTER_CHIPTEST) && (CONFIG_EXAMPLE_MATTER_CHIPTEST == 1)
     example_matter_task();

--- a/project/amebad/Makefile.include.matter
+++ b/project/amebad/Makefile.include.matter
@@ -130,6 +130,11 @@ CFLAGS += -DCONFIG_ENABLE_AMEBA_SNTP=1
 CFLAGS += -DCONFIG_ENABLE_AMEBA_TEST_EVENT_TRIGGER=0
 
 # -------------------------------------------------------------------
+# Matter Commissioning Flow (default: standard)
+# -------------------------------------------------------------------
+CFLAGS += -DCONFIG_USER_ACTION_REQUIRED=0
+
+# -------------------------------------------------------------------
 # Matter Cluster Flags
 # -------------------------------------------------------------------
 

--- a/project/amebaz2/Makefile.include.matter
+++ b/project/amebaz2/Makefile.include.matter
@@ -100,6 +100,11 @@ CFLAGS += -DCONFIG_ENABLE_AMEBA_SNTP=1
 CFLAGS += -DCONFIG_ENABLE_AMEBA_TEST_EVENT_TRIGGER=0
 
 # -------------------------------------------------------------------
+# Matter Commissioning Flow (default: standard)
+# -------------------------------------------------------------------
+CFLAGS += -DCONFIG_USER_ACTION_REQUIRED=0
+
+# -------------------------------------------------------------------
 # Matter Cluster Flags
 # -------------------------------------------------------------------
 

--- a/project/amebaz2plus/Makefile.include.matter
+++ b/project/amebaz2plus/Makefile.include.matter
@@ -100,6 +100,11 @@ CFLAGS += -DCONFIG_ENABLE_AMEBA_SNTP=1
 CFLAGS += -DCONFIG_ENABLE_AMEBA_TEST_EVENT_TRIGGER=0
 
 # -------------------------------------------------------------------
+# Matter Commissioning Flow (default: standard)
+# -------------------------------------------------------------------
+CFLAGS += -DCONFIG_USER_ACTION_REQUIRED=0
+
+# -------------------------------------------------------------------
 # Matter Cluster Flags
 # -------------------------------------------------------------------
 

--- a/tools/docker/amebad/Dockerfile
+++ b/tools/docker/amebad/Dockerfile
@@ -3,7 +3,7 @@ FROM ameba-rtos-matter:common
 
 # Redefine following build arguments to respective repo and tag/branch
 ARG AMEBA_MATTER_REPO=https://github.com/xshuqun/ameba-rtos-matter.git
-ARG TAG_NAME=v1.4.2-PR/update_readme
+ARG TAG_NAME=v1.4.2-PR/support_user_intent
 
 # Define fixed build arguments
 ARG AMBD_REPO=https://github.com/Ameba-AIoT/ameba-rtos-d.git

--- a/tools/docker/amebaz2/Dockerfile
+++ b/tools/docker/amebaz2/Dockerfile
@@ -3,7 +3,7 @@ FROM ameba-rtos-matter:common
 
 # Redefine following build arguments to respective repo and tag/branch
 ARG AMEBA_MATTER_REPO=https://github.com/xshuqun/ameba-rtos-matter.git
-ARG TAG_NAME=v1.4.2-PR/update_readme
+ARG TAG_NAME=v1.4.2-PR/support_user_intent
 
 # Define fixed build arguments
 ARG AMBZ2_REPO=https://github.com/Ameba-AIoT/ameba-rtos-z2.git


### PR DESCRIPTION
## This PR addresses:

* support user intent commissioning flow.

Notes:
* There are 3 commissioning flow, and on default ameba is using standard flow.
  - Standard flow: device enters commissioning mode upon reboot
  - User Intent flow: user must perform an action e.g., pressing button
  - Custom flow: device enters commissioning mode using other ways e.g., via URL
* To support User Intent flow, it requires the following
  - payload.commissioningFlow = chip::CommissioningFlow::kUserActionRequired
  - set CHIP_DEVICE_CONFIG_PAIRING_INITIAL_HINT
  - set CHIP_DEVICE_CONFIG_PAIRING_INITIAL_INSTRUCTION

## Verification:

Tested with commissioning, and qr code parsing.