### PR TITLE
[common][drivers] Reduced Time Synchronization Interval

### DIFF
--- a/common/port/matter_timers.c
+++ b/common/port/matter_timers.c
@@ -42,15 +42,19 @@
 
 #define US_OVERFLOW_MAX            (0xFFFFFFFFUL * 1000000 / configTICK_RATE_HZ)
 
+static uint64_t current_us = 0;
+static uint32_t tick_count = 0;
+
+#if defined(CONFIG_ENABLE_AMEBA_SNTP) && (CONFIG_ENABLE_AMEBA_SNTP == 1)
 #define DEFAULT_SNTP_SERVER_ADDRESS "pool.ntp.org"
 
 // Minimum plausible epoch time (2000-01-01 00:00:00 UTC)
 // matching CHIP_SYSTEM_CONFIG_VALID_REAL_TIME_THRESHOLD
 #define MATTER_SNTP_VALID_TIME_THRESHOLD ((time_t) 946684800)
 
-static uint64_t current_us = 0;
-static uint32_t tick_count = 0;
 static bool matter_sntp_rtc_sync = FALSE;
+bool matter_sntp_initialized = FALSE;
+#endif
 
 void matter_rtc_init(void)
 {
@@ -97,6 +101,12 @@ bool matter_sntp_rtc_is_sync(void)
     return matter_sntp_rtc_sync;
 }
 
+__weak void matter_sntp_prepare_sleep(void)
+{
+    // If WHC DEV is enabled, this api is defined in common\port\whc\matter_whc_dev.c.
+    return;
+}
+
 void matter_sntp_get_current_time(time_t *current_sec, time_t *current_usec)
 {
 #if (defined(CONFIG_AMEBARTOS_V1_0) && (CONFIG_AMEBARTOS_V1_0 == 1)) || \
@@ -119,6 +129,7 @@ void matter_sntp_get_current_time(time_t *current_sec, time_t *current_usec)
 
         matter_rtc_write(*current_sec);
         matter_sntp_rtc_sync = TRUE;
+        matter_sntp_prepare_sleep();
     } else { //if the sntp is not reachable yet, use the last known epoch time if available
         *current_sec = matter_rtc_read();
     }
@@ -132,6 +143,7 @@ void matter_sntp_get_current_time(time_t *current_sec, time_t *current_usec)
 
         matter_rtc_write(*current_sec);
         matter_sntp_rtc_sync = TRUE;
+        matter_sntp_prepare_sleep();
     } else { //if the sntp is not reachable yet, use the last known epoch time if available
         *current_sec = matter_rtc_read();
     }
@@ -145,12 +157,15 @@ void matter_sntp_init(void)
 
 void matter_sntp_init_with_server(const char *server)
 {
-    sntp_stop();
+    if (!matter_sntp_initialized) {
+        sntp_stop();
+    }
 // ameba-rtos v1.0 and v1.1 set the SNTP server at component/network/sntp/sntp.c
 #if defined(CONFIG_AMEBARTOS_V1_2) && (CONFIG_AMEBARTOS_V1_2 == 1)
     sntp_setservername(0, server);
 #endif
     matter_sntp_rtc_sync = FALSE;
     sntp_init();
+    matter_sntp_initialized = TRUE;
 }
 #endif

--- a/common/port/matter_wifis.c
+++ b/common/port/matter_wifis.c
@@ -779,7 +779,8 @@ int matter_wifi_set_powersave_mode(uint8_t ips_enable, uint8_t lps_enable) {
 }
 
 int matter_wifi_set_lps_listen_interval(uint8_t interval) {
-    return wifi_set_lps_listen_interval(interval);
+    // return wifi_set_lps_listen_interval(interval);
+    return RTW_SUCCESS;
 }
 
 /* Support for WiFi Network Diagnostics. */

--- a/common/port/whc/matter_whc_dev.c
+++ b/common/port/whc/matter_whc_dev.c
@@ -41,6 +41,18 @@ static void whc_matter_dev_doorlock_update(u8 lock_state)
 }
 #endif
 
+#if defined(CONFIG_ENABLE_AMEBA_SNTP) && (CONFIG_ENABLE_AMEBA_SNTP == 1)
+extern bool matter_sntp_initialized;
+void matter_sntp_prepare_sleep(void)
+{
+    if (matter_sntp_initialized) {
+        sntp_stop();
+        matter_sntp_initialized = FALSE;
+    }
+    return;
+}
+#endif
+
 void whc_matter_dev_downlink_hdl(u8 *buf)
 {
     u8 event = *buf;

--- a/drivers/matter_drivers/time_synchronization/ameba_time_sync_delegate.h
+++ b/drivers/matter_drivers/time_synchronization/ameba_time_sync_delegate.h
@@ -104,7 +104,7 @@ private:
     static constexpr size_t kMaxServerNameSize           = 128;
     static constexpr uint16_t kPollIntervalMs            = 500;
     static constexpr uint8_t kMaxPollAttempts            = 20;           // ~10s total
-    static constexpr uint64_t kResyncIntervalMs          = 6ULL * 3600ULL * 1000ULL; // 6 hours
+    static constexpr uint64_t kResyncIntervalMs          = 3ULL * 60ULL * 1000ULL; // 30 minutes
     static constexpr uint64_t kQuickTestResyncIntervalMs = 10ULL * 60ULL * 1000ULL; // 10 minutes, for quick test
 
     bool mSimulatePlatformSourceUnavailable = false;

--- a/tools/docker/ameba-rtos/v1.2/Dockerfile
+++ b/tools/docker/ameba-rtos/v1.2/Dockerfile
@@ -11,7 +11,7 @@ ARG TOOLCHAIN_ASDK_FILE_PATH='/opt/rtk-toolchain/prebuilts-linux-1.0.3.tar.gz'
 
 # Redefine following build arguments to respective repo and tag/branch
 ARG AMEBA_MATTER_REPO=https://github.com/mikaelajiwidodo/ameba-rtos-matter.git
-ARG AMEBA_MATTER_TAG_NAME=ameba-rtos/v1.6-PR/camera_update_260807
+ARG AMEBA_MATTER_TAG_NAME=ameba-rtos/v1.6-PR/reduce_resync_interval
 
 # Define fixed build arguments
 ARG AMBRTOS_REPO=https://github.com/Ameba-AIoT/ameba-rtos.git


### PR DESCRIPTION
## This PR addresses:

* Reduced kResyncIntervalMs from 6 hours to 30 minutes
* Added matter_sntp_prepare_sleep API for SNTP power saving

## Verification:

* Build camera_port example, commission by chip-tool, camera_port will do time synchronization every 30 minutes 