### PR TITLE
[common][wifi] start dnssd server after user-specific wi-fi connection

### DIFF
--- a/core/matter_core.cpp
+++ b/core/matter_core.cpp
@@ -260,6 +260,11 @@ void matter_core_init_server(intptr_t context)
 
     if (RTW_SUCCESS != wifi_is_connected_to_ap()) {
         matter_print_onboarding_codes();
+    } else if (matter_server_is_commissioned() != 0) {
+        // Ensure DNSSD server is started for devices connected via user-specific Wi-Fi / fast connect.
+        // Previously, commissioned devices became unreachable/uncontrollable
+        // because the DNSSD service was not initialized after network connection.
+        chip::app::DnssdServer::Instance().StartServer();
     }
 
 #if CONFIG_ENABLE_CHIP_SHELL

--- a/tools/docker/amebad/Dockerfile
+++ b/tools/docker/amebad/Dockerfile
@@ -3,7 +3,7 @@ FROM ameba-rtos-matter:common
 
 # Redefine following build arguments to respective repo and tag/branch
 ARG AMEBA_MATTER_REPO=https://github.com/xshuqun/ameba-rtos-matter.git
-ARG TAG_NAME=v1.5-PR/increase_kvs
+ARG TAG_NAME=v1.5-PR/fix_dnssd_server
 
 # Define fixed build arguments
 ARG AMBD_REPO=https://github.com/Ameba-AIoT/ameba-rtos-d.git

--- a/tools/docker/amebaz2/Dockerfile
+++ b/tools/docker/amebaz2/Dockerfile
@@ -3,7 +3,7 @@ FROM ameba-rtos-matter:common
 
 # Redefine following build arguments to respective repo and tag/branch
 ARG AMEBA_MATTER_REPO=https://github.com/xshuqun/ameba-rtos-matter.git
-ARG TAG_NAME=v1.5-PR/increase_kvs
+ARG TAG_NAME=v1.5-PR/fix_dnssd_server
 
 # Define fixed build arguments
 ARG AMBZ2_REPO=https://github.com/Ameba-AIoT/ameba-rtos-z2.git


### PR DESCRIPTION
## This PR addresses:

* Previously, commissioned devices connected via user-specific wi-fi flow were not controllable because the dnssd server was not started.
* Trigger dnssd start server after wi-fi connection to restore device discovery.

## Verification:

Tested by enabling CONFIG_EXAMPLE_WLAN_FAST_CONNECT.
(1) allow the device to get connected to Wi-Fi first
(2) commission the device
(3) reboot the device
(4) attempt to control the device

Initially it will fail at (4), after adding the changes, this issue has been fixed.