### PR TITLE
ci(scripts): adopt new format for commit messages

### DIFF
--- a/.github/workflows/check_pr_commits.yml
+++ b/.github/workflows/check_pr_commits.yml
@@ -15,9 +15,13 @@ jobs:
 
       - name: Validate commit messages
         run: |
-          VALID_ICS="amebaz2|amebaz2plus|amebad|amebasmart|amebagreen2|common"
-          VALID_COMPONENTS="api|atcmd|ble|core|data-model|dct|docs|drivers|examples|kvs|lwip|mbedtls|ota|scripts|sdk|soc|timer|tools|wifi"
-          SUBJECT_RE="^\[($VALID_ICS)\]\[($VALID_COMPONENTS)\] .{3,}"
+          VALID_TYPES="feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert"
+          # IC tag is optional; omit it for common (chip-agnostic) changes.
+          VALID_ICS="amebaz2|amebaz2plus|amebad|amebalite|amebadplus|amebasmart|amebagreen2"
+          VALID_COMPONENTS="api|atcmd|ble|core|data-model|dct|docs|drivers|examples|fs|kvs|lwip|mbedtls|ota|scripts|sdk|soc|timer|tools|util|wifi"
+          # A leading [..] is only allowed if it is a valid IC; otherwise the
+          # subject must not start with '[' (catches typos like [amebadd]).
+          SUBJECT_RE="^($VALID_TYPES)\(($VALID_COMPONENTS)\)!?: (\[($VALID_ICS)\] )?[^[].{2,}"
 
           BASE="${{ github.event.pull_request.base.sha }}"
           HEAD="${{ github.sha }}"
@@ -31,9 +35,12 @@ jobs:
 
             if ! echo "$subject" | grep -qE "$SUBJECT_RE"; then
               echo "FAIL [$short] bad subject: $subject"
-              echo "     Expected: [IC][component] description"
-              echo "     ICs: amebaz2 | amebaz2plus | amebad | amebalite | amebad+ | amebasmart | amebagreen2 | common"
-              echo "     Components: api | atcmd | ble | core | data-model | dct |docs | drivers | examples | kvs | lwip | mbedtls | ota | scripts | sdk | soc | timer | tools | wifi"
+              echo "     Expected: type(component): [IC] description   (min 3 chars; [IC] optional, omit for common; append ! before ':' for breaking changes)"
+              echo "     Examples: feat(dct): serialize post-init DCT operations        (common)"
+              echo "               fix(api): [amebaz2plus] guard null pointer          (chip-specific)"
+              echo "     Types:      feat | fix | docs | style | refactor | perf | test | build | ci | chore | revert"
+              echo "     ICs:        amebaz2 | amebaz2plus | amebad | amebalite | amebadplus | amebasmart | amebagreen2   (omit for common)"
+              echo "     Components: api | atcmd | ble | core | data-model | dct | docs | drivers | examples | fs | kvs | lwip | mbedtls | ota | scripts | sdk | soc | timer | tools | util | wifi"
               errors=$((errors + 1))
             fi
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,115 @@
+# Contributing
+
+## Commit Message Rules
+
+Commit messages follow this format, with an optional IC (chip) tag:
+
+```
+type(component): [IC] subject
+
+Body explaining what this commit does and why. (mandatory)
+```
+
+Example:
+
+```
+fix(dct): [amebaz2plus] guard DCT access before initialization
+
+The DCT was read from the AT-command thread before matter_init()
+finished, occasionally returning stale values. Serialize the read
+onto the Matter event loop so it always runs after initialization.
+```
+
+### Rules
+
+- **`type`** — required. One of:
+  `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`,
+  `ci`, `chore`, `revert`.
+- **`(component)`** — required. The area of the codebase; see the
+  [Components](#components) table below.
+- **`[IC]`** — optional. Include only for **chip-specific** changes; **omit
+  it for common (chip-agnostic) changes**. One of:
+  `amebaz2`, `amebaz2plus`, `amebad`, `amebalite`, `amebadplus`, `amebasmart`,
+  `amebagreen2`.
+- **`!`** — optional. Append before the colon to mark a breaking change,
+  e.g. `feat(api)!: rename matter_clear_all_fabric`.
+- **subject** — required, at least 3 characters. Imperative mood, no
+  trailing period.
+- **body** — mandatory. Explain *what* the change does and *why*.
+
+### What each type means
+
+| Type       | Use for                                                        |
+| ---------- | -------------------------------------------------------------- |
+| `feat`     | A new feature                                                  |
+| `fix`      | A bug fix                                                      |
+| `docs`     | Documentation only                                             |
+| `style`    | Formatting/whitespace, no behavior change                      |
+| `refactor` | Code change that neither fixes a bug nor adds a feature        |
+| `perf`     | A change that improves performance                             |
+| `test`     | Adding or fixing tests                                         |
+| `build`    | Build system, Makefiles, or dependency changes                 |
+| `ci`       | CI configuration and scripts (workflows, hooks)                |
+| `chore`    | Maintenance that doesn't fit the above                         |
+| `revert`   | Reverting a previous commit                                    |
+
+### Components
+
+| Component    | Use for                                              |
+| ------------ | ---------------------------------------------------- |
+| `api`        | Public Matter API layer                              |
+| `atcmd`      | AT command interface                                 |
+| `ble`        | Bluetooth Low Energy / BLE commissioning             |
+| `core`       | Core Matter integration and event loop               |
+| `data-model` | Matter data model and clusters                       |
+| `dct`        | Device Configuration Table storage                   |
+| `docs`       | Documentation                                        |
+| `drivers`    | Hardware and peripheral drivers                      |
+| `examples`   | Example applications                                 |
+| `fs`         | Filesystem                                           |
+| `kvs`        | Key-value store                                      |
+| `lwip`       | lwIP TCP/IP stack integration                        |
+| `mbedtls`    | mbedTLS crypto integration                           |
+| `ota`        | Over-the-air update                                  |
+| `scripts`    | Build, CI, and tooling scripts (workflows, hooks)    |
+| `sdk`        | Vendor SDK integration                               |
+| `soc`        | SoC-specific code                                    |
+| `timer`      | Timer and system layer                               |
+| `tools`      | Developer tools                                      |
+| `util`       | Utilities and helpers                                |
+| `wifi`       | Wi-Fi stack integration                              |
+
+### Examples
+
+```
+feat(dct): serialize post-init DCT operations onto Matter event loop
+fix(api): [amebaz2plus] guard null pointer in fabric lookup
+docs(docs): update RTL8721F Matter support status to WIP
+ci(scripts): make the [IC] tag optional for common changes
+feat(api)!: rename matter_clear_all_fabric
+```
+
+## Enforcement
+
+The commit format is validated in two places, using the same rule:
+
+- **Locally** — the `pre-push` hook rejects non-conforming commits before
+  they leave your machine. Enable it once after cloning:
+
+  ```sh
+  sh tools/scripts/hooks/install.sh
+  ```
+
+  The same hook also runs the restyle check (`tools/scripts/restyle_check.sh`).
+
+- **In CI** — the `Check PR Commits` workflow
+  (`.github/workflows/check_pr_commits.yml`) re-validates every commit in a
+  pull request.
+
+If a commit is flagged, reword it with `git rebase -i <base-sha>`.
+
+## Pull Requests
+
+PR descriptions must include both a `This PR addresses:` section and a
+`Verification:` section (see the pull request template). This is enforced by
+the `Check PR Template Format` workflow.

--- a/tools/scripts/hooks/pre-push
+++ b/tools/scripts/hooks/pre-push
@@ -1,18 +1,29 @@
 #!/bin/bash
 # Validates commit message format for all commits being pushed.
 #
-# Required format:
-#   [IC][component] Short description
+# Required format (with optional IC tag):
+#   type(component): [IC] Short description
 #
 #   Body explaining what this commit does and why.  (mandatory)
+#
+# The [IC] tag is optional: omit it for common (chip-agnostic) changes,
+#   e.g. feat(dct): serialize post-init DCT operations
+# and add it only for chip-specific changes,
+#   e.g. fix(api): [amebaz2plus] guard null pointer
+# Append '!' before the colon for breaking changes,
+#   e.g. feat(api)!: rename matter_clear_all_fabric
 #
 
 ZERO_SHA=0000000000000000000000000000000000000000
 
-VALID_ICS="amebaz2|amebaz2plus|amebad|amebalite|amebad+|amebasmart|amebagreen2|common"
-VALID_COMPONENTS="api|atcmd|ble|core|data-model|dct|docs|drivers|examples|kvs|lwip|mbedtls|ota|scripts|sdk|soc|timer|tools|wifi"
+VALID_TYPES="feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert"
+# IC tag is optional; omit it for common (chip-agnostic) changes.
+VALID_ICS="amebaz2|amebaz2plus|amebad|amebalite|amebadplus|amebasmart|amebagreen2"
+VALID_COMPONENTS="api|atcmd|ble|core|data-model|dct|docs|drivers|examples|fs|kvs|lwip|mbedtls|ota|scripts|sdk|soc|timer|tools|util|wifi"
 
-SUBJECT_RE="^\[($VALID_ICS)\]\[($VALID_COMPONENTS)\] .{3,}"
+# A leading [..] is only allowed if it is a valid IC; otherwise the subject
+# must not start with '[' (catches typos like [amebadd]).
+SUBJECT_RE="^($VALID_TYPES)\(($VALID_COMPONENTS)\)!?: (\[($VALID_ICS)\] )?[^[].{2,}"
 
 errors=0
 
@@ -34,9 +45,12 @@ while read -r local_ref local_sha remote_ref remote_sha; do
 
         if ! echo "$subject" | grep -qE "$SUBJECT_RE"; then
             printf "\n[FAIL] %s  bad subject:\n  %s\n" "$short" "$subject"
-            printf "  Expected: [IC][component] description (min 3 chars)\n"
-            printf "  ICs:       amebaz2 | amebaz2plus | amebad | amebalite | amebad+ | amebasmart | amebagreen2 | common\n"
-            printf "  Components: api | atcmd | ble | core | data-model | dct |docs | drivers | examples | kvs | lwip | mbedtls | ota | scripts | sdk | soc | timer | tools | wifi\n"
+            printf "  Expected: type(component): [IC] description  (min 3 chars; [IC] optional, omit for common; add ! before ':' for breaking changes)\n"
+            printf "  Examples: feat(dct): serialize post-init DCT operations        (common)\n"
+            printf "            fix(api): [amebaz2plus] guard null pointer          (chip-specific)\n"
+            printf "  Types:      feat | fix | docs | style | refactor | perf | test | build | ci | chore | revert\n"
+            printf "  ICs:        amebaz2 | amebaz2plus | amebad | amebalite | amebadplus | amebasmart | amebagreen2   (omit for common)\n"
+            printf "  Components: api | atcmd | ble | core | data-model | dct | docs | drivers | examples | fs | kvs | lwip | mbedtls | ota | scripts | sdk | soc | timer | tools | util | wifi\n"
             errors=$((errors + 1))
         fi
 


### PR DESCRIPTION
## This PR addresses:

Switch commit validation from [IC][component] to type(component): [IC (optional)] subject

- add the type field and optional ! breaking-change marker
- keep component as the scope and IC as a bracketed tag
- update both enforcement points: check_pr_commits.yml and the pre-push hook
- add amebalite/amebad+ to the workflow IC list and escape the +

Body is still mandatory.

## Verification:

CI must be completed.