### PR TITLE
[common][api] improvement for 2de75e2

### DIFF
--- a/common/atcmd/atcmd_matter.c
+++ b/common/atcmd/atcmd_matter.c
@@ -322,24 +322,29 @@ static void atcmd_matter_device_info(void *arg)
 
 usage:
     printf("[ATMI]: Matter Device Information\n");
-    printf("Usage:\n");
-    printf("  ATMI=0   -> Get manual pairing code\n");
-    printf("  ATMI=1   -> Get QR code\n");
-    printf("  ATMI=2   -> Get Certification Declaration\n");
-    printf("  ATMI=3   -> Get DAC cert\n");
-    printf("  ATMI=4   -> Get PAI cert\n");
-    printf("  ATMI=5   -> Get discriminator\n");
-    printf("  ATMI=6   -> Get passcode\n");
-    printf("  ATMI=7   -> Get vendor name\n");
-    printf("  ATMI=8   -> Get vendor ID\n");
-    printf("  ATMI=9   -> Get product name\n");
-    printf("  ATMI=10  -> Get product ID\n");
-    printf("  ATMI=11  -> Get serial number\n");
-    printf("  ATMI=12  -> Get manufacturing date\n");
-    printf("  ATMI=13  -> Get hardware version\n");
-    printf("  ATMI=14  -> Get hardware version string\n");
-    printf("  ATMI=15  -> Get software version\n");
-    printf("  ATMI=16  -> Get software version string\n");
+#if defined(CONFIG_PLATFORM_8721D)
+    printf("Usage: ATMI <options>\n");
+#elif defined(CONFIG_PLATFORM_8710C)
+    printf("Usage: ATMI=<options>\n");
+#endif
+    printf("options:\n");
+    printf(" 0  -> Get manual pairing code\n");
+    printf(" 1  -> Get QR code\n");
+    printf(" 2  -> Get Certification Declaration\n");
+    printf(" 3  -> Get DAC cert\n");
+    printf(" 4  -> Get PAI cert\n");
+    printf(" 5  -> Get discriminator\n");
+    printf(" 6  -> Get passcode\n");
+    printf(" 7  -> Get vendor name\n");
+    printf(" 8  -> Get vendor ID\n");
+    printf(" 9  -> Get product name\n");
+    printf(" 10 -> Get product ID\n");
+    printf(" 11 -> Get serial number\n");
+    printf(" 12 -> Get manufacturing date\n");
+    printf(" 13 -> Get hardware version\n");
+    printf(" 14 -> Get hardware version string\n");
+    printf(" 15 -> Get software version\n");
+    printf(" 16 -> Get software version string\n");
 
 exit:
     if (read_buf != NULL) {
@@ -419,7 +424,7 @@ log_item_t at_matter_items[] = {
 
 const char *matter_help_str[] = {
     "factory reset. (Usage: ATM$)",
-#if defined(CONFIG_ENABLE_OTA_REQUESTOR) && CONFIG_ENABLE_OTA_REQUESTOR
+#if defined(CONFIG_ENABLE_OTA_REQUESTOR) && CONFIG_EXAMPLE_MATTER_CHIPTEST
     "matter ota query image. (Usage: ATM%)",
     "matter ota apply update. (Usage: ATM^)",
 #endif /* CONFIG_ENABLE_OTA_REQUESTOR */
@@ -468,8 +473,10 @@ void matter_shell_init(void)
 CMD_TABLE_DATA_SECTION
 const COMMAND_TABLE matter_atcmd[] = {
     {(const u8 *)"ATM$", 0, atcmd_matter_factory_reset, (const u8 *)"ATM$ : factory reset. (Usage: ATM$)"},
+#if CONFIG_ENABLE_OTA_REQUESTOR && CONFIG_EXAMPLE_MATTER_CHIPTEST
     {(const u8 *)"ATM%", 0, atcmd_matter_ota_query, (const u8 *)"ATM% : matter ota query image. (Usage: ATM%)"},
     {(const u8 *)"ATM^", 0, atcmd_matter_ota_apply, (const u8 *)"ATM^ : matter ota apply update. (Usage: ATM^)"},
+#endif /* CONFIG_ENABLE_OTA_REQUESTOR */
     {(const u8 *)"ATMH", 1, atcmd_matter_help, (const u8 *)"ATMH : matter help. (Usage: ATMH)"},
 #if defined(CONFIG_ENABLE_AMEBA_DEVICE_INFO) && CONFIG_ENABLE_AMEBA_DEVICE_INFO
     {(const u8 *)"ATMI", 1, atcmd_matter_device_info, (const u8 *)"ATMI : matter device info. (Usage: ATMI)"},

--- a/project/amebad/make/chip_main/all_clusters_app/Makefile
+++ b/project/amebad/make/chip_main/all_clusters_app/Makefile
@@ -14,6 +14,14 @@ OUTPUT_DIR   := $(CHIPDIR)/examples/all-clusters-app/ameba/build/chip
 CODEGEN_DIR  := $(OUTPUT_DIR)/codegen
 
 # -------------------------------------------------------------------
+# Compiler Flags
+# -------------------------------------------------------------------
+GLOBAL_CFLAGS += -DCHIP_AMEBA_APP_TASK=1
+ifeq ($(CHIP_ENABLE_SHELL), true)
+GLOBAL_CFLAGS += -DCONFIG_ENABLE_CHIP_SHELL=1
+endif
+
+# -------------------------------------------------------------------
 # Search Directory
 # -------------------------------------------------------------------
 DIR += $(CHIPDIR)/examples/all-clusters-app/all-clusters-common
@@ -27,7 +35,7 @@ vpath %.c $(DIR) $(shell find $(DIR) -type d)
 # -------------------------------------------------------------------
 # Include Path
 # -------------------------------------------------------------------
-IFLAGS += -I$(CHIPDIR)/examples/all-clusters-app/all-clusters-common/include
+IFLAGS += -I$(MATTER_EXAMPLE_DIR)/chiptest
 IFLAGS += -I$(CHIPDIR)/examples/all-clusters-app/ameba/main/include
 IFLAGS += -I$(CHIPDIR)/examples/all-clusters-app/ameba/build/chip/gen/include
 IFLAGS += -I$(CODEGEN_DIR)

--- a/project/amebad/make/chip_main/chip_main_sources.mk
+++ b/project/amebad/make/chip_main/chip_main_sources.mk
@@ -3,6 +3,7 @@
 # -------------------------------------------------------------------
 CHIP_ENABLE_AMEBA_TC = $(shell grep '\#define CHIP_ENABLE_AMEBA_TERMS_AND_CONDITION ' $(MATTER_COMMON_DIR)/include/platform_opts_matter.h | tr -s '[:space:]' | cut -d' ' -f3)
 CHIP_ENABLE_OTA_REQUESTOR = $(shell grep 'chip_enable_ota_requestor' $(OUTPUT_DIR)/args.gn | cut -d' ' -f3)
+CHIP_ENABLE_SHELL = $(shell grep 'chip_build_libshell' $(OUTPUT_DIR)/args.gn | cut -d' ' -f3)
 
 # -------------------------------------------------------------------
 # Compilation flag

--- a/project/amebad/make/chip_main/light_switch_app/Makefile
+++ b/project/amebad/make/chip_main/light_switch_app/Makefile
@@ -14,6 +14,13 @@ OUTPUT_DIR = $(CHIPDIR)/examples/light-switch-app/ameba/build/chip
 CODEGEN_DIR = $(OUTPUT_DIR)/codegen
 
 # -------------------------------------------------------------------
+# Compiler Flags
+# -------------------------------------------------------------------
+ifeq ($(CHIP_ENABLE_SHELL), true)
+GLOBAL_CFLAGS += -DCONFIG_ENABLE_CHIP_SHELL=1
+endif
+
+# -------------------------------------------------------------------
 # Search Directory
 # -------------------------------------------------------------------
 DIR += $(CODEGEN_DIR)/app

--- a/project/amebaz2/make/all_clusters/lib_chip_main.mk
+++ b/project/amebaz2/make/all_clusters/lib_chip_main.mk
@@ -33,6 +33,14 @@ CODEGENDIR   := $(OUTPUT_DIR)/codegen
 include $(MATTER_MAIN_SRC)
 
 # -------------------------------------------------------------------
+# Compiler Flags
+# -------------------------------------------------------------------
+CFLAGS += -DCHIP_AMEBA_APP_TASK=1
+ifeq ($(CHIP_ENABLE_SHELL), true)
+CFLAGS += -DCONFIG_ENABLE_CHIP_SHELL=1
+endif
+
+# -------------------------------------------------------------------
 # Include Path
 # -------------------------------------------------------------------
 INCLUDES += -I$(CHIPDIR)/examples/all-clusters-app/ameba/main/include

--- a/project/amebaz2/make/chip_core_sources.mk
+++ b/project/amebaz2/make/chip_core_sources.mk
@@ -1,3 +1,15 @@
+# -------------------------------------------------------------------
+# Build Definition
+# -------------------------------------------------------------------
+CHIP_ENABLE_AMEBA_DLOG = $(shell grep '\#define CONFIG_ENABLE_AMEBA_DLOG ' $(MATTER_COMMON_DIR)/include/platform_opts_matter.h | tr -s '[:space:]' | cut -d' ' -f3)
+CHIP_ENABLE_AMEBA_TC = $(shell grep '\#define CHIP_ENABLE_AMEBA_TERMS_AND_CONDITION ' $(MATTER_COMMON_DIR)/include/platform_opts_matter.h | tr -s '[:space:]' | cut -d' ' -f3)
+CHIP_ENABLE_CHIPOBLE = $(shell grep 'CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE' $(MATTER_INCLUDE) | cut -d'=' -f3)
+CHIP_ENABLE_IPV4 = $(shell grep 'INET_CONFIG_ENABLE_IPV4' $(MATTER_INCLUDE) | cut -d'=' -f3)
+CHIP_ENABLE_OTA_REQUESTOR = $(shell grep 'CONFIG_ENABLE_OTA_REQUESTOR' $(MATTER_INCLUDE) | cut -d'=' -f3)
+
+# -------------------------------------------------------------------
+# Includes
+# -------------------------------------------------------------------
 include $(MATTER_INCLUDE)
 
 # -------------------------------------------------------------------
@@ -16,15 +28,6 @@ LD = $(CROSS_COMPILE)gcc
 GDB = $(CROSS_COMPILE)gdb
 OBJCOPY = $(CROSS_COMPILE)objcopy
 OBJDUMP = $(CROSS_COMPILE)objdump
-
-# -------------------------------------------------------------------
-# Build Definition
-# -------------------------------------------------------------------
-CHIP_ENABLE_AMEBA_DLOG = $(shell grep '\#define CONFIG_ENABLE_AMEBA_DLOG ' $(MATTER_COMMON_DIR)/include/platform_opts_matter.h | tr -s '[:space:]' | cut -d' ' -f3)
-CHIP_ENABLE_AMEBA_TC = $(shell grep '\#define CHIP_ENABLE_AMEBA_TERMS_AND_CONDITION ' $(MATTER_COMMON_DIR)/include/platform_opts_matter.h | tr -s '[:space:]' | cut -d' ' -f3)
-CHIP_ENABLE_CHIPOBLE = $(shell grep 'CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE' $(MATTER_INCLUDE) | cut -d'=' -f3)
-CHIP_ENABLE_IPV4 = $(shell grep 'INET_CONFIG_ENABLE_IPV4' $(MATTER_INCLUDE) | cut -d'=' -f3)
-CHIP_ENABLE_OTA_REQUESTOR = $(shell grep 'CONFIG_ENABLE_OTA_REQUESTOR' $(MATTER_INCLUDE) | cut -d'=' -f3)
 
 # -------------------------------------------------------------------
 # Compilation flag

--- a/project/amebaz2/make/chip_main_sources.mk
+++ b/project/amebaz2/make/chip_main_sources.mk
@@ -1,4 +1,17 @@
 # -------------------------------------------------------------------
+# Build Definition
+# -------------------------------------------------------------------
+CHIP_ENABLE_AMEBA_DLOG = $(shell grep '\#define CONFIG_ENABLE_AMEBA_DLOG ' $(MATTER_COMMON_DIR)/include/platform_opts_matter.h | tr -s '[:space:]' | cut -d' ' -f3)
+CHIP_ENABLE_AMEBA_TC = $(shell grep '\#define CHIP_ENABLE_AMEBA_TERMS_AND_CONDITION ' $(MATTER_COMMON_DIR)/include/platform_opts_matter.h | tr -s '[:space:]' | cut -d' ' -f3)
+CHIP_ENABLE_OTA_REQUESTOR = $(shell grep 'chip_enable_ota_requestor' $(OUTPUT_DIR)/args.gn | cut -d' ' -f3)
+CHIP_ENABLE_SHELL = $(shell grep 'chip_build_libshell' $(OUTPUT_DIR)/args.gn | cut -d' ' -f3)
+
+# -------------------------------------------------------------------
+# Includes
+# -------------------------------------------------------------------
+include $(MATTER_INCLUDE)
+
+# -------------------------------------------------------------------
 # Toolchain Definition
 # -------------------------------------------------------------------
 AR = $(CROSS_COMPILE)ar
@@ -9,14 +22,6 @@ LD = $(CROSS_COMPILE)gcc
 GDB = $(CROSS_COMPILE)gdb
 OBJCOPY = $(CROSS_COMPILE)objcopy
 OBJDUMP = $(CROSS_COMPILE)objdump
-
-# -------------------------------------------------------------------
-# Build Definition
-# -------------------------------------------------------------------
-CHIP_ENABLE_AMEBA_DLOG = $(shell grep '\#define CONFIG_ENABLE_AMEBA_DLOG ' $(MATTER_COMMON_DIR)/include/platform_opts_matter.h | tr -s '[:space:]' | cut -d' ' -f3)
-CHIP_ENABLE_AMEBA_TC = $(shell grep '\#define CHIP_ENABLE_AMEBA_TERMS_AND_CONDITION ' $(MATTER_COMMON_DIR)/include/platform_opts_matter.h | tr -s '[:space:]' | cut -d' ' -f3)
-CHIP_ENABLE_OTA_REQUESTOR = $(shell grep 'chip_enable_ota_requestor' $(OUTPUT_DIR)/args.gn | cut -d' ' -f3)
-CHIP_ENABLE_SHELL = $(shell grep 'chip_build_libshell' $(OUTPUT_DIR)/args.gn | cut -d' ' -f3)
 
 # -------------------------------------------------------------------
 # Compilation flag

--- a/project/amebaz2/make/light_switch/lib_chip_light_switch_main.mk
+++ b/project/amebaz2/make/light_switch/lib_chip_light_switch_main.mk
@@ -33,6 +33,14 @@ CODEGENDIR   := $(OUTPUT_DIR)/codegen
 include $(MATTER_MAIN_SRC)
 
 # -------------------------------------------------------------------
+# Compiler Flags
+# -------------------------------------------------------------------
+CFLAGS += -DCONFIG_ENABLE_AMEBA_APP_TASK=1
+ifeq ($(CHIP_ENABLE_SHELL), true)
+CFLAGS += -DCONFIG_ENABLE_CHIP_SHELL=1
+endif
+
+# -------------------------------------------------------------------
 # Include Path
 # -------------------------------------------------------------------
 INCLUDES += -I$(CHIPDIR)/examples/light-switch-app/light-switch-common
@@ -46,6 +54,7 @@ INCLUDES += -I$(CODEGENDIR)
 ifeq ($(CHIP_ENABLE_OTA_REQUESTOR), true)
 SRC_CPP += $(CHIPDIR)/examples/platform/ameba/ota/OTAInitializer.cpp
 endif
+SRC_CPP += $(CHIPDIR)/examples/platform/ameba/shell/launch_shell.cpp
 
 # -------------------------------------------------------------------
 # Source Files (Example)

--- a/project/amebaz2plus/make/all_clusters/lib_chip_main.mk
+++ b/project/amebaz2plus/make/all_clusters/lib_chip_main.mk
@@ -33,6 +33,14 @@ CODEGENDIR   := $(OUTPUT_DIR)/codegen
 include $(MATTER_MAIN_SRC)
 
 # -------------------------------------------------------------------
+# Compiler Flags
+# -------------------------------------------------------------------
+CFLAGS += -DCHIP_AMEBA_APP_TASK=1
+ifeq ($(CHIP_ENABLE_SHELL), true)
+CFLAGS += -DCONFIG_ENABLE_CHIP_SHELL=1
+endif
+
+# -------------------------------------------------------------------
 # Include Path
 # -------------------------------------------------------------------
 INCLUDES += -I$(CHIPDIR)/examples/all-clusters-app/ameba/main/include

--- a/project/amebaz2plus/make/chip_core_sources.mk
+++ b/project/amebaz2plus/make/chip_core_sources.mk
@@ -1,3 +1,15 @@
+# -------------------------------------------------------------------
+# Build Definition
+# -------------------------------------------------------------------
+CHIP_ENABLE_AMEBA_DLOG = $(shell grep '\#define CONFIG_ENABLE_AMEBA_DLOG ' $(MATTER_COMMON_DIR)/include/platform_opts_matter.h | tr -s '[:space:]' | cut -d' ' -f3)
+CHIP_ENABLE_AMEBA_TC = $(shell grep '\#define CHIP_ENABLE_AMEBA_TERMS_AND_CONDITION ' $(MATTER_COMMON_DIR)/include/platform_opts_matter.h | tr -s '[:space:]' | cut -d' ' -f3)
+CHIP_ENABLE_CHIPOBLE = $(shell grep 'CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE' $(MATTER_INCLUDE) | cut -d'=' -f3)
+CHIP_ENABLE_IPV4 = $(shell grep 'INET_CONFIG_ENABLE_IPV4' $(MATTER_INCLUDE) | cut -d'=' -f3)
+CHIP_ENABLE_OTA_REQUESTOR = $(shell grep 'CONFIG_ENABLE_OTA_REQUESTOR' $(MATTER_INCLUDE) | cut -d'=' -f3)
+
+# -------------------------------------------------------------------
+# Includes
+# -------------------------------------------------------------------
 include $(MATTER_INCLUDE)
 
 # -------------------------------------------------------------------
@@ -17,14 +29,7 @@ GDB = $(CROSS_COMPILE)gdb
 OBJCOPY = $(CROSS_COMPILE)objcopy
 OBJDUMP = $(CROSS_COMPILE)objdump
 
-# -------------------------------------------------------------------
-# Build Definition
-# -------------------------------------------------------------------
-CHIP_ENABLE_AMEBA_DLOG = $(shell grep '\#define CONFIG_ENABLE_AMEBA_DLOG ' $(MATTER_COMMON_DIR)/include/platform_opts_matter.h | tr -s '[:space:]' | cut -d' ' -f3)
-CHIP_ENABLE_AMEBA_TC = $(shell grep '\#define CHIP_ENABLE_AMEBA_TERMS_AND_CONDITION ' $(MATTER_COMMON_DIR)/include/platform_opts_matter.h | tr -s '[:space:]' | cut -d' ' -f3)
-CHIP_ENABLE_CHIPOBLE = $(shell grep 'CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE' $(MATTER_INCLUDE) | cut -d'=' -f3)
-CHIP_ENABLE_IPV4 = $(shell grep 'INET_CONFIG_ENABLE_IPV4' $(MATTER_INCLUDE) | cut -d'=' -f3)
-CHIP_ENABLE_OTA_REQUESTOR = $(shell grep 'CONFIG_ENABLE_OTA_REQUESTOR' $(MATTER_INCLUDE) | cut -d'=' -f3)
+
 
 # -------------------------------------------------------------------
 # Compilation flag

--- a/project/amebaz2plus/make/chip_main_sources.mk
+++ b/project/amebaz2plus/make/chip_main_sources.mk
@@ -1,4 +1,17 @@
 # -------------------------------------------------------------------
+# Build Definition
+# -------------------------------------------------------------------
+CHIP_ENABLE_AMEBA_DLOG = $(shell grep '\#define CONFIG_ENABLE_AMEBA_DLOG ' $(MATTER_COMMON_DIR)/include/platform_opts_matter.h | tr -s '[:space:]' | cut -d' ' -f3)
+CHIP_ENABLE_AMEBA_TC = $(shell grep '\#define CHIP_ENABLE_AMEBA_TERMS_AND_CONDITION ' $(MATTER_COMMON_DIR)/include/platform_opts_matter.h | tr -s '[:space:]' | cut -d' ' -f3)
+CHIP_ENABLE_OTA_REQUESTOR = $(shell grep 'chip_enable_ota_requestor' $(OUTPUT_DIR)/args.gn | cut -d' ' -f3)
+CHIP_ENABLE_SHELL = $(shell grep 'chip_build_libshell' $(OUTPUT_DIR)/args.gn | cut -d' ' -f3)
+
+# -------------------------------------------------------------------
+# Includes
+# -------------------------------------------------------------------
+include $(MATTER_INCLUDE)
+
+# -------------------------------------------------------------------
 # Toolchain Definition
 # -------------------------------------------------------------------
 AR = $(CROSS_COMPILE)ar
@@ -9,14 +22,6 @@ LD = $(CROSS_COMPILE)gcc
 GDB = $(CROSS_COMPILE)gdb
 OBJCOPY = $(CROSS_COMPILE)objcopy
 OBJDUMP = $(CROSS_COMPILE)objdump
-
-# -------------------------------------------------------------------
-# Build Definition
-# -------------------------------------------------------------------
-CHIP_ENABLE_AMEBA_DLOG = $(shell grep '\#define CONFIG_ENABLE_AMEBA_DLOG ' $(MATTER_COMMON_DIR)/include/platform_opts_matter.h | tr -s '[:space:]' | cut -d' ' -f3)
-CHIP_ENABLE_AMEBA_TC = $(shell grep '\#define CHIP_ENABLE_AMEBA_TERMS_AND_CONDITION ' $(MATTER_COMMON_DIR)/include/platform_opts_matter.h | tr -s '[:space:]' | cut -d' ' -f3)
-CHIP_ENABLE_OTA_REQUESTOR = $(shell grep 'chip_enable_ota_requestor' $(OUTPUT_DIR)/args.gn | cut -d' ' -f3)
-CHIP_ENABLE_SHELL = $(shell grep 'chip_build_libshell' $(OUTPUT_DIR)/args.gn | cut -d' ' -f3)
 
 # -------------------------------------------------------------------
 # Compilation flag

--- a/project/amebaz2plus/make/light_switch/lib_chip_light_switch_main.mk
+++ b/project/amebaz2plus/make/light_switch/lib_chip_light_switch_main.mk
@@ -33,6 +33,14 @@ CODEGENDIR   := $(OUTPUT_DIR)/codegen
 include $(MATTER_MAIN_SRC)
 
 # -------------------------------------------------------------------
+# Compiler Flags
+# -------------------------------------------------------------------
+CFLAGS += -DCONFIG_ENABLE_AMEBA_APP_TASK=1
+ifeq ($(CHIP_ENABLE_SHELL), true)
+CFLAGS += -DCONFIG_ENABLE_CHIP_SHELL=1
+endif
+
+# -------------------------------------------------------------------
 # Include Path
 # -------------------------------------------------------------------
 INCLUDES += -I$(CHIPDIR)/examples/light-switch-app/light-switch-common
@@ -46,6 +54,7 @@ INCLUDES += -I$(CODEGENDIR)
 ifeq ($(CHIP_ENABLE_OTA_REQUESTOR), true)
 SRC_CPP += $(CHIPDIR)/examples/platform/ameba/ota/OTAInitializer.cpp
 endif
+SRC_CPP += $(CHIPDIR)/examples/platform/ameba/shell/launch_shell.cpp
 
 # -------------------------------------------------------------------
 # Source Files (Example)

--- a/tools/docker/amebad/Dockerfile
+++ b/tools/docker/amebad/Dockerfile
@@ -3,7 +3,7 @@ FROM ameba-rtos-matter:common
 
 # Redefine following build arguments to respective repo and tag/branch
 ARG AMEBA_MATTER_REPO=https://github.com/xshuqun/ameba-rtos-matter.git
-ARG TAG_NAME=v1.4-PR/update_matter_api
+ARG TAG_NAME=v1.4-PR/update_matter_api_v1
 
 # Define fixed build arguments
 ARG AMBD_REPO=https://github.com/Ameba-AIoT/ameba-rtos-d.git

--- a/tools/docker/amebaz2/Dockerfile
+++ b/tools/docker/amebaz2/Dockerfile
@@ -3,7 +3,7 @@ FROM ameba-rtos-matter:common
 
 # Redefine following build arguments to respective repo and tag/branch
 ARG AMEBA_MATTER_REPO=https://github.com/xshuqun/ameba-rtos-matter.git
-ARG TAG_NAME=v1.4-PR/update_matter_api
+ARG TAG_NAME=v1.4-PR/update_matter_api_v1
 
 # Define fixed build arguments
 ARG AMBZ2_REPO=https://github.com/Ameba-AIoT/ameba-rtos-z2.git


### PR DESCRIPTION
## This PR addresses:

Improvement for 2de75e2 (PR#143)
* modified ATMI to distinguish between 8710C and 8721D.
* fixed ota atcmd macro.
* fixed the build issue related to enabling matter shell for all_clusters and light_switch.

## Verification:

Verified with ATMI and ATMS AT command.