### PR TITLE
[common][drivers] update SNTP synchronization feature

### DIFF
--- a/common/port/matter_timers.c
+++ b/common/port/matter_timers.c
@@ -25,6 +25,7 @@
 #include <task.h>
 #include <errno.h>
 #include <time.h>
+#include <matter_timers.h>
 #if (defined(CONFIG_AMEBARTOS_V1_0) && (CONFIG_AMEBARTOS_V1_0 == 1)) || \
     (defined(CONFIG_AMEBARTOS_V1_1) && (CONFIG_AMEBARTOS_V1_1 == 1))
 #include <sntp/sntp.h>
@@ -48,12 +49,10 @@ static uint64_t current_us = 0;
 static uint32_t tick_count = 0;
 
 #if defined(CONFIG_ENABLE_AMEBA_SNTP) && (CONFIG_ENABLE_AMEBA_SNTP == 1)
-#define DEFAULT_SNTP_SERVER_ADDRESS "pool.ntp.org"
 
 // Minimum plausible epoch time (2000-01-01 00:00:00 UTC)
 // matching CHIP_SYSTEM_CONFIG_VALID_REAL_TIME_THRESHOLD
 #define MATTER_SNTP_VALID_TIME_THRESHOLD ((time_t) 946684800)
-#define MATTER_SNTP_SYNC_TIMEOUT_MS    5000
 
 static bool matter_sntp_rtc_sync = FALSE;
 bool matter_sntp_initialized = FALSE;
@@ -104,24 +103,10 @@ bool matter_sntp_rtc_is_sync(void)
     return matter_sntp_rtc_sync;
 }
 
-__weak void matter_sntp_prepare_sleep(void)
+__weak void sntp_set_oneshot(int enable)
 {
-    // If WHC DEV is enabled, this api is defined in common\port\whc\matter_whc_dev.c.
+    (void) enable;
     return;
-}
-
-int matter_sntp_sync(void)
-{
-    uint32_t sec  = 0;
-    uint32_t usec = 0;
-    SNTP_GET_SYSTEM_TIME(sec, usec);
-    if ((time_t)sec >= MATTER_SNTP_VALID_TIME_THRESHOLD) { //if sntp server is reachable, write to the dct and rtc
-        matter_rtc_write((time_t)sec);
-        matter_sntp_rtc_sync = TRUE;
-        matter_sntp_prepare_sleep();
-        return 0;
-    }
-    return -1;
 }
 
 void matter_sntp_get_current_time(time_t *current_sec, time_t *current_usec)
@@ -146,7 +131,6 @@ void matter_sntp_get_current_time(time_t *current_sec, time_t *current_usec)
 
         matter_rtc_write(*current_sec);
         matter_sntp_rtc_sync = TRUE;
-        matter_sntp_prepare_sleep();
     } else { //if the sntp is not reachable yet, use the last known epoch time if available
         *current_sec = matter_rtc_read();
     }
@@ -160,7 +144,6 @@ void matter_sntp_get_current_time(time_t *current_sec, time_t *current_usec)
 
         matter_rtc_write(*current_sec);
         matter_sntp_rtc_sync = TRUE;
-        matter_sntp_prepare_sleep();
     } else { //if the sntp is not reachable yet, use the last known epoch time if available
         *current_sec = matter_rtc_read();
     }
@@ -177,31 +160,19 @@ void matter_sntp_init_with_server(const char *server)
     if (matter_sntp_initialized) {
         sntp_stop();
     }
-// ameba-rtos v1.0 and v1.1 set the SNTP server at component/network/sntp/sntp.c
+    // ameba-rtos v1.0 and v1.1 set the SNTP server at component/network/sntp/sntp.c
 #if defined(CONFIG_AMEBARTOS_V1_2) && (CONFIG_AMEBARTOS_V1_2 == 1)
     sntp_setservername(0, server);
+#if SNTP_MAX_SERVERS > 1
+    sntp_setservername(1, SNTP_FALLBACK_SERVER_1);
+#endif
+#if SNTP_MAX_SERVERS > 2
+    sntp_setservername(2, SNTP_FALLBACK_SERVER_2);
+#endif
+    sntp_set_oneshot(1);
 #endif
     matter_sntp_rtc_sync = FALSE;
     sntp_init();
     matter_sntp_initialized = TRUE;
-
-    uint32_t start_time = xTaskGetTickCount();
-    int sync_result;
-
-    if (lwip_check_connectivity(NETIF_WLAN_STA_INDEX) == CONNECTION_VALID) {
-        while ((sync_result = matter_sntp_sync()) != 0) {
-            if ((xTaskGetTickCount() - start_time) >= pdMS_TO_TICKS(MATTER_SNTP_SYNC_TIMEOUT_MS)) {
-                RTK_LOGW(TAG, "SNTP sync timeout\n");
-                break;
-            }
-            vTaskDelay(pdMS_TO_TICKS(100));
-        }
-
-        if (sync_result == 0) {
-            RTK_LOGD(TAG, "SNTP sync successful\n");
-        } else {
-            RTK_LOGD(TAG, "SNTP sync failed\n");
-        }
-    }
 }
 #endif

--- a/common/port/matter_timers.h
+++ b/common/port/matter_timers.h
@@ -25,6 +25,22 @@ extern "C" {
 
 #include <time.h>
 
+#if defined(CONFIG_ENABLE_AMEBA_SNTP) && (CONFIG_ENABLE_AMEBA_SNTP == 1)
+/*
+ * SNTP server addresses — override via -D at build time without modifying source.
+ */
+#ifndef DEFAULT_SNTP_SERVER_ADDRESS
+#define DEFAULT_SNTP_SERVER_ADDRESS "pool.ntp.org"
+#endif
+#ifndef SNTP_FALLBACK_SERVER_1
+#define SNTP_FALLBACK_SERVER_1      "ntp.aliyun.com"
+#endif
+#ifndef SNTP_FALLBACK_SERVER_2
+#define SNTP_FALLBACK_SERVER_2      "time.google.com"
+#endif
+
+#endif
+
 /*
  * @brief  Initialize Matter Real Time Clock.
  */
@@ -58,11 +74,6 @@ void matter_timer_init(void);
  * @brief  Return true if ameba RTC is sync with SNTP.
  */
 bool matter_sntp_rtc_is_sync(void);
-
-/*
- * @brief  Return 0 if sntp has been sync; otherwise -1.
- */
-int matter_sntp_sync(void);
 
 /*
  * @brief  Get SNTP Current Time and write it to the DCT and RTC if SNTP server is reachable.

--- a/common/port/matter_wifis.c
+++ b/common/port/matter_wifis.c
@@ -627,9 +627,6 @@ static void matter_wifi_join_status_event_hdl(u8 * buf, s32 buf_len, s32 flags, 
     case RTW_JOINSTATUS_SUCCESS: // Connecting --> Connected Succesfully
         error_flag = RTW_NO_ERROR;
         RTK_LOGI(TAG, "Join success!\n");
-#if CONFIG_ENABLE_AMEBA_SNTP
-        matter_sntp_init();
-#endif
         matter_wifi_indication(MATTER_WIFI_EVENT_CONNECT, NULL, 0, flags);
         matter_LwIP_IP_Address_Request();
         break;
@@ -679,9 +676,6 @@ static void matter_wifi_join_status_event_hdl(u8 * buf) {
     case RTW_JOINSTATUS_SUCCESS: // Connecting --> Connected Succesfully
         error_flag = RTW_NO_ERROR;
         RTK_LOGI(TAG, "Join success!\n");
-#if CONFIG_ENABLE_AMEBA_SNTP
-        matter_sntp_init();
-#endif
         matter_wifi_indication(MATTER_WIFI_EVENT_CONNECT, NULL, 0, flags);
         matter_LwIP_IP_Address_Request();
         break;

--- a/common/port/whc/matter_whc_dev.c
+++ b/common/port/whc/matter_whc_dev.c
@@ -41,18 +41,6 @@ static void whc_matter_dev_doorlock_update(u8 lock_state)
 }
 #endif
 
-#if defined(CONFIG_ENABLE_AMEBA_SNTP) && (CONFIG_ENABLE_AMEBA_SNTP == 1)
-extern bool matter_sntp_initialized;
-void matter_sntp_prepare_sleep(void)
-{
-    if (matter_sntp_initialized) {
-        sntp_stop();
-        matter_sntp_initialized = FALSE;
-    }
-    return;
-}
-#endif
-
 void whc_matter_dev_downlink_hdl(u8 *buf)
 {
     u8 event = *buf;

--- a/tools/docker/ameba-rtos/v1.2/Dockerfile
+++ b/tools/docker/ameba-rtos/v1.2/Dockerfile
@@ -10,8 +10,8 @@ ARG TOOLCHAIN_ASDK_LINUX_URL_ALIYUN='https://rs-wn.oss-cn-shanghai.aliyuncs.com/
 ARG TOOLCHAIN_ASDK_FILE_PATH='/opt/rtk-toolchain/prebuilts-linux-1.0.3.tar.gz'
 
 # Redefine following build arguments to respective repo and tag/branch
-ARG AMEBA_MATTER_REPO=https://github.com/jack155069/ameba-rtos-matter.git
-ARG AMEBA_MATTER_TAG_NAME=ameba-rtos/v1.6/update_sdk_260819
+ARG AMEBA_MATTER_REPO=https://github.com/xshuqun/ameba-rtos-matter.git
+ARG AMEBA_MATTER_TAG_NAME=ameba-rtos/v1.6-PR/update_sntp_sync
 
 # Define fixed build arguments
 ARG AMBRTOS_REPO=https://github.com/Ameba-AIoT/ameba-rtos.git


### PR DESCRIPTION
## This PR addresses:

* stop sntp after first valid sync shall be implemented in sntp_set_system_time() via a deferred tcpip_callback, eliminating the blocking poll loop in matter_sntp_init_with_server.
* Configure three NTP servers (primary + two fallbacks) so lwIP rotates through them automatically.  Server addresses are defined in matter_timers.h

## Verification:

Verified the sntp time is sync-ed correctly.