### PR TITLE
[common][core] Move T&C Manager to be a reference not a pointer

### DIFF
--- a/core/matter_core.cpp
+++ b/core/matter_core.cpp
@@ -278,7 +278,7 @@ void matter_core_init_server(intptr_t context)
     const Optional<app::TermsAndConditions> termsAndConditions = Optional<app::TermsAndConditions>(
                             app::TermsAndConditions(CHIP_AMEBA_TC_REQUIRED_ACKNOWLEDGEMENTS, CHIP_AMEBA_TC_MIN_REQUIRED_VERSION));
     PersistentStorageDelegate &persistentStorageDelegate = Server::GetInstance().GetPersistentStorage();
-    chip::app::TermsAndConditionsManager::GetInstance()->Init(&persistentStorageDelegate, termsAndConditions);
+    chip::app::TermsAndConditionsManager::GetInstance().Init(&persistentStorageDelegate, termsAndConditions);
 #endif
 
     sWiFiNetworkCommissioningInstance.Init();

--- a/tools/docker/ameba-rtos/v1.0/Dockerfile
+++ b/tools/docker/ameba-rtos/v1.0/Dockerfile
@@ -2,8 +2,8 @@
 FROM ameba-rtos-matter:common
 
 # Redefine following build arguments to respective repo and tag/branch
-ARG AMEBA_MATTER_REPO=https://github.com/mikaelajiwidodo/ameba-rtos-matter.git
-ARG AMEBA_MATTER_TAG_NAME=ameba-rtos/v1.5-PR/sdk_update_260709
+ARG AMEBA_MATTER_REPO=https://github.com/jack155069/ameba-rtos-matter.git
+ARG AMEBA_MATTER_TAG_NAME=ameba-rtos/v1.6/update_sdk_260819
 
 # Define fixed build arguments
 ARG AMBRTOS_REPO=https://github.com/mikaelajiwidodo/ameba-rtos.git

--- a/tools/docker/ameba-rtos/v1.1/Dockerfile
+++ b/tools/docker/ameba-rtos/v1.1/Dockerfile
@@ -12,8 +12,8 @@ ARG TOOLCHAIN_ASDK_OLD_DIR='/opt/rtk-toolchain/asdk-10.3.1'
 ARG TOOLCHAIN_ASDK_NEW_DIR='/opt/rtk-toolchain/asdk-10.3.1-4354'
 
 # Redefine following build arguments to respective repo and tag/branch
-ARG AMEBA_MATTER_REPO=https://github.com/mikaelajiwidodo/ameba-rtos-matter.git
-ARG AMEBA_MATTER_TAG_NAME=ameba-rtos/v1.5-PR/sdk_update_260709
+ARG AMEBA_MATTER_REPO=https://github.com/jack155069/ameba-rtos-matter.git
+ARG AMEBA_MATTER_TAG_NAME=ameba-rtos/v1.6/update_sdk_260819
 
 # Define fixed build arguments
 ARG AMBRTOS_REPO=https://github.com/mikaelajiwidodo/ameba-rtos.git

--- a/tools/docker/ameba-rtos/v1.2/Dockerfile
+++ b/tools/docker/ameba-rtos/v1.2/Dockerfile
@@ -10,8 +10,8 @@ ARG TOOLCHAIN_ASDK_LINUX_URL_ALIYUN='https://rs-wn.oss-cn-shanghai.aliyuncs.com/
 ARG TOOLCHAIN_ASDK_FILE_PATH='/opt/rtk-toolchain/prebuilts-linux-1.0.3.tar.gz'
 
 # Redefine following build arguments to respective repo and tag/branch
-ARG AMEBA_MATTER_REPO=https://github.com/mikaelajiwidodo/ameba-rtos-matter.git
-ARG AMEBA_MATTER_TAG_NAME=ameba-rtos/v1.6-PR/camera_update_260807
+ARG AMEBA_MATTER_REPO=https://github.com/jack155069/ameba-rtos-matter.git
+ARG AMEBA_MATTER_TAG_NAME=ameba-rtos/v1.6/update_sdk_260819
 
 # Define fixed build arguments
 ARG AMBRTOS_REPO=https://github.com/Ameba-AIoT/ameba-rtos.git


### PR DESCRIPTION
## This PR addresses:

Following the official connectedhomeip PR#41717, the T&C Manager has been changed from a pointer to a reference.

## Verification:

This has been verified on rtos-v1.2 with the light_port on 8730E, 8721DX, and 8721F, and commissioning with T&C enabled has also been tested successfully.