### PR TITLE
[common][certification] fix for TC-RR-1.1

### DIFF
--- a/common/include/platform_opts_matter.h
+++ b/common/include/platform_opts_matter.h
@@ -90,7 +90,7 @@
  * MATTER KVS2, for key length large than 64 (Fabric1 ~ FabricF)
  * Uses DCT2, set flash address MATTER_KVS_BEGIN_ADDR2
  ****************************************************************/
-#define MATTER_KVS_MODULE_NUM2                  10                      // max number of module
+#define MATTER_KVS_MODULE_NUM2                  11                      // max number of module
 #define MATTER_KVS_VARIABLE_NAME_SIZE2          32                      // max size of the variable name
 #define MATTER_KVS_VARIABLE_VALUE_SIZE2         400+4                   // max size of the variable value, +4 so it can store 400 bytes variable
 // max value number in moudle = floor(4024 / (32 + 400 + 4)) = 9
@@ -113,17 +113,21 @@
 #undef BT_FTL_PHY_ADDR1
 #undef BT_FTL_BKUP_ADDR
 #undef UART_SETTING_SECTOR
-#undef DCT_BEGIN_ADDR
 #undef MATTER_KVS_BEGIN_ADDR
 #undef MATTER_KVS_BEGIN_ADDR2
 
-#define FAST_RECONNECT_DATA                     (0x400000 - 0x1000)     // 0x3FF000
-#define BT_FTL_PHY_ADDR0                        (0x400000 - 0x2000)     // 0x3FE000
-#define BT_FTL_PHY_ADDR1                        (0x400000 - 0x3000)     // 0x3FD000
-#define BT_FTL_BKUP_ADDR                        (0x400000 - 0x4000)     // 0x3FC000
-#define UART_SETTING_SECTOR                     (0x400000 - 0x5000)     // 0x3FB000
-#define MATTER_KVS_BEGIN_ADDR                   (0x400000 - 0x13000)    // 0x3ED000 ~ 0x3FB000 : 56K
-#define MATTER_KVS_BEGIN_ADDR2                  (0x400000 - 0x1E000)    // 0x3E6000 ~ 0x3ED000 : 24K
+#define FAST_RECONNECT_DATA                     (0x400000 - 0x1000)     // 0x3FF000 (4K)
+#define BT_FTL_PHY_ADDR0                        (0x400000 - 0x2000)     // 0x3FE000 (4K)
+#define BT_FTL_PHY_ADDR1                        (0x400000 - 0x3000)     // 0x3FD000 (4K)
+#define BT_FTL_BKUP_ADDR                        (0x400000 - 0x4000)     // 0x3FC000 (4K)
+#define UART_SETTING_SECTOR                     (0x400000 - 0x5000)     // 0x3FB000 (4K)
+#if (MATTER_KVS_ENABLE_BACKUP == 0)
+#define MATTER_KVS_BEGIN_ADDR                   (0x400000 - 0x13000)    // 0x3ED000 ~ 0x3FB000 (56K)
+#define MATTER_KVS_BEGIN_ADDR2                  (0x400000 - 0x1F000)    // 0x3E1000 ~ 0x3ED000 (48K)
+#elif (MATTER_KVS_ENABLE_BACKUP == 1)
+#define MATTER_KVS_BEGIN_ADDR                   (0x400000 - 0x20000)    // 0x3E0000 ~ 0x3FB000 (108K)
+#define MATTER_KVS_BEGIN_ADDR2                  (0x400000 - 0x37000)    // 0x3C9000 ~ 0x3E0000 (92K)
+#endif /* MATTER_KVS_ENABLE_BACKUP */
 
 #elif defined(CONFIG_PLATFORM_8721D)
 

--- a/tools/docker/amebad/Dockerfile
+++ b/tools/docker/amebad/Dockerfile
@@ -3,7 +3,7 @@ FROM ameba-rtos-matter:common
 
 # Redefine following build arguments to respective repo and tag/branch
 ARG AMEBA_MATTER_REPO=https://github.com/xshuqun/ameba-rtos-matter.git
-ARG TAG_NAME=v1.5-PR/support_user_intent
+ARG TAG_NAME=v1.5-PR/increase_kvs
 
 # Define fixed build arguments
 ARG AMBD_REPO=https://github.com/Ameba-AIoT/ameba-rtos-d.git

--- a/tools/docker/amebaz2/Dockerfile
+++ b/tools/docker/amebaz2/Dockerfile
@@ -3,7 +3,7 @@ FROM ameba-rtos-matter:common
 
 # Redefine following build arguments to respective repo and tag/branch
 ARG AMEBA_MATTER_REPO=https://github.com/xshuqun/ameba-rtos-matter.git
-ARG TAG_NAME=v1.5-PR/support_user_intent
+ARG TAG_NAME=v1.5-PR/increase_kvs
 
 # Define fixed build arguments
 ARG AMBZ2_REPO=https://github.com/Ameba-AIoT/ameba-rtos-z2.git


### PR DESCRIPTION
## This PR addresses:

* Increase DCT2 module from 10 to 11.

Notes:
* Due to the add on of VIDVerification, another element will be stored into KVS and requires expanding of KVS to pass TC-RR-1.1.

## Verification:

Verified TC-RR-1.1 pass.