### PR TITLE
[common][sdk] Camera App Example Fixes

### DIFF
--- a/common/port/matter_lwip.c
+++ b/common/port/matter_lwip.c
@@ -31,27 +31,52 @@ void matter_lwip_dhcp(void)
     netif_set_link_up(&xnetif[0]);
     matter_wifi_set_autoreconnect(0);
 
+#if (defined(CONFIG_AMEBARTOS_V1_0) && (CONFIG_AMEBARTOS_V1_0 == 1)) || \
+    (defined(CONFIG_AMEBARTOS_V1_1) && (CONFIG_AMEBARTOS_V1_1 == 1))
     LwIP_DHCP(0, DHCP_START);
+#elif defined(CONFIG_AMEBARTOS_V1_2) && (CONFIG_AMEBARTOS_V1_2 == 1)
+    lwip_dhcp(0, DHCP_START);
+#endif
 }
 
 void matter_lwip_releaseip(void)
 {
+#if (defined(CONFIG_AMEBARTOS_V1_0) && (CONFIG_AMEBARTOS_V1_0 == 1)) || \
+    (defined(CONFIG_AMEBARTOS_V1_1) && (CONFIG_AMEBARTOS_V1_1 == 1))
     LwIP_ReleaseIP(0);
+#elif defined(CONFIG_AMEBARTOS_V1_2) && (CONFIG_AMEBARTOS_V1_2 == 1)
+    lwip_clear_ip(0);
+#endif
 }
 
 unsigned char *matter_LwIP_GetIP(uint8_t idx)
 {
+#if (defined(CONFIG_AMEBARTOS_V1_0) && (CONFIG_AMEBARTOS_V1_0 == 1)) || \
+    (defined(CONFIG_AMEBARTOS_V1_1) && (CONFIG_AMEBARTOS_V1_1 == 1))
     return LwIP_GetIP(idx);
+#elif defined(CONFIG_AMEBARTOS_V1_2) && (CONFIG_AMEBARTOS_V1_2 == 1)
+    return lwip_get_ip(idx);
+#endif
 }
 
 unsigned char *matter_LwIP_GetGW(uint8_t idx)
 {
+#if (defined(CONFIG_AMEBARTOS_V1_0) && (CONFIG_AMEBARTOS_V1_0 == 1)) || \
+    (defined(CONFIG_AMEBARTOS_V1_1) && (CONFIG_AMEBARTOS_V1_1 == 1))
     return LwIP_GetGW(idx);
+#elif defined(CONFIG_AMEBARTOS_V1_2) && (CONFIG_AMEBARTOS_V1_2 == 1)
+    return lwip_get_gw(idx);
+#endif
 }
 
 uint8_t *matter_LwIP_GetMASK(uint8_t idx)
 {
+#if (defined(CONFIG_AMEBARTOS_V1_0) && (CONFIG_AMEBARTOS_V1_0 == 1)) || \
+    (defined(CONFIG_AMEBARTOS_V1_1) && (CONFIG_AMEBARTOS_V1_1 == 1))
     return LwIP_GetMASK(idx);
+#elif defined(CONFIG_AMEBARTOS_V1_2) && (CONFIG_AMEBARTOS_V1_2 == 1)
+    return lwip_get_mask(idx);
+#endif
 }
 
 #if LWIP_IPV6
@@ -132,7 +157,7 @@ static void matter_LwIP_IP_Address_Request_thread(void *pvParameters)
 #endif
 #elif defined(CONFIG_AMEBARTOS_V1_2) && (CONFIG_AMEBARTOS_V1_2 == 1)
     while (dhcp_ret != DHCP_ADDRESS_ASSIGNED) {
-        dhcp_ret = LwIP_IP_Address_Request(NETIF_WLAN_STA_INDEX);
+        dhcp_ret = lwip_request_ip(NETIF_WLAN_STA_INDEX);
     }
 #if LWIP_IPV6
     matter_lwip_dhcp6();

--- a/drivers/device/camera_driver.cpp
+++ b/drivers/device/camera_driver.cpp
@@ -34,6 +34,7 @@ void MatterCamera::Init(void)
 
     instance = this;
 
+#ifdef CONFIG_USB_HOST_EN
     mUsbhConfig   = (usbh_config_t *)  pvPortMalloc(sizeof(usbh_config_t));
     mUvcConfig    = (usbh_uvc_ctx_t *) pvPortMalloc(sizeof(usbh_uvc_ctx_t));
     mUvcCallBacks = (usbh_uvc_cb_t *)  pvPortMalloc(sizeof(usbh_uvc_cb_t));
@@ -68,13 +69,31 @@ void MatterCamera::Init(void)
     if (status != RTK_SUCCESS) {
         ChipLogError(DeviceLayer, "Create thread fail");
     }
+#else
+    //TODO: If camera is not using USBH, please initial it by other means
+    rtos_mutex_create(&mDummyBufMutex);
+    UNUSED(status);
+    UNUSED(task);
+#endif
 }
 
 void MatterCamera::deInit(void)
 {
+#ifdef CONFIG_USB_HOST_EN
     vPortFree(mUsbhConfig);
     vPortFree(mUvcConfig);
     vPortFree(mUvcCallBacks);
+#else
+    if (mDummyTask != NULL) {
+        rtos_task_delete(mDummyTask);
+        mDummyTask = NULL;
+    }
+    if (mDummyBuf != nullptr) {
+        rtos_mem_free(mDummyBuf);
+        mDummyBuf = nullptr;
+    }
+    rtos_mutex_delete(mDummyBufMutex);
+#endif
 }
 
 void MatterCamera::EnableMatterVideoStream(uint16_t streamId)
@@ -82,12 +101,22 @@ void MatterCamera::EnableMatterVideoStream(uint16_t streamId)
     ChipLogProgress(DeviceLayer, "Enabling video stream for streamId(%u)", streamId);
     mCurrentVideoStreamId = streamId;
     mStreamEnabled        = true;
+#ifndef CONFIG_USB_HOST_EN
+    if (mDummyTask == NULL) {
+        int status = rtos_task_create(&mDummyTask, "DummyStreaming", StartDummyStreamingWrapper, NULL,
+                                      DUMMY_STREAMING_THREAD_STACK_SIZE, 1U);
+        if (status != RTK_SUCCESS) {
+            ChipLogError(DeviceLayer, "Create DummyStreaming thread fail");
+            mDummyTask = NULL;
+        }
+    }
+#endif
 }
 
 void MatterCamera::DisableMatterVideoStream(void)
 {
     ChipLogProgress(DeviceLayer, "Disabling video stream for streamId(%u)", mCurrentVideoStreamId);
-    mCurrentVideoStreamId = USBH_UVC_MATTER_INVALID_ID;
+    mCurrentVideoStreamId = MATTER_INVALID_SESSION_ID;
     mStreamEnabled        = false;
 }
 
@@ -101,7 +130,7 @@ void MatterCamera::RegisterWebRtcTransport(WebRTCProviderManager *mWebRTCProvide
 void MatterCamera::DeregisterWebRtcTransport(void)
 {
     ChipLogProgress(DeviceLayer, "Deregistering WebRTC transport for sessionId(%u)", mCurrentSessionId);
-    mCurrentSessionId = USBH_UVC_MATTER_INVALID_ID;
+    mCurrentSessionId = MATTER_INVALID_SESSION_ID;
     mWebrtcTransport  = nullptr;
 }
 
@@ -112,6 +141,7 @@ MatterCamera *MatterCamera::GetInstance(void)
 
 // Private
 
+#ifdef CONFIG_USB_HOST_EN
 void MatterCamera::UsbhUvcMainThread(void *param)
 {
     ChipLogProgress(DeviceLayer, "USBH UVC task start");
@@ -378,7 +408,7 @@ void MatterCamera::UvcMatterThread(void *param)
             ChipLogError(DeviceLayer, "Error, WebRTC transport is null!");
         } else {
             if(mWebrtcTransport->CanSendVideo() == true){
-                mWebrtcTransport->SendVideo(videoData, rtos_time_get_current_system_time_ms_64bit(), mCurrentVideoStreamId);
+                mWebrtcTransport->SendVideo(videoData, (int64_t)(rtos_time_get_current_system_time_ms_64bit() * 90ULL), mCurrentVideoStreamId);
                 ChipLogProgress(DeviceLayer, "Video sent");
             } else {
                 ChipLogError(DeviceLayer, "WebRTC Transport is not ready to send Video");
@@ -396,7 +426,7 @@ void MatterCamera::UvcMatterThread(void *param)
                 ChipLogError(DeviceLayer, "Error, WebRTC transport is null!");
             } else {
                 if(mWebrtcTransport->CanSendVideo() == true){
-                    mWebrtcTransport->SendVideo(videoData, rtos_time_get_current_system_time_ms_64bit(), mCurrentVideoStreamId);
+                    mWebrtcTransport->SendVideo(videoData, (int64_t)(rtos_time_get_current_system_time_ms_64bit() * 90ULL), mCurrentVideoStreamId);
                     ChipLogProgress(DeviceLayer, "Video sent");
                 } else {
                     ChipLogError(DeviceLayer, "WebRTC Transport is not ready to send Video");
@@ -596,3 +626,230 @@ int MatterCamera::UvcSetparamWrapper()
 {
     return instance->UvcSetparam();
 }
+#else
+
+namespace {
+
+/*
+ * Minimal MSB-first bitstream writer used to assemble the dummy H.264 frame.
+ * It supports the few Exp-Golomb / fixed-length syntax elements needed to
+ * build an SPS, PPS and a single I-slice. Writes are clamped to the buffer
+ * capacity so a miscalculation can never overflow mDummyBuf.
+ */
+class BitWriter
+{
+public:
+    BitWriter(uint8_t *buf, size_t cap) : mBuf(buf), mCap(cap) {}
+
+    void PutBit(uint32_t bit)
+    {
+        mCurrent = (uint8_t)((mCurrent << 1) | (bit & 1U));
+        if (++mBitsInByte == 8) {
+            Flush();
+        }
+    }
+
+    void PutBits(uint32_t value, int numBits)
+    {
+        for (int i = numBits - 1; i >= 0; i--) {
+            PutBit((value >> i) & 1U);
+        }
+    }
+
+    /* ue(v): unsigned Exp-Golomb */
+    void PutUE(uint32_t codeNum)
+    {
+        uint32_t v = codeNum + 1;
+        int leadingZeros = 0;
+        for (uint32_t t = v >> 1; t != 0; t >>= 1) {
+            leadingZeros++;
+        }
+        for (int i = 0; i < leadingZeros; i++) {
+            PutBit(0);
+        }
+        PutBits(v, leadingZeros + 1);
+    }
+
+    /* se(v): signed Exp-Golomb */
+    void PutSE(int32_t value)
+    {
+        uint32_t codeNum = (value <= 0) ? (uint32_t)(-2 * value) : (uint32_t)(2 * value - 1);
+        PutUE(codeNum);
+    }
+
+    /* rbsp_trailing_bits(): stop-one bit followed by zero padding to byte align */
+    void Trailing()
+    {
+        PutBit(1);
+        while (mBitsInByte != 0) {
+            PutBit(0);
+        }
+    }
+
+    size_t Bytes() const { return mLen; }
+
+private:
+    void Flush()
+    {
+        if (mLen < mCap) {
+            mBuf[mLen] = mCurrent;
+        }
+        mLen++;
+        mCurrent    = 0;
+        mBitsInByte = 0;
+    }
+
+    uint8_t *mBuf;
+    size_t   mCap;
+    size_t   mLen        = 0;
+    uint8_t  mCurrent    = 0;
+    int      mBitsInByte = 0;
+};
+
+} // namespace
+
+/*
+ * Build a single, fully decodable H.264 Annex-B keyframe (SPS + PPS + IDR
+ * I-slice) for a 1280x720 picture and store it in mDummyBuf.
+ *
+ * Every macroblock is encoded as I_16x16 with DC prediction and no residual
+ * coefficients, so the frame decodes to a flat gray image (luma/chroma = 128).
+ * This is intentionally a placeholder ("dummy") frame whose only purpose is to
+ * feed valid, decodable data into mWebrtcTransport->SendVideo() for testing.
+ *
+ * 1280x720 => 80 x 45 macroblocks = 3600 macroblocks. With the chosen syntax
+ * each macroblock costs exactly 8 bits, so the whole stream is ~3.6 KB.
+ */
+void MatterCamera::GenerateDummyH264Frame(void)
+{
+    const int kMbWidth  = 1280 / 16;            // 80
+    const int kMbHeight = 720 / 16;             // 45
+    const int kNumMbs   = kMbWidth * kMbHeight; // 3600
+
+    BitWriter bw(mDummyBuf, DUMMY_H264_BUF_SIZE);
+
+    /* ---- Sequence Parameter Set (nal_ref_idc=3, nal_unit_type=7) ---- */
+    bw.PutBits(0x00000001, 32);   // Annex-B start code
+    bw.PutBits(0x67, 8);          // NAL unit header
+    bw.PutBits(66, 8);            // profile_idc = Baseline
+    bw.PutBits(0, 8);             // constraint_set flags + reserved_zero_2bits
+    bw.PutBits(31, 8);            // level_idc = 3.1 (supports 1280x720@30)
+    bw.PutUE(0);                  // seq_parameter_set_id
+    bw.PutUE(0);                  // log2_max_frame_num_minus4
+    bw.PutUE(0);                  // pic_order_cnt_type
+    bw.PutUE(0);                  // log2_max_pic_order_cnt_lsb_minus4
+    bw.PutUE(1);                  // max_num_ref_frames
+    bw.PutBits(0, 1);             // gaps_in_frame_num_value_allowed_flag
+    bw.PutUE(kMbWidth - 1);       // pic_width_in_mbs_minus1
+    bw.PutUE(kMbHeight - 1);      // pic_height_in_map_units_minus1
+    bw.PutBits(1, 1);             // frame_mbs_only_flag
+    bw.PutBits(1, 1);             // direct_8x8_inference_flag
+    bw.PutBits(0, 1);             // frame_cropping_flag
+    bw.PutBits(0, 1);             // vui_parameters_present_flag
+    bw.Trailing();
+
+    /* ---- Picture Parameter Set (nal_ref_idc=3, nal_unit_type=8) ---- */
+    bw.PutBits(0x00000001, 32);
+    bw.PutBits(0x68, 8);
+    bw.PutUE(0);                  // pic_parameter_set_id
+    bw.PutUE(0);                  // seq_parameter_set_id
+    bw.PutBits(0, 1);             // entropy_coding_mode_flag (0 = CAVLC)
+    bw.PutBits(0, 1);             // bottom_field_pic_order_in_frame_present_flag
+    bw.PutUE(0);                  // num_slice_groups_minus1
+    bw.PutUE(0);                  // num_ref_idx_l0_default_active_minus1
+    bw.PutUE(0);                  // num_ref_idx_l1_default_active_minus1
+    bw.PutBits(0, 1);             // weighted_pred_flag
+    bw.PutBits(0, 2);             // weighted_bipred_idc
+    bw.PutSE(0);                  // pic_init_qp_minus26 (QP = 26)
+    bw.PutSE(0);                  // pic_init_qs_minus26
+    bw.PutSE(0);                  // chroma_qp_index_offset
+    bw.PutBits(0, 1);             // deblocking_filter_control_present_flag
+    bw.PutBits(0, 1);             // constrained_intra_pred_flag
+    bw.PutBits(0, 1);             // redundant_pic_cnt_present_flag
+    bw.Trailing();
+
+    /* ---- IDR slice (nal_ref_idc=3, nal_unit_type=5) ---- */
+    bw.PutBits(0x00000001, 32);
+    bw.PutBits(0x65, 8);
+    /* slice_header() */
+    bw.PutUE(0);                  // first_mb_in_slice
+    bw.PutUE(7);                  // slice_type = 7 (I, all slices in pic are I)
+    bw.PutUE(0);                  // pic_parameter_set_id
+    bw.PutBits(0, 4);             // frame_num (log2_max_frame_num = 4 bits)
+    bw.PutUE(0);                  // idr_pic_id
+    bw.PutBits(0, 4);             // pic_order_cnt_lsb (4 bits)
+    bw.PutBits(0, 1);             // no_output_of_prior_pics_flag
+    bw.PutBits(0, 1);             // long_term_reference_flag
+    bw.PutSE(0);                  // slice_qp_delta
+
+    /* slice_data(): every macroblock is I_16x16, DC pred, no residual */
+    for (int i = 0; i < kNumMbs; i++) {
+        bw.PutUE(3);              // mb_type = 3 => I_16x16, DC pred, CBP luma/chroma = 0
+        bw.PutUE(0);              // intra_chroma_pred_mode = DC
+        bw.PutSE(0);              // mb_qp_delta = 0
+        bw.PutBits(1, 1);         // luma DC coeff_token (TotalCoeff=0, TrailingOnes=0, nC<2)
+    }
+    bw.Trailing();
+
+    mDummyBufSize = (int) bw.Bytes();
+    ChipLogProgress(DeviceLayer, "Generated dummy H.264 1280x720 keyframe: %d bytes", mDummyBufSize);
+}
+
+void MatterCamera::StartDummyStreaming(void *param)
+{
+    if (mDummyBuf == nullptr) {
+
+        mDummyBuf = (uint8_t*) rtos_mem_zmalloc(DUMMY_H264_BUF_SIZE);
+        if (mDummyBuf == nullptr) {
+            ChipLogError(DeviceLayer, "Failed to allocate dummy H.264 buffer (%d bytes)", DUMMY_H264_BUF_SIZE);
+            mDummyTask = NULL;
+            rtos_task_delete(NULL);
+            return;
+        }
+        GenerateDummyH264Frame();
+    }
+
+    DummyStreaming(param);
+    rtos_task_delete(NULL);
+}
+
+void MatterCamera::StartDummyStreamingWrapper(void *param)
+{
+    instance->StartDummyStreaming(param);
+}
+
+void MatterCamera::DummyStreaming(void *param)
+{
+    UNUSED(param);
+
+    while (1) {
+        while ((mStreamEnabled == false) || (mWebrtcTransport == nullptr)) {
+            ChipLogProgress(DeviceLayer, "Waiting for liveview start request from controller...");
+            rtos_time_delay_ms(1000);
+        }
+
+        ChipLogProgress(DeviceLayer, "Start Matter Dummy Streaming");
+        rtos_time_delay_ms(2000);
+
+        while (mStreamEnabled == true) {
+            rtos_mutex_take(mDummyBufMutex, RTOS_MAX_TIMEOUT);
+            chip::ByteSpan videoData(mDummyBuf, static_cast<size_t>(mDummyBufSize));
+            rtos_mutex_give(mDummyBufMutex);
+
+            if (mWebrtcTransport == nullptr) {
+                ChipLogError(DeviceLayer, "Error, WebRTC transport is null!");
+            } else {
+                if(mWebrtcTransport->CanSendVideo() == true){
+                    mWebrtcTransport->SendVideo(videoData, (int64_t)(rtos_time_get_current_system_time_ms_64bit() * 90ULL), mCurrentVideoStreamId);
+                    ChipLogProgress(DeviceLayer, "Video sent");
+                } else {
+                    ChipLogError(DeviceLayer, "WebRTC Transport is not ready to send Video");
+                }
+            }
+
+            rtos_time_delay_ms(1000);
+        }
+    }
+}
+
+#endif

--- a/drivers/device/camera_driver.h
+++ b/drivers/device/camera_driver.h
@@ -26,13 +26,16 @@
 #include <webrtc/ameba_webrtc_provider_manager.h>
 
 extern "C" {
+#ifdef CONFIG_USB_HOST_EN
 #include <usbh_uvc_intf.h>
 #include <usbh.h>
+#endif
 #include <lwipconf.h>
 #include <lwip_netconf.h>
 #include <ringbuffer.h>
 }
 
+#ifdef CONFIG_USB_HOST_EN
 /* Private defines -----------------------------------------------------------*/
 /* Supported formats: USBH_UVC_FORMAT_MJPEG, USBH_UVC_FORMAT_YUV, USBH_UVC_FORMAT_H264
  * Note: Users must verify which formats their specific camera supports and
@@ -118,7 +121,20 @@ extern "C" {
 #define USBH_UVC_MATTER_WRITE_SIZE        (4 * 1024)
 #define USBH_UVC_MATTER_VIDEO_SIZE        (2 * 1024 * 1024)
 #define USBH_UVC_MATTER_TAG               "MATTER"
-#define USBH_UVC_MATTER_INVALID_ID        0xFFFF
+#endif
+
+#define MATTER_INVALID_SESSION_ID        0xFFFF
+
+/* Buffer size for the generated dummy H.264 1280x720 keyframe.
+ * The frame is ~3.6 KB (SPS + PPS + one 80x45-macroblock I-slice). Keep this
+ * tight: the buffer is allocated permanently in Init(), and oversizing it
+ * starves the heap that WebRTC/CASE negotiation needs (malloc fails otherwise). */
+#define DUMMY_H264_BUF_SIZE              (5 * 1024)
+
+/* Stack size (bytes) for the dummy streaming task. It performs the same deep
+ * WebRTC SendVideo() calls (plus CHIP logging) as the USB UVC Matter thread, so
+ * it needs a comparably large stack. 1 KB overflows on the first log call. */
+#define DUMMY_STREAMING_THREAD_STACK_SIZE (5 * 1024)
 
 using namespace chip::app::Clusters::WebRTCTransportProvider;
 
@@ -135,6 +151,7 @@ public:
     static MatterCamera *GetInstance(void);
 
 private:
+#ifdef CONFIG_USB_HOST_EN
     /* USBH UVC */
     void UsbhUvcMainThread(void *param);
 #if CONFIG_USBH_UVC_HOT_PLUG
@@ -167,8 +184,6 @@ private:
     static int UvcSetupWrapper(void);
     static int UvcSetparamWrapper(void);
 
-    static MatterCamera *instance;
-
     rtos_sema_t mUvcAttachSema;
     rtos_sema_t mUvcDetachSema;
     rtos_sema_t mUvcStartSema;
@@ -185,15 +200,28 @@ private:
     int mUvcMatterIsInit = 0;
     int mUvcBufSize = 0;
     RingBuffer *mUvcRb;
-    bool mStreamEnabled = false;
-    uint16_t mCurrentSessionId        = USBH_UVC_MATTER_INVALID_ID;
-    uint16_t mCurrentVideoStreamId    = USBH_UVC_MATTER_INVALID_ID;
-    WebrtcTransport *mWebrtcTransport = nullptr;
 
     u8 *mUvcBuf = nullptr;
 
     usbh_config_t  *mUsbhConfig   = NULL;
     usbh_uvc_ctx_t *mUvcConfig    = NULL;
     usbh_uvc_cb_t  *mUvcCallBacks = NULL;
+#else
+    void StartDummyStreaming(void *param);
+    static void StartDummyStreamingWrapper(void *param);
+    void DummyStreaming(void *param);
+    void GenerateDummyH264Frame(void);
+
+    rtos_mutex_t mDummyBufMutex = NULL;
+    rtos_task_t mDummyTask = NULL;
+    int mDummyBufSize = 0;
+    u8 *mDummyBuf = nullptr;
+#endif
+    static MatterCamera *instance;
+
+    bool mStreamEnabled = false;
+    uint16_t mCurrentSessionId        = MATTER_INVALID_SESSION_ID;
+    uint16_t mCurrentVideoStreamId    = MATTER_INVALID_SESSION_ID;
+    WebrtcTransport *mWebrtcTransport = nullptr;
 
 };

--- a/examples/camera/example_matter_camera.cpp
+++ b/examples/camera/example_matter_camera.cpp
@@ -34,7 +34,7 @@ static void example_matter_camera_task(void *pvParameters)
 {
     matter_wifi_wait();
 
-    ChipLogProgress(DeviceLayer, "Matter Lighting Example!");
+    ChipLogProgress(DeviceLayer, "Matter Camera Example!");
 
     CHIP_ERROR err = CHIP_NO_ERROR;
 

--- a/project/cmake/flags/public_definitions_matter.cmake
+++ b/project/cmake/flags/public_definitions_matter.cmake
@@ -133,7 +133,10 @@ endif()
 
 # Chip TCP Endpoint
 if(CHIP_ENABLE_TCP_ENDPOINT)
-    ameba_list_append(matter_defintions INET_CONFIG_ENABLE_TCP_ENDPOINT=1)
+    ameba_list_append(matter_defintions
+        INET_CONFIG_ENABLE_TCP_ENDPOINT=1
+        CHIP_SYSTEM_CONFIG_MAX_LARGE_BUFFER_SIZE_BYTES=2048
+    )
 else()
     ameba_list_append(matter_defintions INET_CONFIG_ENABLE_TCP_ENDPOINT=0)
 endif()

--- a/tools/docker/ameba-rtos/v1.0/Dockerfile
+++ b/tools/docker/ameba-rtos/v1.0/Dockerfile
@@ -3,7 +3,7 @@ FROM ameba-rtos-matter:common
 
 # Redefine following build arguments to respective repo and tag/branch
 ARG AMEBA_MATTER_REPO=https://github.com/mikaelajiwidodo/ameba-rtos-matter.git
-ARG AMEBA_MATTER_TAG_NAME=ameba-rtos/v1.5-PR/update_matter_apply_conf
+ARG AMEBA_MATTER_TAG_NAME=ameba-rtos/v1.5-PR/fix-camera-app
 
 # Define fixed build arguments
 ARG AMBRTOS_REPO=https://github.com/mikaelajiwidodo/ameba-rtos.git

--- a/tools/docker/ameba-rtos/v1.1/Dockerfile
+++ b/tools/docker/ameba-rtos/v1.1/Dockerfile
@@ -13,7 +13,7 @@ ARG TOOLCHAIN_ASDK_NEW_DIR='/opt/rtk-toolchain/asdk-10.3.1-4354'
 
 # Redefine following build arguments to respective repo and tag/branch
 ARG AMEBA_MATTER_REPO=https://github.com/mikaelajiwidodo/ameba-rtos-matter.git
-ARG AMEBA_MATTER_TAG_NAME=ameba-rtos/v1.5-PR/update_matter_apply_conf
+ARG AMEBA_MATTER_TAG_NAME=ameba-rtos/v1.5-PR/fix-camera-app
 
 # Define fixed build arguments
 ARG AMBRTOS_REPO=https://github.com/mikaelajiwidodo/ameba-rtos.git

--- a/tools/docker/ameba-rtos/v1.2/Dockerfile
+++ b/tools/docker/ameba-rtos/v1.2/Dockerfile
@@ -11,7 +11,7 @@ ARG TOOLCHAIN_ASDK_FILE_PATH='/opt/rtk-toolchain/prebuilts-linux-1.0.3.tar.gz'
 
 # Redefine following build arguments to respective repo and tag/branch
 ARG AMEBA_MATTER_REPO=https://github.com/mikaelajiwidodo/ameba-rtos-matter.git
-ARG AMEBA_MATTER_TAG_NAME=ameba-rtos/v1.5-PR/update_matter_apply_conf
+ARG AMEBA_MATTER_TAG_NAME=ameba-rtos/v1.5-PR/fix-camera-app
 
 # Define fixed build arguments
 ARG AMBRTOS_REPO=https://github.com/Ameba-AIoT/ameba-rtos.git


### PR DESCRIPTION
## This PR addresses:

* Added CONFIG_USB_HOST_EN wrapper to camera_driver code to support non-USB camera
* Added dummy streaming task if USB is not supported
* Set CHIP_SYSTEM_CONFIG_MAX_LARGE_BUFFER_SIZE_BYTES to 2048 if CHIP_ENABLE_TCP_ENDPOINT is set
* Updated LwIP APIs for ameba-rtos-v1.2

## Verification:

Built camera-app example with experimental WebRTC library, WHC_DEV enabled, and USB disabled. Commissioning and streaming conducted successfully by linux-camera-controller