### PR TITLE
[common][kvs] revise DCT numbers

### DIFF
--- a/common/include/platform_opts_matter.h
+++ b/common/include/platform_opts_matter.h
@@ -82,19 +82,19 @@
  * MATTER KVS (chip-factory, chip-config, chip-counters)
  * Uses DCT1, set flash address MATTER_KVS_BEGIN_ADDR
  ****************************************************************/
-#define MATTER_KVS_MODULE_NUM                   13                      // max number of module
+#define MATTER_KVS_MODULE_NUM                   6                       // max number of module
 #define MATTER_KVS_VARIABLE_NAME_SIZE           32                      // max size of the variable name
 #define MATTER_KVS_VARIABLE_VALUE_SIZE          64+4                    // max size of the variable value, +4 so it can store 64 bytes variable
-// max value number in moudle = floor(4024 / (32 + 64 + 4)) = 40
+// max variable number in one module = floor(4024 / (32 + 64 + 4)) = 40
 
 /****************************************************************
  * MATTER KVS2, for key length large than 64 (Fabric1 ~ FabricF)
  * Uses DCT2, set flash address MATTER_KVS_BEGIN_ADDR2
  ****************************************************************/
-#define MATTER_KVS_MODULE_NUM2                  11                      // max number of module
+#define MATTER_KVS_MODULE_NUM2                  15                      // max number of module
 #define MATTER_KVS_VARIABLE_NAME_SIZE2          32                      // max size of the variable name
 #define MATTER_KVS_VARIABLE_VALUE_SIZE2         400+4                   // max size of the variable value, +4 so it can store 400 bytes variable
-// max value number in moudle = floor(4024 / (32 + 400 + 4)) = 9
+// max variable number in one module = floor(4024 / (32 + 400 + 4)) = 9
 
 /*****************************************************************
  * Matter Factory Data: last 4KB of external flash
@@ -123,11 +123,11 @@
 #define BT_FTL_BKUP_ADDR                        (0x400000 - 0x4000)     // 0x3FC000 (4K)
 #define UART_SETTING_SECTOR                     (0x400000 - 0x5000)     // 0x3FB000 (4K)
 #if (MATTER_KVS_ENABLE_BACKUP == 0)
-#define MATTER_KVS_BEGIN_ADDR                   (0x400000 - 0x13000)    // 0x3ED000 ~ 0x3FB000 (56K)
-#define MATTER_KVS_BEGIN_ADDR2                  (0x400000 - 0x1F000)    // 0x3E1000 ~ 0x3ED000 (48K)
+#define MATTER_KVS_BEGIN_ADDR                   (0x400000 - 0xB000)     // 0x3FB000 - 0x3F5000 ((6  + 1) * 4K)
+#define MATTER_KVS_BEGIN_ADDR2                  (0x400000 - 0x1A000)    // 0x3F5000 - 0x3E6000 ((15 + 1) * 4K)
 #elif (MATTER_KVS_ENABLE_BACKUP == 1)
-#define MATTER_KVS_BEGIN_ADDR                   (0x400000 - 0x20000)    // 0x3E0000 ~ 0x3FB000 (108K)
-#define MATTER_KVS_BEGIN_ADDR2                  (0x400000 - 0x37000)    // 0x3C9000 ~ 0x3E0000 (92K)
+#define MATTER_KVS_BEGIN_ADDR                   (0x400000 - 0x12000)    // 0x3FB000 - 0x3EE000 ((12 + 1) * 4K)
+#define MATTER_KVS_BEGIN_ADDR2                  (0x400000 - 0x31000)    // 0x3EE000 ~ 0x3CF000 ((30 + 1) * 4K)
 #endif /* MATTER_KVS_ENABLE_BACKUP */
 
 #elif defined(CONFIG_PLATFORM_8721D)

--- a/tools/docker/amebad/Dockerfile
+++ b/tools/docker/amebad/Dockerfile
@@ -3,7 +3,7 @@ FROM ameba-rtos-matter:common
 
 # Redefine following build arguments to respective repo and tag/branch
 ARG AMEBA_MATTER_REPO=https://github.com/xshuqun/ameba-rtos-matter.git
-ARG TAG_NAME=v1.5-PR/mbedtls_upgrade
+ARG TAG_NAME=v1.5-PR/update_kvs
 
 # Define fixed build arguments
 ARG AMBD_REPO=https://github.com/Ameba-AIoT/ameba-rtos-d.git

--- a/tools/docker/amebaz2/Dockerfile
+++ b/tools/docker/amebaz2/Dockerfile
@@ -3,7 +3,7 @@ FROM ameba-rtos-matter:common
 
 # Redefine following build arguments to respective repo and tag/branch
 ARG AMEBA_MATTER_REPO=https://github.com/xshuqun/ameba-rtos-matter.git
-ARG TAG_NAME=v1.5-PR/mbedtls_upgrade
+ARG TAG_NAME=v1.5-PR/update_kvs
 
 # Define fixed build arguments
 ARG AMBZ2_REPO=https://github.com/Ameba-AIoT/ameba-rtos-z2.git

--- a/tools/docker/amebaz2plus/Dockerfile
+++ b/tools/docker/amebaz2plus/Dockerfile
@@ -3,7 +3,7 @@ FROM ameba-rtos-matter:common
 
 # Redefine following build arguments to respective repo and tag/branch
 ARG AMEBA_MATTER_REPO=https://github.com/xshuqun/ameba-rtos-matter.git
-ARG TAG_NAME=v1.5-PR/mbedtls_upgrade
+ARG TAG_NAME=v1.5-PR/update_kvs
 
 # Define fixed build arguments
 ARG AMBZ2_REPO=https://github.com/Ameba-AIoT/ameba-rtos-z2.git


### PR DESCRIPTION
## This PR addresses:

* DCT1 which stores 32bytes and below data does not require such a huge space, reduce from 13 to 6.
* DCT2 which stores 64bytes and above data will require more spaces, increase from 11 to 15 for further usage.
* This will be sufficient for 5 fabrics and TC-RR-1.1

## Verification:

chip-tool commissioning successful.