### PR TITLE
[amebasmart][nand][ota] Fix AmebaSmart NAND flash Matter OTA

### DIFF
--- a/common/port/matter_ota.c
+++ b/common/port/matter_ota.c
@@ -27,6 +27,11 @@
 #include <FreeRTOS.h>
 #include <task.h>
 #include <ameba_ota.h>
+#if defined(CONFIG_AMEBASMART)
+#include <ameba_spic.h>
+#include <ameba_spinand.h>
+#include <ftl_nand.h>
+#endif
 
 #define MATTER_OTA_SECTOR_SIZE 4096
 
@@ -39,12 +44,98 @@ update_ota_target_hdr matterOtaTargetHdr = {0};
 
 bool matter_ota_first_sector_written = false;
 uint32_t matter_ota_flash_sector_base;
-uint32_t matter_ota_new_firmware_addr;
+uint32_t matter_ota_new_firmware_addr_start;
+uint32_t matter_ota_new_firmware_addr_end;
 
 uint8_t matter_ota_header[MATTER_OTA_HEADER_SIZE];
 uint8_t matter_ota_header_size = 0; // variable to track size of ota header
 uint8_t matter_ota_buffer[MATTER_OTA_SECTOR_SIZE]; // 4KB buffer to be written to one sector
 uint16_t matter_ota_buffer_size = 0; // variable to track size of buffer
+
+// SPI NAND Flash APIs for AmebaSmart
+#if defined(CONFIG_AMEBASMART)
+
+#define MATTER_OTA_NAND_FLASH_DEBUG 0
+extern uint32_t IMG_ADDR[OTA_IMGID_MAX][2];
+uint32_t boot_from_nor;
+
+// For NAND, first sector will be written at last together with manifest update
+uint8_t matter_ota_nand_first_sector[MATTER_OTA_SECTOR_SIZE] = {0};
+
+// Bad blocks checking
+#define MATTER_OTA_NAND_BBT_UNCHECKED  0
+#define MATTER_OTA_NAND_BBT_GOOD       1
+#define MATTER_OTA_NAND_BBT_BAD        2
+
+uint8_t  *matter_ota_nand_bbt = NULL;
+uint32_t matter_ota_nand_region_block_id_start;
+uint32_t matter_ota_nand_region_block_id_end;
+uint32_t matter_ota_nand_region_block_length;
+
+/**
+ * @brief Init the NAND Bad Block Table (BBT)
+ */
+void matter_ota_nand_create_bbt(void);
+
+/**
+ * @brief Free the NAND Bad Block Table (BBT)
+ */
+void matter_ota_nand_free_bbt(void);
+
+/**
+ * @brief  Get the status of the NAND Block ID based on BBT,
+ *         or from the first 2 bytes of Out-of-bound (OOB) area of the block
+ * @param[in] block_id: Block ID to be checked.
+ * @return MATTER_OTA_NAND_BBT_UNCHECKED if Block ID is out of the OTA region
+ *         MATTER_OTA_NAND_BBT_GOOD if Block ID is good block
+ *         MATTER_OTA_NAND_BBT_BAD if Block ID is bad block
+ */
+uint8_t matter_ota_nand_block_status(uint32_t block_id);
+
+/**
+ * @brief  Mechanism to skip a bad block during NAND flash program.
+ *         This will be called every time entering new block.
+ *         If new block is bad block, update raw address to the next good block.
+ *         Otherwise, do not update the raw address
+ * @param[in]  addr: Pointer to the raw address.
+ * @return OTA_SUCCESS if successful; OTA_ERROR if no good blocks left.
+ */
+int8_t matter_ota_nand_skip_bad_block(uint32_t *addr);
+
+/**
+ * @brief  Program the NAND flash using the SPI NAND APIs
+ * @param[in]  StartAddr: Start of the raw address.
+ * @param[in]  DataLen  : Len of the data.
+ * @param[in]  pData    : Pointer to the data.
+ * @return OTA_SUCCESS if programed successfully; OTA_ERROR otherwise
+ */
+int8_t matter_ota_nand_flash_program(uint32_t StartAddr, uint32_t DataLen, uint8_t *pData);
+
+/**
+ * @brief  Erase the NAND flash of the new OTA region.
+ *         If a block has been marked bad block, it will erase the block.
+ */
+void matter_ota_nand_flash_erase_new_ota_region(void);
+
+/**
+ * @brief  Update manifest of the new OTA region.
+ * @param[in]  pOtaTgtHdr      : Pointer to the update_ota_target_hdr.
+ * @param[in]  ota_target_index: OTA Index of the new OTA region.
+ * @param[in]  index           : OTA Index of the current image.
+ * @return 1 if manifest updated correctly; 0 otherwise
+ */
+uint32_t matter_ota_nand_flash_update_manifest(update_ota_target_hdr *pOtaTgtHdr, uint32_t ota_target_index, int index);
+
+#if MATTER_OTA_NAND_FLASH_DEBUG
+/**
+ * @brief  Log the pattern of the manifest
+ * @param[in]  var_name: Variable name that is logged.
+ * @param[in]  buf     : Pointer to the manifest buffer.
+ */
+void matter_ota_nand_flash_check_manifest_pattern(char *var_name, uint8_t *buf);
+#endif // MATTER_OTA_NAND_FLASH_DEBUG
+
+#endif // CONFIG_AMEBASMART
 
 uint8_t matter_ota_get_total_header_size(void)
 {
@@ -58,6 +149,8 @@ uint8_t matter_ota_get_current_header_size(void)
 
 void matter_ota_prepare_partition(void)
 {
+    matter_ota_first_sector_written = false;
+
     memset(matter_ota_buffer, 0, sizeof(matter_ota_buffer));
     memset(matter_ota_header, 0, sizeof(matter_ota_header));
     matter_ota_header_size = 0;
@@ -83,15 +176,27 @@ void matter_ota_prepare_partition(void)
     if (ota_get_cur_index(matterCtx.otactrl->ImgId) == OTA_INDEX_1) {
         matterCtx.otactrl->index = OTA_INDEX_1;
         matterCtx.otactrl->targetIdx = OTA_INDEX_2;
-        flash_get_layout_info(IMG_APP_OTA2, &matter_ota_new_firmware_addr, NULL);
+        flash_get_layout_info(IMG_APP_OTA2, &matter_ota_new_firmware_addr_start, &matter_ota_new_firmware_addr_end);
     } else {
         matterCtx.otactrl->index = OTA_INDEX_2;
         matterCtx.otactrl->targetIdx = OTA_INDEX_1;
-        flash_get_layout_info(IMG_APP_OTA1, &matter_ota_new_firmware_addr, NULL);
+        flash_get_layout_info(IMG_APP_OTA1, &matter_ota_new_firmware_addr_start, &matter_ota_new_firmware_addr_end);
     }
-    matter_ota_new_firmware_addr = matter_ota_new_firmware_addr - SPI_FLASH_BASE;
-    matterCtx.otactrl->FlashAddr = matter_ota_new_firmware_addr;
-    matter_ota_flash_sector_base = matter_ota_new_firmware_addr; // Note that the new fw address must be multiples of 4KB
+    matter_ota_new_firmware_addr_start = matter_ota_new_firmware_addr_start - SPI_FLASH_BASE;
+    matter_ota_new_firmware_addr_end   = matter_ota_new_firmware_addr_end   - SPI_FLASH_BASE;
+    matterCtx.otactrl->FlashAddr       = matter_ota_new_firmware_addr_start;
+    matter_ota_flash_sector_base       = matter_ota_new_firmware_addr_start; // Note that the new fw address must be multiples of 4KB
+
+#if defined(CONFIG_AMEBASMART)
+    boot_from_nor = SYSCFG_BootFromNor();
+    if (!boot_from_nor) { // NAND
+        matter_ota_nand_create_bbt();
+        matter_ota_nand_flash_erase_new_ota_region();
+        if (matter_ota_nand_block_status(matter_ota_nand_region_block_id_start) == MATTER_OTA_NAND_BBT_BAD) {
+            DiagPrintf("[NAND][OTA] CRITICAL ERROR: FIRST BLOCK IS BAD BLOCK, OTA MAY NOT PROCEED!!!!!\n");
+        }
+    }
+#endif
 }
 
 int8_t matter_ota_store_header(uint8_t *data, uint32_t size)
@@ -134,14 +239,50 @@ int8_t matter_ota_flash_burst_write(uint8_t *data, uint32_t size)
     }
 
     if (matter_ota_buffer_size == writeLength) {
+#if defined(CONFIG_AMEBADPLUS) || defined(CONFIG_AMEBALITE)
         // buffer is full, time to erase sector and write buffer data to flash
         flash_erase_sector(&matter_ota_flash, matter_ota_flash_sector_base);
         flash_burst_write(&matter_ota_flash, sectorBase, writeLength, matter_ota_buffer);
+#elif defined(CONFIG_AMEBASMART)
+        if (boot_from_nor) { // NOR
+            // buffer is full, time to erase sector and write buffer data to flash
+            flash_erase_sector(&matter_ota_flash, matter_ota_flash_sector_base);
+            flash_burst_write(&matter_ota_flash, sectorBase, writeLength, matter_ota_buffer);
+        } else { // NAND
+            if (!matter_ota_first_sector_written) {
+                // For NAND, first sector will be written at last together with manifest update
+                memcpy(matter_ota_nand_first_sector + matter_ota_header_size, matter_ota_buffer, writeLength);
+                // Immediately abort OTA if first sector is bad block
+                if (matter_ota_nand_block_status(matter_ota_nand_region_block_id_start) == MATTER_OTA_NAND_BBT_BAD) {
+                    DiagPrintf("[NAND][OTA] CRITICAL ERROR: FIRST BLOCK IS BAD BLOCK, OTA MAY NOT PROCEED!!!!!\n");
+                    return OTA_ERROR;
+                }
+            } else {
+                if (matter_ota_nand_flash_program(sectorBase, writeLength, matter_ota_buffer) != OTA_SUCCESS) {
+                    // Bad block detected, abort OTA!
+                    return OTA_ERROR;
+                }
+            }
+        }
+#endif
         if (!matter_ota_first_sector_written) {
             matter_ota_first_sector_written = true;
         }
 
         matter_ota_flash_sector_base += MATTER_OTA_SECTOR_SIZE; // point to next sector
+#if defined(CONFIG_AMEBASMART)
+        if (!boot_from_nor) {
+            uint32_t current_page = NAND_ADDR_TO_PAGE_ADDR(matter_ota_flash_sector_base);
+            // Only do checking if it is the first page of a block
+            if ((current_page & NAND_BLOCK_PAGE_MASK) == 0) {
+                // It will not skip block(s) if it is a good block
+                if (matter_ota_nand_skip_bad_block(&matter_ota_flash_sector_base) != OTA_SUCCESS) {
+                    DiagPrintf("[NAND][OTA] No good block left in OTA region!\n");
+                    return OTA_ERROR;
+                }
+            }
+        }
+#endif
         memset(matter_ota_buffer, 0, sizeof(matter_ota_buffer)); // clear buffer after writing
         matter_ota_buffer_size = 0;
     }
@@ -158,8 +299,20 @@ int8_t matter_ota_flash_burst_write(uint8_t *data, uint32_t size)
 int8_t matter_ota_flush_last(void)
 {
     if (matter_ota_buffer_size > 0) {
+#if defined(CONFIG_AMEBADPLUS) || defined(CONFIG_AMEBALITE)
         flash_erase_sector(&matter_ota_flash, matter_ota_flash_sector_base);
         flash_burst_write(&matter_ota_flash, matter_ota_flash_sector_base, matter_ota_buffer_size, matter_ota_buffer);
+#elif defined(CONFIG_AMEBASMART)
+        if (boot_from_nor) { // NOR
+            flash_erase_sector(&matter_ota_flash, matter_ota_flash_sector_base);
+            flash_burst_write(&matter_ota_flash, matter_ota_flash_sector_base, matter_ota_buffer_size, matter_ota_buffer);
+        } else { // NAND
+            if (matter_ota_nand_flash_program(matter_ota_flash_sector_base, matter_ota_buffer_size, matter_ota_buffer) != OTA_SUCCESS) {
+                // Bad block detected, abort OTA!
+                return OTA_ERROR;
+            }
+        }
+#endif
 
         matter_ota_flash_sector_base += MATTER_OTA_SECTOR_SIZE; // point to next sector
         memset(matter_ota_buffer, 0, sizeof(matter_ota_buffer)); // clear buffer after writing
@@ -172,9 +325,21 @@ int8_t matter_ota_flush_last(void)
 int8_t matter_ota_update_signature(void)
 {
     memcpy(&(matterCtx.otaTargetHdr->Manifest[matterCtx.otactrl->index]), matter_ota_header, sizeof(Manifest_TypeDef));
+#if defined(CONFIG_AMEBADPLUS) || defined(CONFIG_AMEBALITE)
     if (!ota_update_manifest(matterCtx.otaTargetHdr, matterCtx.otactrl->targetIdx, matterCtx.otactrl->index)) {
         return OTA_ERROR;
     }
+#elif defined(CONFIG_AMEBASMART)
+    if (boot_from_nor) { // NOR
+        if (!ota_update_manifest(matterCtx.otaTargetHdr, matterCtx.otactrl->targetIdx, matterCtx.otactrl->index)) {
+            return OTA_ERROR;
+        }
+    } else { // NAND
+        if (!matter_ota_nand_flash_update_manifest(matterCtx.otaTargetHdr, matterCtx.otactrl->targetIdx, matterCtx.otactrl->index)) {
+            return OTA_ERROR;
+        }
+    }
+#endif
     return OTA_SUCCESS;
 }
 
@@ -190,10 +355,20 @@ static void matter_ota_abort_task(void *pvParameters)
     DiagPrintf("Cleaning up aborted OTA\r\n");
     DiagPrintf("Erasing %d sectors\r\n", newFWBlkSize);
 
-    if (matter_ota_new_firmware_addr != 0) {
+    if (matter_ota_new_firmware_addr_start != 0) {
         for (size_t i = 0; i < newFWBlkSize; i++) {
             rtos_time_delay_ms(2); // to avoid undefined behaviour when it suddenly resets the ameba during flash erase
-            flash_erase_sector(&matter_ota_flash, matter_ota_new_firmware_addr + (i * MATTER_OTA_SECTOR_SIZE));
+#if defined(CONFIG_AMEBADPLUS) || defined(CONFIG_AMEBALITE)
+            flash_erase_sector(&matter_ota_flash, matter_ota_new_firmware_addr_start + (i * MATTER_OTA_SECTOR_SIZE));
+#elif defined(CONFIG_AMEBASMART)
+            if (boot_from_nor) { // NOR
+                flash_erase_sector(&matter_ota_flash, matter_ota_new_firmware_addr_start + (i * MATTER_OTA_SECTOR_SIZE));
+            } else { // NAND
+                matter_ota_nand_flash_erase_new_ota_region();
+                matter_ota_nand_free_bbt();
+                break; // exit the loop because the API above will erase the entire new OTA region
+            }
+#endif
         }
     }
     matter_ota_first_sector_written = false;
@@ -206,3 +381,266 @@ void matter_ota_create_abort_task(void)
         printf("[%s] Failed to create matter_ota_abort_task\n", __FUNCTION__);
     }
 }
+
+// SPI NAND Flash APIs for AmebaSmart
+#if defined(CONFIG_AMEBASMART)
+
+void matter_ota_nand_create_bbt(void)
+{
+    // Get page address and block id of start and end address of the target OTA region
+    uint32_t page_addr_start              = NAND_ADDR_TO_PAGE_ADDR(matter_ota_new_firmware_addr_start);
+    uint32_t page_addr_end                = NAND_ADDR_TO_PAGE_ADDR(matter_ota_new_firmware_addr_end);
+    matter_ota_nand_region_block_id_start = NAND_PAGE_ADDR_TO_BLOCK_ID(page_addr_start);
+    matter_ota_nand_region_block_id_end   = NAND_PAGE_ADDR_TO_BLOCK_ID(page_addr_end);
+    matter_ota_nand_region_block_length   = matter_ota_nand_region_block_id_end - matter_ota_nand_region_block_id_start + 1;
+
+    // Dynamically assign the BBT depends on the OTA region size
+    matter_ota_nand_bbt = (uint8_t*) rtos_mem_malloc(matter_ota_nand_region_block_length);
+    if (matter_ota_nand_bbt == NULL) {
+        DiagPrintf("[NAND][OTA] matter_ota_nand_bbt is null\n");
+        return;
+    }
+    memset(matter_ota_nand_bbt, MATTER_OTA_NAND_BBT_UNCHECKED, matter_ota_nand_region_block_length);
+
+    // Init the BBT
+    DiagPrintf("[NAND][OTA] Scanning the NAND blocks...\n");
+    for(int bbt_index = 0; bbt_index < matter_ota_nand_region_block_length; bbt_index++) {
+        matter_ota_nand_bbt[bbt_index] = matter_ota_nand_block_status(matter_ota_nand_region_block_id_start + bbt_index);
+    }
+    DiagPrintf("[NAND][OTA] Scanning finished!\n");
+}
+
+void matter_ota_nand_free_bbt(void)
+{
+    if (matter_ota_nand_bbt != NULL) {
+        rtos_mem_free(matter_ota_nand_bbt);
+        matter_ota_nand_bbt = NULL;
+    }
+}
+
+uint8_t matter_ota_nand_block_status(uint32_t block_id)
+{
+    uint32_t bbt_index = block_id - matter_ota_nand_region_block_id_start;
+    if (bbt_index >= matter_ota_nand_region_block_length) {
+        DiagPrintf("[NAND][OTA] block_id 0x%x out of OTA region\n", block_id);
+        return MATTER_OTA_NAND_BBT_UNCHECKED;
+    }
+
+    if (matter_ota_nand_bbt != NULL) {
+        if (matter_ota_nand_bbt[bbt_index] != MATTER_OTA_NAND_BBT_UNCHECKED) {
+            return matter_ota_nand_bbt[bbt_index];
+        }
+    }
+
+    // unchecked read OOB spare byte 0+1, same method as NAND_CHECK_IS_BAD_BLOCK
+    uint8_t oob[4];
+    NAND_Page_Read(NAND_BLOCK_ID_TO_PAGE_ADDR(block_id), NAND_PAGE_SIZE_MAIN, 4, oob);
+    if (oob[0] != 0xFF || oob[1] != 0xFF) {
+        DiagPrintf("[NAND][OTA] Block 0x%x is bad (OOB=0x%02x 0x%02x)\n", block_id, oob[0], oob[1]);
+        return MATTER_OTA_NAND_BBT_BAD;
+    }
+
+    return MATTER_OTA_NAND_BBT_GOOD;
+}
+
+int8_t matter_ota_nand_skip_bad_block(uint32_t *addr)
+{
+    uint32_t block_id = NAND_PAGE_ADDR_TO_BLOCK_ID(NAND_ADDR_TO_PAGE_ADDR(*addr));
+
+    // Enter the loop only if the the block is within the target OTA region and if it is BB
+    while (block_id <= matter_ota_nand_region_block_id_end &&
+           matter_ota_nand_block_status(block_id) == MATTER_OTA_NAND_BBT_BAD) {
+        // Keep looping until it arrives at the good block
+        *addr     += NAND_BLOCK_PAGE_CNT * NAND_PAGE_SIZE_MAIN; // advance one full block
+        block_id += 1;
+    }
+
+    // Return error if there is no more good blocks in the new OTA region
+    if (block_id > matter_ota_nand_region_block_id_end) {
+        return OTA_ERROR;
+    }
+
+    return OTA_SUCCESS;
+}
+
+void matter_ota_nand_mark_bad_block(uint32_t block_id)
+{
+    uint8_t oob[2] = {0};
+
+    // Physically mark it as bad block
+    DiagPrintf("[NAND][OTA] Block 0x%x Mark BB!\n", block_id);
+    if (NAND_Page_Write(NAND_BLOCK_ID_TO_PAGE_ADDR(block_id), NAND_PAGE_SIZE_MAIN, 2, oob)) {
+        DiagPrintf("[NAND][OTA] Block 0x%x Mark BB Fail!\n", block_id);
+    }
+
+    // Update the BBT
+    if (matter_ota_nand_bbt != NULL) {
+        matter_ota_nand_bbt[block_id - matter_ota_nand_region_block_id_start] = MATTER_OTA_NAND_BBT_BAD;
+    }
+}
+
+int8_t matter_ota_nand_flash_program(uint32_t StartAddr, uint32_t DataLen, uint8_t *pData)
+{
+    // Flash
+    uint32_t WriteAddr   = StartAddr;
+    uint32_t DataLenLeft = DataLen;
+    uint8_t *pNewData    = pData;
+    // Pages
+    uint32_t PageAddr, ByteAddr, ByteLen, BlockId;
+    uint32_t page_begin = NAND_ADDR_TO_PAGE_ADDR(StartAddr);
+    uint32_t page_end   = NAND_ADDR_TO_PAGE_ADDR(StartAddr + DataLen - 1);
+    uint32_t page_cnt   = page_end - page_begin + 1;
+    // Check Pages
+#if MATTER_OTA_NAND_FLASH_DEBUG
+    uint32_t check_page_mismatch = 0;
+    uint8_t  check_page[NAND_PAGE_SIZE] = {0};
+#endif // MATTER_OTA_NAND_FLASH_DEBUG
+    while (page_cnt) {
+        PageAddr = NAND_ADDR_TO_PAGE_ADDR(WriteAddr);
+        BlockId  = NAND_PAGE_ADDR_TO_BLOCK_ID(PageAddr);
+        ByteAddr = NAND_ADDR_TO_BYTE_ADDR(WriteAddr);
+        ByteLen  = (page_cnt == 1) ? DataLenLeft : (NAND_PAGE_SIZE_MAIN - ByteAddr);
+
+        if (NAND_Page_Write(PageAddr, ByteAddr, ByteLen, pNewData)) {
+            // Bad block detected, mark the current block as bad, abort OTA!
+            DiagPrintf("[NAND][OTA] Block 0x%x Page 0x%x Program Fail!\n", BlockId, PageAddr & NAND_BLOCK_PAGE_MASK);
+            matter_ota_nand_mark_bad_block(BlockId);
+            return OTA_ERROR;
+        }
+
+#if MATTER_OTA_NAND_FLASH_DEBUG
+        if (NAND_Page_Read(PageAddr, ByteAddr, ByteLen, check_page)) {
+            // Bad block detected, mark the current block as bad, abort OTA!
+            DiagPrintf("[NAND][OTA] Block 0x%x Page 0x%x Read Fail!\n", BlockId, PageAddr & NAND_BLOCK_PAGE_MASK);
+            matter_ota_nand_mark_bad_block(BlockId);
+            return OTA_ERROR;
+        } else {
+            for (int i = 0; i < ByteLen; i++) {
+                if (check_page[i] != *(pNewData+i)) {
+                    check_page_mismatch += 1;
+                }
+            }
+        }
+#endif // MATTER_OTA_NAND_FLASH_DEBUG
+
+        WriteAddr = WriteAddr + ByteLen;
+        DataLenLeft = DataLenLeft - ByteLen;
+        pNewData += ByteLen;
+        page_cnt--;
+    }
+
+#if MATTER_OTA_NAND_FLASH_DEBUG
+    if (check_page_mismatch > 0) {
+        DiagPrintf("Total mismatch is %d\n", check_page_mismatch);
+    }
+#endif // MATTER_OTA_NAND_FLASH_DEBUG
+
+    return OTA_SUCCESS;
+}
+
+void matter_ota_nand_flash_erase_new_ota_region()
+{
+    for(int block_id = matter_ota_nand_region_block_id_start; block_id <= matter_ota_nand_region_block_id_end; block_id++) {
+        if (matter_ota_nand_block_status(block_id) == MATTER_OTA_NAND_BBT_BAD) {
+            // never erase a bad block (preserve marker)
+            continue;
+        } else if (NAND_Erase(NAND_BLOCK_ID_TO_PAGE_ADDR(block_id))) {
+            // Bad block detected, mark the current block as bad, continue erasing the other blocks
+            DiagPrintf("[NAND][OTA] Block 0x%x Erase Fail!\n", block_id);
+            matter_ota_nand_mark_bad_block(block_id);
+        } else {
+            DiagPrintf("[NAND][OTA] Block 0x%x Erased Successfully!\n", block_id);
+        }
+    }
+}
+
+uint32_t matter_ota_nand_flash_update_manifest(update_ota_target_hdr *pOtaTgtHdr, uint32_t ota_target_index, int index)
+{
+    // OTA
+    uint32_t addr;
+    Manifest_TypeDef *manifest = NULL;
+
+    // Pages
+    uint32_t PageAddr, ByteAddr, ByteLen, BlockId;
+
+#if OTA_CLEAR_PATTERN
+    u8 ota_old_index = ota_target_index ^ 1;
+    u8 empty_sig[8] = {0x0};
+#endif
+
+    addr     = IMG_ADDR[pOtaTgtHdr->FileImgHdr[index].ImgID][ota_target_index];
+    manifest = &pOtaTgtHdr->Manifest[index];
+#if MATTER_OTA_NAND_FLASH_DEBUG
+    matter_ota_nand_flash_check_manifest_pattern("manifest->Pattern", manifest->Pattern);
+#endif // MATTER_OTA_NAND_FLASH_DEBUG
+
+    DiagPrintf("[NAND][OTA] update addr: 0x%08x\n", (unsigned int)addr);
+    DiagPrintf("[NAND][OTA] update version major: %d, minor: %d\n", manifest->MajorImgVer, manifest->MinorImgVer);
+
+    PageAddr = NAND_ADDR_TO_PAGE_ADDR(addr - SPI_FLASH_BASE);
+    BlockId  = NAND_PAGE_ADDR_TO_BLOCK_ID(PageAddr);
+    ByteAddr = NAND_ADDR_TO_BYTE_ADDR(addr - SPI_FLASH_BASE);
+    ByteLen  = MATTER_OTA_SECTOR_SIZE;
+
+    /*write the manifest, write pattern finally*/
+    memcpy(matter_ota_nand_first_sector + 8, (u8 *)manifest + 8, sizeof(Manifest_TypeDef) - 8);
+    memcpy(matter_ota_nand_first_sector, (u8 *)manifest->Pattern, 8);
+
+#if OTA_CLEAR_PATTERN
+    if (strncmp("OTA", (const char *)pOtaTgtHdr->FileImgHdr[index].Signature, 3) == 0) {
+        addr = IMG_ADDR[pOtaTgtHdr->FileImgHdr[index].ImgID][ota_old_index];
+    } else {
+        matter_ota_nand_free_bbt();
+        return 0;
+    }
+
+    /*clear the old FW pattern to 0 finally*/
+    DiagPrintf("[NAND][OTA] ImgID: %lu, clear the old FW pattern, addr: 0x%08x\n", pOtaTgtHdr->FileImgHdr[index].ImgID, (unsigned int)addr);
+    memcpy(matter_ota_nand_first_sector, empty_sig, 8);
+#endif
+
+#if MATTER_OTA_NAND_FLASH_DEBUG
+    matter_ota_nand_flash_check_manifest_pattern("matter_ota_nand_first_sector before write", matter_ota_nand_first_sector);
+#endif // MATTER_OTA_NAND_FLASH_DEBUG
+    // Immediately abort if first sector is bad block
+    if (matter_ota_nand_block_status(matter_ota_nand_region_block_id_start) == MATTER_OTA_NAND_BBT_BAD) {
+        DiagPrintf("[NAND][OTA] CRITICAL ERROR: FIRST BLOCK IS BAD BLOCK, MANIFEST MAY NOT BE UPDATED!!!!!\n");
+        matter_ota_nand_free_bbt();
+        return 0;
+    }
+    if (matter_ota_nand_flash_program(addr - SPI_FLASH_BASE, ByteLen, matter_ota_nand_first_sector) != OTA_SUCCESS) {
+        // Bad block detected, block is marked bad inside the API, return 0
+        DiagPrintf("[NAND][OTA] Block 0x%x Page 0x%x Program Fail!\n", BlockId, PageAddr & NAND_BLOCK_PAGE_MASK);
+        matter_ota_nand_free_bbt();
+        return 0;
+    } else {
+        DiagPrintf("[NAND][OTA] Update OTA success!\n");
+    }
+
+#if MATTER_OTA_NAND_FLASH_DEBUG
+    if (NAND_Page_Read(PageAddr, ByteAddr, NAND_PAGE_SIZE, matter_ota_nand_first_sector)) {
+        // Bad block detected, mark the starting block as bad.
+        DiagPrintf("[NAND][OTA] Block 0x%x Page 0x%x Read Fail!\n", BlockId, PageAddr & NAND_BLOCK_PAGE_MASK);
+        matter_ota_nand_mark_bad_block(BlockId);
+        matter_ota_nand_free_bbt();
+        return 0;
+    }
+    matter_ota_nand_flash_check_manifest_pattern("matter_ota_nand_first_sector after read", matter_ota_nand_first_sector);
+#endif // MATTER_OTA_NAND_FLASH_DEBUG
+
+    matter_ota_nand_free_bbt();
+    return 1;
+}
+
+#if MATTER_OTA_NAND_FLASH_DEBUG
+void matter_ota_nand_flash_check_manifest_pattern(char *var_name, uint8_t *buf)
+{
+    printf("\n[NAND][OTA] %s, manifest contains: ", var_name);
+    for (int i = 0; i < 8; i++) {
+        printf("0x%02x ", *(buf+i));
+    }
+    printf("\n");
+}
+#endif // MATTER_OTA_NAND_FLASH_DEBUG
+
+#endif // CONFIG_AMEBASMART

--- a/tools/docker/ameba-rtos/Dockerfile
+++ b/tools/docker/ameba-rtos/Dockerfile
@@ -3,7 +3,7 @@ FROM ameba-rtos-matter:common
 
 # Redefine following build arguments to respective repo and tag/branch
 ARG AMEBA_MATTER_REPO=https://github.com/mikaelajiwidodo/ameba-rtos-matter.git
-ARG TAG_NAME=ameba-rtos/v1.3-PR/sdk_update_260424
+ARG TAG_NAME=ameba-rtos/v1.3-PR/amebasmart-nand-ota-fix
 
 # Define fixed build arguments
 ARG AMBRTOS_REPO=https://github.com/Ameba-AIoT/ameba-rtos.git


### PR DESCRIPTION
## This PR addresses:

* Added new Matter OTA APIs for AmebaSmart utilizing the SPI NAND APIs
* Added branching for AmebaSmart to use different erase/write flash API which depends on the flash type
* Added NAND bad block checking and skipping mechanism

## Verification:

Build and commissioning success. Tested Matter OTA on both NOR and NAND flash AmebaSmart, OTA executed successfully and device boots from the new OTA region