### PR TITLE
[common][drivers] Add SNTP synchronization

### DIFF
--- a/common/port/matter_kvs.c
+++ b/common/port/matter_kvs.c
@@ -193,7 +193,7 @@ s32 deleteKey(const char *domain, const char *key)
             ret = MATTER_KVS_ERROR;
         }
     } else {
-        RTK_LOGI(TAG, "deleteKey %s success.\r\n", tempKey);
+        RTK_LOGD(TAG, "deleteKey %s success.\r\n", tempKey);
         ret = MATTER_KVS_SUCCESS;
     }
 
@@ -211,7 +211,7 @@ bool checkExist(const char *domain, const char *key)
     ret = rt_kv_size(tempKey);
 
     if (ret > 0) {
-        RTK_LOGI(TAG, "checkExist key=%s found.\n", tempKey);
+        RTK_LOGD(TAG, "checkExist key=%s found.\n", tempKey);
     }
 
     free(tempKey);
@@ -234,7 +234,7 @@ s32 setPref_new(const char *domain, const char *key, u8 *value, size_t byteCount
     if (ret <= 0) { //0 is inclusive because 0 bytes were written
         ret = MATTER_KVS_ERROR;
     } else {
-        RTK_LOGI(TAG, "setPref_new %s success, write %d bytes.\r\n", tempKey, byteCount);
+        RTK_LOGD(TAG, "setPref_new %s success, write %d bytes.\r\n", tempKey, byteCount);
         ret = MATTER_KVS_SUCCESS;
     }
 
@@ -262,7 +262,7 @@ s32 getPref_bool_new(const char *domain, const char *key, u8 *val)
             ret = MATTER_KVS_ERROR;
         }
     } else {
-        RTK_LOGI(TAG, "getPref_bool_new %s success, read %d bytes.\r\n", tempKey, sizeof(u8));
+        RTK_LOGD(TAG, "getPref_bool_new %s success, read %d bytes.\r\n", tempKey, sizeof(u8));
         ret = MATTER_KVS_SUCCESS;
     }
 
@@ -290,7 +290,7 @@ s32 getPref_u32_new(const char *domain, const char *key, u32 *val)
             ret = MATTER_KVS_ERROR;
         }
     } else {
-        RTK_LOGI(TAG, "getPref_u32_new %s success, read %d bytes.\r\n", tempKey, sizeof(u32));
+        RTK_LOGD(TAG, "getPref_u32_new %s success, read %d bytes.\r\n", tempKey, sizeof(u32));
         ret = MATTER_KVS_SUCCESS;
     }
 
@@ -318,7 +318,7 @@ s32 getPref_u64_new(const char *domain, const char *key, u64 *val)
             ret = MATTER_KVS_ERROR;
         }
     } else {
-        RTK_LOGI(TAG, "getPref_u64_new %s success, read %d bytes.\r\n", tempKey, sizeof(u64));
+        RTK_LOGD(TAG, "getPref_u64_new %s success, read %d bytes.\r\n", tempKey, sizeof(u64));
         ret = MATTER_KVS_SUCCESS;
     }
 
@@ -348,7 +348,7 @@ s32 getPref_str_new(const char *domain, const char *key, char *buf, size_t bufSi
             ret = MATTER_KVS_ERROR;
         }
     } else {
-        RTK_LOGI(TAG, "getPref_str_new %s success, read %d bytes.\r\n", tempKey, bufSize);
+        RTK_LOGD(TAG, "getPref_str_new %s success, read %d bytes.\r\n", tempKey, bufSize);
         ret = MATTER_KVS_SUCCESS;
     }
 
@@ -378,7 +378,7 @@ s32 getPref_bin_new(const char *domain, const char *key, u8 *buf, size_t bufSize
             ret = MATTER_KVS_ERROR;
         }
     } else {
-        RTK_LOGI(TAG, "getPref_bin_new %s success, read %d bytes.\r\n", tempKey, bufSize);
+        RTK_LOGD(TAG, "getPref_bin_new %s success, read %d bytes.\r\n", tempKey, bufSize);
         ret = MATTER_KVS_SUCCESS;
     }
 

--- a/common/port/matter_lwip.c
+++ b/common/port/matter_lwip.c
@@ -183,6 +183,10 @@ static void matter_LwIP_IP_Address_Request_thread(void *pvParameters)
 #endif
 #endif
 
+#if CONFIG_ENABLE_AMEBA_SNTP
+    matter_sntp_init();
+#endif
+
     vTaskDelete(NULL);
 }
 

--- a/common/port/matter_timers.c
+++ b/common/port/matter_timers.c
@@ -35,6 +35,8 @@
 #include <rtc_api.h>
 #include <timer_api.h>
 
+static const char *const TAG = "MATTER_TIMERS";
+
 #define MICROSECONDS_PER_SECOND    ( 1000000LL )                                   /**< Microseconds per second. */
 #define NANOSECONDS_PER_SECOND     ( 1000000000LL )                                /**< Nanoseconds per second. */
 #define NANOSECONDS_PER_TICK       ( NANOSECONDS_PER_SECOND / configTICK_RATE_HZ ) /**< Nanoseconds per FreeRTOS tick. */
@@ -51,6 +53,7 @@ static uint32_t tick_count = 0;
 // Minimum plausible epoch time (2000-01-01 00:00:00 UTC)
 // matching CHIP_SYSTEM_CONFIG_VALID_REAL_TIME_THRESHOLD
 #define MATTER_SNTP_VALID_TIME_THRESHOLD ((time_t) 946684800)
+#define MATTER_SNTP_SYNC_TIMEOUT_MS    5000
 
 static bool matter_sntp_rtc_sync = FALSE;
 bool matter_sntp_initialized = FALSE;
@@ -107,6 +110,20 @@ __weak void matter_sntp_prepare_sleep(void)
     return;
 }
 
+int matter_sntp_sync(void)
+{
+    uint32_t sec  = 0;
+    uint32_t usec = 0;
+    SNTP_GET_SYSTEM_TIME(sec, usec);
+    if ((time_t)sec >= MATTER_SNTP_VALID_TIME_THRESHOLD) { //if sntp server is reachable, write to the dct and rtc
+        matter_rtc_write((time_t)sec);
+        matter_sntp_rtc_sync = TRUE;
+        matter_sntp_prepare_sleep();
+        return 0;
+    }
+    return -1;
+}
+
 void matter_sntp_get_current_time(time_t *current_sec, time_t *current_usec)
 {
 #if (defined(CONFIG_AMEBARTOS_V1_0) && (CONFIG_AMEBARTOS_V1_0 == 1)) || \
@@ -157,7 +174,7 @@ void matter_sntp_init(void)
 
 void matter_sntp_init_with_server(const char *server)
 {
-    if (!matter_sntp_initialized) {
+    if (matter_sntp_initialized) {
         sntp_stop();
     }
 // ameba-rtos v1.0 and v1.1 set the SNTP server at component/network/sntp/sntp.c
@@ -167,5 +184,24 @@ void matter_sntp_init_with_server(const char *server)
     matter_sntp_rtc_sync = FALSE;
     sntp_init();
     matter_sntp_initialized = TRUE;
+
+    uint32_t start_time = xTaskGetTickCount();
+    int sync_result;
+
+    if (lwip_check_connectivity(NETIF_WLAN_STA_INDEX) == CONNECTION_VALID) {
+        while ((sync_result = matter_sntp_sync()) != 0) {
+            if ((xTaskGetTickCount() - start_time) >= pdMS_TO_TICKS(MATTER_SNTP_SYNC_TIMEOUT_MS)) {
+                RTK_LOGW(TAG, "SNTP sync timeout\n");
+                break;
+            }
+            vTaskDelay(pdMS_TO_TICKS(100));
+        }
+
+        if (sync_result == 0) {
+            RTK_LOGD(TAG, "SNTP sync successful\n");
+        } else {
+            RTK_LOGD(TAG, "SNTP sync failed\n");
+        }
+    }
 }
 #endif

--- a/common/port/matter_timers.h
+++ b/common/port/matter_timers.h
@@ -60,6 +60,11 @@ void matter_timer_init(void);
 bool matter_sntp_rtc_is_sync(void);
 
 /*
+ * @brief  Return 0 if sntp has been sync; otherwise -1.
+ */
+int matter_sntp_sync(void);
+
+/*
  * @brief  Get SNTP Current Time and write it to the DCT and RTC if SNTP server is reachable.
  *         If not reachable, retain the last known epoch time written in DCT if available
  * @param  current_sec : Pointer to be set as current epoch in seconds.

--- a/common/port/matter_wifis.c
+++ b/common/port/matter_wifis.c
@@ -578,9 +578,6 @@ static void matter_wifi_join_status_event_hdl(char *buf, int buf_len, int flags,
     case RTW_JOINSTATUS_SUCCESS: // Connecting --> Connected Succesfully
         error_flag = RTW_NO_ERROR;
         RTK_LOGI(TAG, "Join success!\n");
-#if CONFIG_ENABLE_AMEBA_SNTP
-        matter_sntp_init();
-#endif
         matter_wifi_indication(MATTER_WIFI_EVENT_CONNECT, NULL, 0, flags);
         matter_LwIP_IP_Address_Request();
         break;

--- a/core/matter_mdns_filter.h
+++ b/core/matter_mdns_filter.h
@@ -145,7 +145,7 @@ public:
 
         // Drop all IPv4 Mdns packets
         if (pktInfo.DestAddress.IsIPv4() && pktInfo.DestPort == chip::Dnssd::kMdnsPort) {
-            ChipLogProgress(DeviceLayer, "IPv4 MDNS packet dropped...");
+            ChipLogDetail(DeviceLayer, "IPv4 MDNS packet dropped...");
             return FilterOutcome::kDropPacket;
         }
 
@@ -172,7 +172,7 @@ public:
         // NOTE: This is always called from Matter platform event loop
 
         if (pktInfo.DestAddress.IsIPv4() && pktInfo.DestPort == chip::Dnssd::kMdnsPort) {
-            ChipLogProgress(DeviceLayer, "IPv4 MDNS packet dropped...");
+            ChipLogDetail(DeviceLayer, "IPv4 MDNS packet dropped...");
             return FilterOutcome::kDropPacket;
         }
 

--- a/drivers/matter_drivers/time_synchronization/ameba_time_sync_delegate.h
+++ b/drivers/matter_drivers/time_synchronization/ameba_time_sync_delegate.h
@@ -104,7 +104,7 @@ private:
     static constexpr size_t kMaxServerNameSize           = 128;
     static constexpr uint16_t kPollIntervalMs            = 500;
     static constexpr uint8_t kMaxPollAttempts            = 20;           // ~10s total
-    static constexpr uint64_t kResyncIntervalMs          = 3ULL * 60ULL * 1000ULL; // 30 minutes
+    static constexpr uint64_t kResyncIntervalMs          = 30ULL * 60ULL * 1000ULL; // 30 minutes
     static constexpr uint64_t kQuickTestResyncIntervalMs = 10ULL * 60ULL * 1000ULL; // 10 minutes, for quick test
 
     bool mSimulatePlatformSourceUnavailable = false;
@@ -120,7 +120,6 @@ private:
     static void PollSntpResult(System::Layer *layer, void *appState);
     void OnPollTick();
     void CompleteFallback(bool success);
-
 #endif
 };
 

--- a/tools/docker/ameba-rtos/v1.2/Dockerfile
+++ b/tools/docker/ameba-rtos/v1.2/Dockerfile
@@ -10,8 +10,8 @@ ARG TOOLCHAIN_ASDK_LINUX_URL_ALIYUN='https://rs-wn.oss-cn-shanghai.aliyuncs.com/
 ARG TOOLCHAIN_ASDK_FILE_PATH='/opt/rtk-toolchain/prebuilts-linux-1.0.3.tar.gz'
 
 # Redefine following build arguments to respective repo and tag/branch
-ARG AMEBA_MATTER_REPO=https://github.com/mikaelajiwidodo/ameba-rtos-matter.git
-ARG AMEBA_MATTER_TAG_NAME=ameba-rtos/v1.6-PR/reduce_resync_interval
+ARG AMEBA_MATTER_REPO=https://github.com/xshuqun/ameba-rtos-matter.git
+ARG AMEBA_MATTER_TAG_NAME=ameba-rtos/v1.6-PR/add_sntp_sync
 
 # Define fixed build arguments
 ARG AMBRTOS_REPO=https://github.com/Ameba-AIoT/ameba-rtos.git


### PR DESCRIPTION
## This PR addresses:

* Move matter_sntp_init() from matter_wifi_join_status_event_hdl to matter_LwIP_IP_Address_Request_thread as it requires obtaining IP address to connect to ntp server.
* Added a while loop to continuous check SNTP time and perform SNTP sync, as Matter Protocol does not sync immediately.
* Change RTK_LOGI to RTK_LOGD to reduce printed logs in matter kvs.
* Change ChipLogProgress to ChipLogDetail in matter filter to reduce printed logs.
* Correct resync interval from 3minutes to 30minutes.

## Verification:

Commissioned device and check time sync feature.