### PR TITLE
[common][core] support app device event callback registration

### DIFF
--- a/core/matter_core.cpp
+++ b/core/matter_core.cpp
@@ -116,8 +116,21 @@ constexpr size_t kMaxPendingMdnsPackets = 10u;
 chip::Inet::DropIfTooManyQueuedPacketsFilter sMdnsPacketFilter(kMaxPendingMdnsPackets);
 #endif
 
+static matter_app_device_callback_t sDeviceCallback = NULL;
+static void * sDeviceCallbackContext = NULL;
+
+void matter_reg_app_device_callback(matter_app_device_callback_t callback, void * context)
+{
+    sDeviceCallback = callback;
+    sDeviceCallbackContext = context;
+}
+
 void matter_core_device_callback_internal(const ChipDeviceEvent *event, intptr_t arg)
 {
+    if (sDeviceCallback != NULL) {
+        sDeviceCallback(event->Type, sDeviceCallbackContext);
+    }
+
     switch (event->Type) {
     case DeviceEventType::kInternetConnectivityChange:
 #if CHIP_DEVICE_CONFIG_ENABLE_OTA_REQUESTOR

--- a/core/matter_core.h
+++ b/core/matter_core.h
@@ -10,9 +10,48 @@
 
 #include <platform/CHIPDeviceLayer.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Matter device event callback prototype
+ *
+ * @param event       Event ID
+ * @param context     User registered context pointer
+ */
+typedef void (*matter_app_device_callback_t)(uint16_t event, void * context);
+
+/**
+ * @brief Register Matter device callback
+ *        This API allows the application to register a callback function to receive
+ *        Matter device events.
+ * @param callback    User callback function
+ * @param context     User context pointer, returned when callback is invoked
+ *
+ * @reference for "event":
+ *      Please check the enumerate in
+ *          - connectedhomeip/src/include/platform/CHIPDeviceEvent.h
+ *          - sdk/component/common/application/matter/core/matter_events.h
+ * @code
+ * static void example_matter_app_device_callback(uint16_t event, void * context)
+ * {
+ *     printf("Device Event = %d\n", event);
+ * }
+ *
+ * // Register callback
+ * matter_reg_app_device_callback(example_matter_app_device_callback, NULL);
+ * @endcode
+ */
+void matter_reg_app_device_callback(matter_app_device_callback_t callback, void * context);
+
 /**
  * @brief  Start the Matter Core task in the porting layer implementation.
  *         This function initializes and starts the Matter Core task.
  * @return CHIP_NO_ERROR if start successfully.
  */
 CHIP_ERROR matter_core_start(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/tools/docker/amebad/Dockerfile
+++ b/tools/docker/amebad/Dockerfile
@@ -3,7 +3,7 @@ FROM ameba-rtos-matter:common
 
 # Redefine following build arguments to respective repo and tag/branch
 ARG AMEBA_MATTER_REPO=https://github.com/xshuqun/ameba-rtos-matter.git
-ARG TAG_NAME=v1.4-PR/fix_dnssd_server
+ARG TAG_NAME=v1.4-PR/add_app_device_cb
 
 # Define fixed build arguments
 ARG AMBD_REPO=https://github.com/Ameba-AIoT/ameba-rtos-d.git

--- a/tools/docker/amebaz2/Dockerfile
+++ b/tools/docker/amebaz2/Dockerfile
@@ -3,7 +3,7 @@ FROM ameba-rtos-matter:common
 
 # Redefine following build arguments to respective repo and tag/branch
 ARG AMEBA_MATTER_REPO=https://github.com/xshuqun/ameba-rtos-matter.git
-ARG TAG_NAME=v1.4-PR/fix_dnssd_server
+ARG TAG_NAME=v1.4-PR/add_app_device_cb
 
 # Define fixed build arguments
 ARG AMBZ2_REPO=https://github.com/Ameba-AIoT/ameba-rtos-z2.git


### PR DESCRIPTION
## This PR addresses:

* add API for application to register device event callback from matter device event.
* callback is invoked from internal device event handler with event type and user context.

## Verification:

Tested with light_port and event callback is properly triggered.